### PR TITLE
Fix reference to test file in sars-cov-2-se-illumina-wgs-variant-calling

### DIFF
--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/.dockstore.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/.dockstore.yml
@@ -4,4 +4,4 @@ workflows:
   primaryDescriptorPath: /se-wgs-variation.ga
   subclass: Galaxy
   testParameterFiles:
-  - /se-wgs-variation.ga-test.yml
+  - /se-wgs-variation-test.yml


### PR DESCRIPTION
Fixes a problem that breaks the build (see https://github.com/galaxyproject/iwc/runs/2803865520) now that `planemo-ci-action` has been updated to include https://github.com/galaxyproject/planemo-ci-action/pull/19.

Before this fix:
```
$ planemo workflow_lint --fail_level error workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling
Applying linter dockstore... FAIL
.. ERROR: .dockstore.yml workflow entry references absent file /se-wgs-variation.ga-test.yml
Applying linter tests... CHECK
.. CHECK: Tests appear structurally correct for workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/se-wgs-variation.ga
```

After this fix:
```
(venv) [simleo@neuron:iwc (fix_dockstore)]$ planemo workflow_lint --fail_level error workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling
Applying linter tests... CHECK
.. CHECK: Tests appear structurally correct for workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/se-wgs-variation.ga
```
