### PR TITLE
Fix title in README for sars-cov-2-se-illumina-wgs-variant-calling

### DIFF
--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/README.md
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/README.md
@@ -1,4 +1,4 @@
-COVID-19: variation analysis on WGS PE data
+COVID-19: variation analysis on WGS SE data
 -------------------------------------------
 
 This workflows performs single end read mapping with bowtie2 followed by


### PR DESCRIPTION
to fix the description on [WorkflowHub](https://workflowhub.eu/workflows/112) which is inconsistent ("COVID-19: variation analysis on WGS PE data" for the SE workflow)
