### PR TITLE
Generate RO-Crate metadata before deployment

### DIFF
--- a/.github/workflows/workflow_test.yml
+++ b/.github/workflows/workflow_test.yml
@@ -202,6 +202,10 @@ jobs:
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_{{ needs.setup.outputs.galaxy-head-sha }}
+    - name: Install requirements for gen_crates.py
+      run: pip install -r workflows/requirements.txt
+    - name: Generate RO-Crate metadata for workflow repositories
+      run: python workflows/gen_crates.py workflows
     - name: Set git user
       run: |
         git config --global user.email "$GITHUB_USER@galaxyproject.org"


### PR DESCRIPTION
Updates the GitHub workflow with steps to generate RO-Crate metadata for all the workflows before deployment, using the `gen_crates.py` tool.

The deployment phase will actually be skipped for _this_ PR, since no workflow has changed. I'm not sure what would be the best way to "force" the addition of the RO-Crate files to the repos, since the deploy action updates a repo only for new workflow releases.
