### PR TITLE
RO-Crate upload to WorkflowHub

### DIFF
--- a/workflows/data-fetching/parallel-accession-download/.workflowhub.yml
+++ b/workflows/data-fetching/parallel-accession-download/.workflowhub.yml
@@ -1,0 +1,5 @@
+version: "0.1"
+registries:
+- url: "https://workflowhub.eu"
+  project: 33
+  workflow: 137

--- a/workflows/data-fetching/parallel-accession-download/.workflowhub.yml
+++ b/workflows/data-fetching/parallel-accession-download/.workflowhub.yml
@@ -1,5 +1,5 @@
 version: "0.1"
 registries:
 - url: "https://workflowhub.eu"
-  project: 33
-  workflow: 137
+  project: iwc
+  workflow: parallel-accession-download/main

--- a/workflows/data-fetching/parallel-accession-download/.workflowhub.yml
+++ b/workflows/data-fetching/parallel-accession-download/.workflowhub.yml
@@ -1,5 +1,5 @@
-version: "0.1"
+version: '0.1'
 registries:
-- url: "https://workflowhub.eu"
+- url: https://workflowhub.eu
   project: iwc
   workflow: parallel-accession-download/main

--- a/workflows/gen_crates.py
+++ b/workflows/gen_crates.py
@@ -316,10 +316,10 @@ def main(args):
             print(f"  archived as {archive}")
             if args.upload:
                 proj_name, wf_name = get_proj_and_wf(repo, hub_url=args.hub_url)
-                if args.hub_team:
-                    proj_name = args.hub_team
+                if args.hub_project:
+                    proj_name = args.hub_project
                 if proj_name is None:
-                    raise RuntimeError(f"no WorkflowHub team specified for {args.hub_url}")
+                    raise RuntimeError(f"no WorkflowHub project specified for {args.hub_url}")
                 proj_id = client.resolve_proj(proj_name)
                 wf_id = client.resolve_wf(proj_id, wf_name)
                 new_workflow = not wf_id
@@ -359,6 +359,6 @@ if __name__ == "__main__":
     parser.add_argument("--upload", action="store_true", help="upload crates to WorkflowHub")
     parser.add_argument("--hub-url", metavar="STRING", default=HUB_URL,
                         help="WorkflowHub URL for crate upload")
-    parser.add_argument("--hub-team", metavar="STRING",
-                        help="WorkflowHub team for crate upload (default: get from .workflowhub.yml)")
+    parser.add_argument("--hub-project", metavar="STRING",
+                        help="WorkflowHub project for crate upload (default: get from .workflowhub.yml)")
     main(parser.parse_args())

--- a/workflows/requirements.txt
+++ b/workflows/requirements.txt
@@ -1,3 +1,4 @@
 rocrate~=0.4.0
 planemo>=0.74.5
+pyyaml~=5.4.0
 requests~=2.26.0

--- a/workflows/requirements.txt
+++ b/workflows/requirements.txt
@@ -1,2 +1,3 @@
 rocrate~=0.4.0
 planemo>=0.74.5
+requests~=2.26.0

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/.workflowhub.yml
@@ -1,5 +1,5 @@
 version: "0.1"
 registries:
 - url: "https://workflowhub.eu"
-  project: 33
-  workflow: 138
+  project: iwc
+  workflow: sars-cov-2-consensus-from-variation/COVID-19-CONSENSUS-CONSTRUCTION

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/.workflowhub.yml
@@ -1,0 +1,5 @@
+version: "0.1"
+registries:
+- url: "https://workflowhub.eu"
+  project: 33
+  workflow: 138

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/.workflowhub.yml
@@ -1,5 +1,5 @@
-version: "0.1"
+version: '0.1'
 registries:
-- url: "https://workflowhub.eu"
+- url: https://workflowhub.eu
   project: iwc
   workflow: sars-cov-2-consensus-from-variation/COVID-19-CONSENSUS-CONSTRUCTION

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/.workflowhub.yml
@@ -1,5 +1,5 @@
 version: "0.1"
 registries:
 - url: "https://workflowhub.eu"
-  project: 33
-  workflow: 111
+  project: iwc
+  workflow: sars-cov-2-ont-artic-variant-calling/COVID-19-ARTIC-ONT

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/.workflowhub.yml
@@ -1,5 +1,5 @@
-version: "0.1"
+version: '0.1'
 registries:
-- url: "https://workflowhub.eu"
+- url: https://workflowhub.eu
   project: iwc
   workflow: sars-cov-2-ont-artic-variant-calling/COVID-19-ARTIC-ONT

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/.workflowhub.yml
@@ -1,0 +1,5 @@
+version: "0.1"
+registries:
+- url: "https://workflowhub.eu"
+  project: 33
+  workflow: 111

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/.workflowhub.yml
@@ -1,0 +1,5 @@
+version: "0.1"
+registries:
+- url: "https://workflowhub.eu"
+  project: 33
+  workflow: 110

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/.workflowhub.yml
@@ -1,5 +1,5 @@
-version: "0.1"
+version: '0.1'
 registries:
-- url: "https://workflowhub.eu"
+- url: https://workflowhub.eu
   project: iwc
   workflow: sars-cov-2-pe-illumina-artic-variant-calling/COVID-19-PE-ARTIC-ILLUMINA

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/.workflowhub.yml
@@ -1,5 +1,5 @@
 version: "0.1"
 registries:
 - url: "https://workflowhub.eu"
-  project: 33
-  workflow: 110
+  project: iwc
+  workflow: sars-cov-2-pe-illumina-artic-variant-calling/COVID-19-PE-ARTIC-ILLUMINA

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/.workflowhub.yml
@@ -1,5 +1,5 @@
-version: "0.1"
+version: '0.1'
 registries:
-- url: "https://workflowhub.eu"
+- url: https://workflowhub.eu
   project: iwc
   workflow: sars-cov-2-pe-illumina-wgs-variant-calling/COVID-19-PE-WGS-ILLUMINA

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/.workflowhub.yml
@@ -1,0 +1,5 @@
+version: "0.1"
+registries:
+- url: "https://workflowhub.eu"
+  project: 33
+  workflow: 113

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/.workflowhub.yml
@@ -1,5 +1,5 @@
 version: "0.1"
 registries:
 - url: "https://workflowhub.eu"
-  project: 33
-  workflow: 113
+  project: iwc
+  workflow: sars-cov-2-pe-illumina-wgs-variant-calling/COVID-19-PE-WGS-ILLUMINA

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/.workflowhub.yml
@@ -1,5 +1,5 @@
-version: "0.1"
+version: '0.1'
 registries:
-- url: "https://workflowhub.eu"
+- url: https://workflowhub.eu
   project: iwc
   workflow: sars-cov-2-se-illumina-wgs-variant-calling/COVID-19-SE-WGS-ILLUMINA

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/.workflowhub.yml
@@ -1,5 +1,5 @@
 version: "0.1"
 registries:
 - url: "https://workflowhub.eu"
-  project: 33
-  workflow: 112
+  project: iwc
+  workflow: sars-cov-2-se-illumina-wgs-variant-calling/COVID-19-SE-WGS-ILLUMINA

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/.workflowhub.yml
@@ -1,0 +1,5 @@
+version: "0.1"
+registries:
+- url: "https://workflowhub.eu"
+  project: 33
+  workflow: 112

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/.workflowhub.yml
@@ -1,5 +1,5 @@
 version: "0.1"
 registries:
 - url: "https://workflowhub.eu"
-  project: 33
-  workflow: 109
+  project: iwc
+  workflow: sars-cov-2-variation-reporting/COVID-19-VARIATION-REPORTING

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/.workflowhub.yml
@@ -1,5 +1,5 @@
-version: "0.1"
+version: '0.1'
 registries:
-- url: "https://workflowhub.eu"
+- url: https://workflowhub.eu
   project: iwc
   workflow: sars-cov-2-variation-reporting/COVID-19-VARIATION-REPORTING

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/.workflowhub.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/.workflowhub.yml
@@ -1,0 +1,5 @@
+version: "0.1"
+registries:
+- url: "https://workflowhub.eu"
+  project: 33
+  workflow: 109


### PR DESCRIPTION
Extends the `gen_crates` tool with functionality to upload RO-Crates to WorkflowHub.

The tool needed some additional info to perform this action:

* WorkflowHub URL: defaults to https://workflowhub.eu, can be overridden with `--hub-url` (can point to https://dev.workflowhub.eu or http://localhost:3000 for testing)
* WorkflowHub API key for authentication: passed via the `HUB_API_KEY` environment variable (passing this via CLI would not be safe). We should be able to set this from a secret in GitHub Actions
* WorkflowHub team/project name: read from `.workflowhub.yml`, can be overridden with `--hub-project`. Can be omitted in `.workflowhub.yml`, but then `--hub-project` must be specified.
* WorkflowHub workflow name: read from `.workflowhub.yml`. If a workflow with this name is found in the given project, the tool creates a new version for it; if not, it creates a new workflow. In any event, the tool prints the resulting WorkflowHub link, which provides the final workflow id and version

Example:

```console
$ # Workflows not in WorkflowHub yet
$ python gen_crates.py --upload --hub-url https://dev.workflowhub.eu
processing data-fetching/parallel-accession-download
  archived as /tmp/iwc_7zp3847w/parallel-accession-download.crate.zip
  uploaded as https://dev.workflowhub.eu/workflows/193?version=1
processing sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation
  archived as /tmp/iwc_7zp3847w/sars-cov-2-consensus-from-variation.crate.zip
  uploaded as https://dev.workflowhub.eu/workflows/194?version=1
$ # Now all workflows have been registered
$ python gen_crates.py --upload --hub-url https://dev.workflowhub.eu
processing data-fetching/parallel-accession-download
  archived as /tmp/iwc_6dds16hx/parallel-accession-download.crate.zip
  uploaded as https://dev.workflowhub.eu/workflows/193?version=2
processing sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation
  archived as /tmp/iwc_6dds16hx/sars-cov-2-consensus-from-variation.crate.zip
  uploaded as https://dev.workflowhub.eu/workflows/194?version=2
```

The `.workflowhub.yml` file format should be self-explanatory. Example:

```yaml
version: '0.1'
registries:
- url: https://workflowhub.eu
  project: iwc
  workflow: sars-cov-2-consensus-from-variation/COVID-19-CONSENSUS-CONSTRUCTION
- url: https://dev.workflowhub.eu
  project: LifeMonitorDev
  workflow: sars-cov-2-consensus-from-variation/COVID-19-CONSENSUS-CONSTRUCTION
```

We should be able to integrate this in the GitHub Actions workflow, so that (scientific) workflows are automatically uploaded to WorkflowHub at each release.

* An IWC admin should add a secret containing their WorkflowHub API key to this repository
* A WorkflowHub admin should add that IWC admin to the "iwc" team on WorkflowHub, so that the above API key would allow the workflow upload