### PR TITLE
Update bump_version tool

### DIFF
--- a/bump_version.py
+++ b/bump_version.py
@@ -31,18 +31,20 @@ Workflow repositories are expected to contain:
 - the .ga workflow file (e.g., "consensus-from-variation.ga"), which is
   expected to list its version in the "release" metadata field
 - a CHANGELOG.md file with atx-style Markdown headers (the ones with the
-  leading hash marks), with the convention that:
-  - the top-level header is "# Changelog"
-  - level 2 headers start with ## <VERSION>
+  leading hash marks), formatted according to https://keepachangelog.com
+  (but not necessarily following semantic versioning).
 
 Example:
 
 # Changelog
 
+## Unreleased
+### Fixed
+- This
+- That
+
 ## [0.4] - 2021-06-16
-
 ### Changed
-
 - Upgrade multiqc to 1.9+galaxy1
 """
 

--- a/bump_version.py
+++ b/bump_version.py
@@ -145,12 +145,17 @@ def update_changelog(changelog, md, version, msg, date=datetime.date.today(),
     date = date.strftime(DATE_FMT)
     entry = NEW_LOG_ENTRY.substitute(version=version, date=date, msg=msg,
                                      entry_type=entry_type)
-    entry_tree = marko.block.Document(entry)
     for ins_pos, elem in enumerate(tree.children):
         if isinstance(elem, marko.block.Heading) and elem.level == 2:
+            if elem.children[0].children.strip(" []").lower() == "unreleased":
+                # Insert after the "Unreleased" heading but before its contents
+                # Any unreleased changes become part of the new version
+                ins_pos += 1
+                entry = "\n" + entry
             break
     else:
         ins_pos = len(tree.children)
+    entry_tree = marko.block.Document(entry)
     tree.children[ins_pos:ins_pos] = entry_tree.children
     with open(changelog, "wt") as f:
         f.write(md.render(tree))


### PR DESCRIPTION
Updates `bump_version.py` to handle the ["Unreleased" log entry](https://keepachangelog.com/en/1.0.0/#effort).

Additionally, it is now possible to specify a heading-only new log entry by providing an empty log message (`python bump_version.py -m ''`). Rather than actually adding an empty section to the changelog, the indented usage is to avoid having to specify additional changes when making a new release for a workflow whose latest changes are already listed in the `Unreleased` section.

For instance, when bumping the version for:

```markdown
# Changelog
Changelog for SuperWorkflow

## [Unreleased]
### Fixed
- This and that

## [0.1.0] - 2021-08-31
### Added
- First version of SuperWorkflow
```

We want the entry for 0.1.1 to list the currently unreleased changes, and perhaps we don't want to add anything else. This is where `-m ''` comes in handy (the default would be to add an `Update for version 0.1.1` entry).