### PR TITLE
add report and fail level for lint

### DIFF
--- a/.github/workflows/workflow_test.yml
+++ b/.github/workflows/workflow_test.yml
@@ -92,6 +92,8 @@ jobs:
       with:
         mode: lint
         workflows: true
+        report-level: all
+        fail-level: warn
         repository-list: "${{ needs.setup.outputs.repository-list }}"
 
   test:


### PR DESCRIPTION
values are the defaults that will be introduced in https://github.com/galaxyproject/planemo-ci-action/pull/23 but I think its a good idea to add them here anyway .. just in case anyone uses the repo as template.

fail level warn will be more strict that before, but I guess this is a good
idea