### PR TITLE
Expression Atlas Smartseq/Droplet downstream workflow

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "workflows/single-cell-RNAseq/.ebi-gene-expression-group/scxa-workflows"]
+	path = workflows/single-cell-RNAseq/.ebi-gene-expression-group/scxa-workflows
+	url = https://github.com/ebi-gene-expression-group/scxa-workflows

--- a/workflows/single-cell-RNAseq/SingleCellExpressionAtlas-downstream/SingleCellExpressionAtlas-smartseq-test.yml
+++ b/workflows/single-cell-RNAseq/SingleCellExpressionAtlas-downstream/SingleCellExpressionAtlas-smartseq-test.yml
@@ -1,0 +1,17 @@
+- doc: Test Single Cell Expression Atlas smartseq execution using E-MTAB-6077
+  job:
+    genemeta:
+      class: File
+      location: http://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/E-MTAB-6077/Danio_rerio.GRCz11.99.gtf.gz
+    genes:
+      class: File
+      location: http://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/E-MTAB-6077/E-MTAB-6077.aggregated_counts.mtx_rows.gz
+    cellmeta:
+      class: File
+      location: http://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/E-MTAB-6077/E-MTAB-6077.cell_metadata.tsv 
+    barcodes:
+      class: File
+      location: http://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/E-MTAB-6077/E-MTAB-6077.aggregated_counts.mtx_cols.gz
+    matrix:
+      class: File
+      location: http://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/sc_experiments/E-MTAB-6077/E-MTAB-6077.aggregated_counts.mtx.gz

--- a/workflows/single-cell-RNAseq/SingleCellExpressionAtlas-downstream/SingleCellExpressionAtlas-smartseq.ga
+++ b/workflows/single-cell-RNAseq/SingleCellExpressionAtlas-downstream/SingleCellExpressionAtlas-smartseq.ga
@@ -1,0 +1,1 @@
+../.ebi-gene-expression-group/scxa-workflows/w_smart-seq_clustering/scanpy_clustering_workflow.json


### PR DESCRIPTION
This PR aims to add the EMBL-EBI Single Cell Expression Atlas downstream analysis workflow as used to produce data with the resource, with a hopefully lightweight example.

I have a few concerns though:

1.- I would hope that the WorkflowHub.eu entry can be annotated to give credits to the person who wrote the workflow. I think that it will currently show as IWC, and while I of course value all the excellent feedback that the IWC community will provide, I still think that the main credit should go to the person writing the workflow (Jon Manning in this case).
2.- It would be great as well if, besides setting the author of the workflow to be passed to WorkflowHub.eu, additional organisations could be added (so that we could add, for instance, the EBI Gene Expression Team, next to IWC).
3.- Our workflow setup currently allows certains steps to fail. For instance, when it comes to the cluster phase, I think that the process relies on some convergence criteria, and for some resolutions value a dataset might not converge if I remember well. Will the testing here consider the workflow failed if one of those steps failed? On our setup (https://github.com/ebi-gene-expression-group/galaxy-workflow-executor) we allow certain steps to fail while still considering the workflow to be successful.

I would be happy to PR needed changes to deal with 1 and 2 if given some directions on where you would do these changes and how you would like them.

