### PR TITLE
Workflow-specific CI workflows

### DIFF
--- a/workflows/computational-chemistry/fragment-based-docking-scoring/CHANGELOG.md
+++ b/workflows/computational-chemistry/fragment-based-docking-scoring/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.2] 2021-12-13
+
+### Added
+- Added GitHub Actions workflow. No functional changes.
+
 ## [0.1.1] 2021-12-06
 
 ### Fixed

--- a/workflows/computational-chemistry/fragment-based-docking-scoring/fragment-based-docking-scoring.ga
+++ b/workflows/computational-chemistry/fragment-based-docking-scoring/fragment-based-docking-scoring.ga
@@ -16,7 +16,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "Fragment-based virtual screening using rDock for docking and SuCOS for pose scoring",
-    "release": "0.1.1",
+    "release": "0.1.2",
     "steps": {
         "0": {
             "annotation": "Number of docking poses to generate per input compound",

--- a/workflows/computational-chemistry/gromacs-dctmd/CHANGELOG.md
+++ b/workflows/computational-chemistry/gromacs-dctmd/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.2] 2021-12-13
+
+### Added
+- Added GitHub Actions workflow. No functional changes.
+
 ## [0.1.1] 2021-12-06
 
 ### Fixed

--- a/workflows/computational-chemistry/gromacs-dctmd/gromacs-dctmd.ga
+++ b/workflows/computational-chemistry/gromacs-dctmd/gromacs-dctmd.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "dcTMD calculations with GROMACS",
-    "release": "0.1.1",
+    "release": "0.1.2",
     "steps": {
         "0": {
             "annotation": "List of atom indices (separated with spaces) which make up the protein pull group",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/CHANGELOG.md
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.2] 2021-12-13
+
+### Added
+- Added GitHub Actions workflow. No functional changes.
+
 ## [0.1.1] 2021-12-06
 
 ### Fixed

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.1",
+    "release": "0.1.2",
     "steps": {
         "0": {
             "annotation": "Size of the MMGBSA ensemble",

--- a/workflows/computational-chemistry/protein-ligand-complex-parameterization/CHANGELOG.md
+++ b/workflows/computational-chemistry/protein-ligand-complex-parameterization/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.2] 2021-12-13
+
+### Added
+- Added GitHub Actions workflow. No functional changes.
+
 ## [0.1.1] 2021-12-06
 
 ### Fixed

--- a/workflows/computational-chemistry/protein-ligand-complex-parameterization/protein-ligand-complex-parameterization.ga
+++ b/workflows/computational-chemistry/protein-ligand-complex-parameterization/protein-ligand-complex-parameterization.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "Create GRO and TOP complex files",
-    "release": "0.1.1",
+    "release": "0.1.2",
     "steps": {
         "0": {
             "annotation": "pH for protonating the ligand. Set to -1.0 to skip.",

--- a/workflows/data-fetching/parallel-accession-download/CHANGELOG.md
+++ b/workflows/data-fetching/parallel-accession-download/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.2] 2021-12-13
+
+### Added
+- Added GitHub Actions workflow. No functional changes.
+
 ## [0.1.1] 2021-07-23
 
 ### Added

--- a/workflows/data-fetching/parallel-accession-download/parallel-accession-download.ga
+++ b/workflows/data-fetching/parallel-accession-download/parallel-accession-download.ga
@@ -15,7 +15,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.1.1",
+    "release": "0.1.2",
     "name": "Parallel Accession Download",
     "steps": {
         "0": {

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/CHANGELOG.md
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.2] 2021-12-13
+
+### Added
+- Added GitHub Actions workflow. No functional changes.
+
 ## [0.2.1] 2021-07-23
 
 ### Added

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: consensus construction",
-    "release": "0.2.1",
+    "release": "0.2.2",
     "steps": {
         "0": {
             "annotation": "Collection of VCFs produced by upstream workflows for variation analysis",

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/CHANGELOG.md
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.1] 2021-12-13
+
+### Added
+- Added GitHub Actions workflow. No functional changes.
+
 ## [0.3] 2021-09-22
 
 ### Changed
@@ -24,12 +29,10 @@ statistics are calculated:
 
   * the tool can now emit variant calls at complex sites with > 1 lengths of
     both the REF and the ALT allele, which were previously dropped
-
   * the workflow became more complex; to account for shortcomings of medaka
     tools annotate, the variant call statistics of regular variants and of
     primer binding site variants have to be determined in separate runs of the
     tool
-
   * All key INFO fields (DP, DP4, AF) will change slightly in this version of
     the workflow
 
@@ -38,7 +41,6 @@ which have been introduced into version 0.3 of the PE Illumina worflow for
 amplicon data before:
 
 - Update ivar trim to version 1.3.1
-
 - Run ivar trim as the last mapped reads processing step before variant
   calling, i.e., after left-alignment of indels
 
@@ -47,7 +49,6 @@ and:
 - Rename the output of the ivar trim step to "Fully processed reads for
   variant calling (primer-trimmed, realigned reads)" like the corresponding
   output of the PE Illumina workflow
-
 - Fix a typo in the allowed input formats for the collection of sequenced
   reads, which caused fastqsanger.gz data to undergo an implicit and
   unnecessary decompression step.

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: variation analysis of ARTIC ONT data",
-    "release": "0.3",
+    "release": "0.3.1",
     "steps": {
         "0": {
             "annotation": "ONT reads from ARTIC assay with fastqsanger encoding",

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-ivar-analysis/CHANGELOG.md
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-ivar-analysis/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.2] 2021-12-13
+
+### Added
+- Added GitHub Actions workflow. No functional changes.
+
 ## [0.2.1] 2021-11-04
 
 ### Added

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-ivar-analysis/pe-wgs-ivar-analysis.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-ivar-analysis/pe-wgs-ivar-analysis.ga
@@ -8,7 +8,7 @@
             "name": "Peter van Heusden"
         }
     ],
-    "release": "0.2.1",
+    "release": "0.2.2",
     "format-version": "0.1",
     "license": "MIT",
     "name": "SARS-CoV-2 Illumina Amplicon pipeline - iVar based",

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/CHANGELOG.md
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.2] 2021-12-13
+
+### Added
+- Added GitHub Actions workflow. No functional changes.
+
 ## [0.4.1] 2021-07-23
 
 ### Added

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: variation analysis on ARTIC PE data",
-    "release": "0.4.1",
+    "release": "0.4.2",
     "steps": {
         "0": {
             "annotation": "Illumina reads from ARTIC assay with fastqsanger encoding",

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/CHANGELOG.md
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2.2] 2021-12-13
+
+### Added
+- Added GitHub Actions workflow. No functional changes.
+
 ## [0.2.1] 2021-07-23
 
 ### Added

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/pe-wgs-variation.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/pe-wgs-variation.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: variation analysis on WGS PE data",
-    "release": "0.2.1",
+    "release": "0.2.2",
     "steps": {
         "0": {
             "annotation": "Illumina reads with fastqsanger encoding",

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/CHANGELOG.md
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.3] 2021-12-13
+
+### Added
+- Added GitHub Actions workflow. No functional changes.
+
 ## [0.1.2] 2021-07-23
 
 ### Added

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/se-wgs-variation.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/se-wgs-variation.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: variation analysis on WGS SE data",
-    "release": "0.1.2",
+    "release": "0.1.3",
     "steps": {
         "0": {
             "annotation": "Illumina reads with fastqsanger encoding",

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/CHANGELOG.md
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.2] 2021-12-13
+
+### Added
+- Added GitHub Actions workflow. No functional changes.
+
 ## [0.1.1] 2021-07-23
 
 ### Added

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: variation analysis reporting",
-    "release": "0.1.1",
+    "release": "0.1.2",
     "steps": {
         "0": {
             "annotation": "Allele Frequency Filter. This is the minimum allele frequency required for variants to be included in the report.",

--- a/workflows/wftest.yml
+++ b/workflows/wftest.yml
@@ -4,20 +4,21 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:
 jobs:
+  setup:
+    name: Setup cache
+    uses: galaxyproject/iwc/.github/workflows/setup.yml@main
+    with:
+      python-version-list: "[\"3.7\"]"
+      galaxy-fork: galaxyproject
+      galaxy-branch: master
   test:
     name: Test workflow
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-    - uses: actions/setup-python@v1
-      with:
-        python-version: '3.7'
-    - name: install Planemo
-      run: |
-        pip install --upgrade pip
-        pip install planemo
-    - name: run planemo test
-      run: |
-        planemo test --biocontainers .
+    needs: setup
+    uses: galaxyproject/iwc/.github/workflows/test_workflows.yml@main
+    with:
+      galaxy-head-sha: ${{ needs.setup.outputs.galaxy-head-sha }}
+      python-version-list: "[\"3.7\"]"
+      galaxy-fork: galaxyproject
+      galaxy-branch: master
+      repository-list: '.'
+      check-outputs: true

--- a/workflows/wftest.yml
+++ b/workflows/wftest.yml
@@ -1,0 +1,23 @@
+name: Periodic workflow test
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+jobs:
+  test:
+    name: Test workflow
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+    - name: install Planemo
+      run: |
+        pip install --upgrade pip
+        pip install planemo
+    - name: run planemo test
+      run: |
+        planemo test --biocontainers .


### PR DESCRIPTION
Resolves #71.

The script that generates RO-Crate metadata files now also places a GitHub workflow that tests the scientific workflow under `.github/workflows`, allowing each deployed repository to have its own GitHub Actions history reflecting the status of its specific workflow. The GitHub workflow is set to run on a daily schedule and it's also configured to enable manual triggering; I've tested it on a fork of `iwc-workflows/sars-cov-2-pe-illumina-artic-variant-calling`, see https://github.com/simleo/sars-cov-2-pe-illumina-artic-variant-calling/actions.