### PR TITLE
Update sarscov2 pe wgs ivar analysis workflow

### DIFF
--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-ivar-analysis/CHANGELOG.md
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-ivar-analysis/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.3] 2022-05-12
+
+### Changed
+
+- Upgrade pangolin to 4.0.5
+  - Analysis engine switched to UShER, that is more accurate but slower than the previous default PangoLEARN engine
+  - https://github.com/cov-lineages/pangolin/releases
+- Upgrade Nextclade to 1.11.0
+  - https://github.com/nextstrain/nextclade/releases
+- Upgrade MultiQC to 1.11.0
+  - Modules updates (notably fastp)
+  - https://github.com/ewels/MultiQC/releases
+- Upgrade fastp to 0.23.2
+  - Improved performances
+  - https://github.com/OpenGene/fastp/releases
+
 ## [0.2.2] 2021-12-13
 
 ### Added

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-ivar-analysis/pe-wgs-ivar-analysis.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-ivar-analysis/pe-wgs-ivar-analysis.ga
@@ -8,48 +8,16 @@
             "name": "Peter van Heusden"
         }
     ],
-    "release": "0.2.2",
+    "release": "0.3",
     "format-version": "0.1",
     "license": "MIT",
     "name": "SARS-CoV-2 Illumina Amplicon pipeline - iVar based",
     "steps": {
         "0": {
-            "annotation": "FASTQ format Illumina Reads (Amplicon Protocol)",
-            "content_id": null,
-            "errors": null,
-            "id": 0,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "FASTQ format Illumina Reads (Amplicon Protocol)",
-                    "name": "Paired read collection for samples"
-                }
-            ],
-            "label": "Paired read collection for samples",
-            "name": "Input dataset collection",
-            "outputs": [],
-            "position": {
-                "bottom": 338.74998474121094,
-                "height": 82.19999694824219,
-                "left": -364.683349609375,
-                "right": -164.683349609375,
-                "top": 256.54998779296875,
-                "width": 200,
-                "x": -364.683349609375,
-                "y": 256.54998779296875
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false, \"collection_type\": \"list:paired\"}",
-            "tool_version": null,
-            "type": "data_collection_input",
-            "uuid": "ce39f6b7-b9f6-4431-8831-7a284fe826a7",
-            "workflow_outputs": []
-        },
-        "1": {
             "annotation": "SARS-CoV-2 reference genome (typically MN908947.3)",
             "content_id": null,
             "errors": null,
-            "id": 1,
+            "id": 0,
             "input_connections": {},
             "inputs": [
                 {
@@ -61,20 +29,52 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 564.3499908447266,
-                "height": 61.80000305175781,
-                "left": -366.683349609375,
-                "right": -166.683349609375,
-                "top": 502.54998779296875,
+                "bottom": 172.21875,
+                "height": 82.171875,
+                "left": 116.5,
+                "right": 316.5,
+                "top": 90.046875,
                 "width": 200,
-                "x": -366.683349609375,
-                "y": 502.54998779296875
+                "x": 116.5,
+                "y": 90.046875
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "25167e70-195c-4cda-9219-dbfe2f70c863",
+            "workflow_outputs": []
+        },
+        "1": {
+            "annotation": "FASTQ format Illumina Reads (Amplicon Protocol)",
+            "content_id": null,
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "FASTQ format Illumina Reads (Amplicon Protocol)",
+                    "name": "Paired read collection for samples"
+                }
+            ],
+            "label": "Paired read collection for samples",
+            "name": "Input dataset collection",
+            "outputs": [],
+            "position": {
+                "bottom": -73.78125,
+                "height": 82.171875,
+                "left": 118.5,
+                "right": 318.5,
+                "top": -155.953125,
+                "width": 200,
+                "x": 118.5,
+                "y": -155.953125
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"collection_type\": \"list:paired\"}",
+            "tool_version": null,
+            "type": "data_collection_input",
+            "uuid": "ce39f6b7-b9f6-4431-8831-7a284fe826a7",
             "workflow_outputs": []
         },
         "2": {
@@ -93,14 +93,14 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 696.2499847412109,
-                "height": 82.19999694824219,
-                "left": -360.683349609375,
-                "right": -160.683349609375,
-                "top": 614.0499877929688,
+                "bottom": 263.328125,
+                "height": 61.78125,
+                "left": 122.5,
+                "right": 322.5,
+                "top": 201.546875,
                 "width": 200,
-                "x": -360.683349609375,
-                "y": 614.0499877929688
+                "x": 122.5,
+                "y": 201.546875
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
@@ -125,14 +125,14 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 961.1499786376953,
-                "height": 102.59999084472656,
-                "left": -332.33331298828125,
-                "right": -132.33331298828125,
-                "top": 858.5499877929688,
+                "bottom": 548.609375,
+                "height": 102.5625,
+                "left": 150.84375,
+                "right": 350.84375,
+                "top": 446.046875,
                 "width": 200,
-                "x": -332.33331298828125,
-                "y": 858.5499877929688
+                "x": 150.84375,
+                "y": 446.046875
             },
             "tool_id": null,
             "tool_state": "{\"default\": 0.7, \"parameter_type\": \"float\", \"optional\": true}",
@@ -157,14 +157,14 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 1127.1500396728516,
-                "height": 102.59999084472656,
-                "left": -337.2833251953125,
-                "right": -137.2833251953125,
-                "top": 1024.550048828125,
+                "bottom": 714.609375,
+                "height": 102.5625,
+                "left": 145.890625,
+                "right": 345.890625,
+                "top": 612.046875,
                 "width": 200,
-                "x": -337.2833251953125,
-                "y": 1024.550048828125
+                "x": 145.890625,
+                "y": 612.046875
             },
             "tool_id": null,
             "tool_state": "{\"default\": 20, \"parameter_type\": \"integer\", \"optional\": true}",
@@ -174,17 +174,72 @@
             "workflow_outputs": []
         },
         "5": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.20.1+galaxy0",
+            "annotation": "If the reference is named MN908947.3 (Genbank name of SARS-CoV-2 reference genome), rename it to NC_045512.2 (RefSeq name of SARS-CoV-2 reference genome)",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sed_tool/1.1.1",
             "errors": null,
             "id": 5,
             "input_connections": {
-                "single_paired|paired_input": {
+                "infile": {
                     "id": 0,
                     "output_name": "output"
                 }
             },
             "inputs": [],
+            "label": "Rename reference to NC_045512.2",
+            "name": "Text transformation",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 198.109375,
+                "height": 113.5625,
+                "left": 386.5,
+                "right": 586.5,
+                "top": 84.546875,
+                "width": 200,
+                "x": 386.5,
+                "y": 84.546875
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sed_tool/1.1.1",
+            "tool_shed_repository": {
+                "changeset_revision": "ddf54b12c295",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"adv_opts\": {\"adv_opts_selector\": \"basic\", \"__current_case__\": 0}, \"code\": \"/^>/s/^>MN908947.3/>NC_045512.2/\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.1",
+            "type": "tool",
+            "uuid": "5828628c-ef20-428d-b76e-8d502a8d3097",
+            "workflow_outputs": []
+        },
+        "6": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.20.1+galaxy0",
+            "errors": null,
+            "id": 6,
+            "input_connections": {
+                "single_paired|paired_input": {
+                    "id": 1,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool fastp",
+                    "name": "single_paired"
+                }
+            ],
             "label": "fastp: Trimmed Illumina Reads",
             "name": "fastp",
             "outputs": [
@@ -202,14 +257,14 @@
                 }
             ],
             "position": {
-                "bottom": 458.1499938964844,
-                "height": 235.59999084472656,
-                "left": -86.68333435058594,
-                "right": 113.31666564941406,
-                "top": 222.5500030517578,
+                "bottom": 45.5625,
+                "height": 235.515625,
+                "left": 396.5,
+                "right": 596.5,
+                "top": -189.953125,
                 "width": 200,
-                "x": -86.68333435058594,
-                "y": 222.5500030517578
+                "x": 396.5,
+                "y": -189.953125
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_paired_coll": {
@@ -230,65 +285,15 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.20.1+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "dbf9c561ef29",
+                "changeset_revision": "65b93b623c77",
                 "name": "fastp",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": \"false\", \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": \"false\", \"length_required\": null, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": \"false\", \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": \"true\", \"report_json\": \"true\"}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": \"false\", \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": \"false\", \"umi_loc\": \"\", \"umi_len\": null, \"umi_prefix\": \"\"}, \"cutting_by_quality_options\": {\"cut_by_quality5\": \"false\", \"cut_by_quality3\": \"false\", \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": \"false\"}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 2, \"paired_input\": {\"__class__\": \"ConnectedValue\"}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": \"false\", \"adapter_sequence1\": \"\", \"adapter_sequence2\": \"\"}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.20.1+galaxy0",
+            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": \"false\", \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": \"false\", \"length_required\": null, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": \"false\", \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": \"true\", \"report_json\": \"true\"}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": \"false\", \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": \"false\", \"umi_loc\": \"\", \"umi_len\": null, \"umi_prefix\": \"\"}, \"cutting_by_quality_options\": {\"cut_by_quality5\": \"false\", \"cut_by_quality3\": \"false\", \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": \"false\"}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 2, \"paired_input\": {\"__class__\": \"RuntimeValue\"}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": \"false\", \"adapter_sequence1\": \"\", \"adapter_sequence2\": \"\"}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.23.2+galaxy0",
             "type": "tool",
             "uuid": "fb6601de-99e2-4271-813d-0e97027e54c7",
-            "workflow_outputs": []
-        },
-        "6": {
-            "annotation": "If the reference is named MN908947.3 (Genbank name of SARS-CoV-2 reference genome), rename it to NC_045512.2 (RefSeq name of SARS-CoV-2 reference genome)",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sed_tool/1.1.1",
-            "errors": null,
-            "id": 6,
-            "input_connections": {
-                "infile": {
-                    "id": 1,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": "Rename reference to NC_045512.2",
-            "name": "Text transformation",
-            "outputs": [
-                {
-                    "name": "output",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "bottom": 610.6499786376953,
-                "height": 113.59999084472656,
-                "left": -96.68333435058594,
-                "right": 103.31666564941406,
-                "top": 497.04998779296875,
-                "width": 200,
-                "x": -96.68333435058594,
-                "y": 497.04998779296875
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sed_tool/1.1.1",
-            "tool_shed_repository": {
-                "changeset_revision": "fb4ff3c42cd3",
-                "name": "text_processing",
-                "owner": "bgruening",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"adv_opts\": {\"adv_opts_selector\": \"basic\", \"__current_case__\": 0}, \"code\": \"/^>/s/^>MN908947.3/>NC_045512.2/\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.1.1",
-            "type": "tool",
-            "uuid": "5828628c-ef20-428d-b76e-8d502a8d3097",
             "workflow_outputs": []
         },
         "7": {
@@ -298,15 +303,24 @@
             "id": 7,
             "input_connections": {
                 "fastq_input|fastq_input1": {
-                    "id": 5,
+                    "id": 6,
                     "output_name": "output_paired_coll"
                 },
                 "reference_source|ref_file": {
-                    "id": 6,
+                    "id": 5,
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Map with BWA-MEM",
+                    "name": "fastq_input"
+                },
+                {
+                    "description": "runtime parameter for tool Map with BWA-MEM",
+                    "name": "reference_source"
+                }
+            ],
             "label": null,
             "name": "Map with BWA-MEM",
             "outputs": [
@@ -316,14 +330,14 @@
                 }
             ],
             "position": {
-                "bottom": 523.7499847412109,
-                "height": 205.1999969482422,
-                "left": 191.31666564941406,
-                "right": 391.31666564941406,
-                "top": 318.54998779296875,
+                "bottom": 111.171875,
+                "height": 205.125,
+                "left": 674.484375,
+                "right": 874.484375,
+                "top": -93.953125,
                 "width": 200,
-                "x": 191.31666564941406,
-                "y": 318.54998779296875
+                "x": 674.484375,
+                "y": -93.953125
             },
             "post_job_actions": {
                 "HideDatasetActionbam_output": {
@@ -334,12 +348,12 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.1",
             "tool_shed_repository": {
-                "changeset_revision": "3fe632431b68",
+                "changeset_revision": "dfd8b7f78c37",
                 "name": "bwa",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"analysis_type\": {\"analysis_type_selector\": \"illumina\", \"__current_case__\": 0}, \"fastq_input\": {\"fastq_input_selector\": \"paired_collection\", \"__current_case__\": 2, \"fastq_input1\": {\"__class__\": \"ConnectedValue\"}, \"iset_stats\": \"\"}, \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"ConnectedValue\"}, \"index_a\": \"auto\"}, \"rg\": {\"rg_selector\": \"do_not_set\", \"__current_case__\": 3}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"analysis_type\": {\"analysis_type_selector\": \"illumina\", \"__current_case__\": 0}, \"fastq_input\": {\"fastq_input_selector\": \"paired_collection\", \"__current_case__\": 2, \"fastq_input1\": {\"__class__\": \"RuntimeValue\"}, \"iset_stats\": \"\"}, \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"RuntimeValue\"}, \"index_a\": \"auto\"}, \"rg\": {\"rg_selector\": \"do_not_set\", \"__current_case__\": 3}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.7.17.1",
             "type": "tool",
             "uuid": "11cea040-0e8a-4b53-8d16-7bd55f9e1074",
@@ -366,14 +380,14 @@
                 }
             ],
             "position": {
-                "bottom": 432.1499786376953,
-                "height": 113.59999084472656,
-                "left": 469.316650390625,
-                "right": 669.316650390625,
-                "top": 318.54998779296875,
+                "bottom": 40,
+                "height": 133.953125,
+                "left": 952.484375,
+                "right": 1152.484375,
+                "top": -93.953125,
                 "width": 200,
-                "x": 469.316650390625,
-                "y": 318.54998779296875
+                "x": 952.484375,
+                "y": -93.953125
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -416,14 +430,14 @@
                 }
             ],
             "position": {
-                "bottom": 672.6166839599609,
-                "height": 154.40000915527344,
-                "left": 472.66668701171875,
-                "right": 672.6666870117188,
-                "top": 518.2166748046875,
+                "bottom": 280.4375,
+                "height": 174.734375,
+                "left": 955.828125,
+                "right": 1155.828125,
+                "top": 105.703125,
                 "width": 200,
-                "x": 472.66668701171875,
-                "y": 518.2166748046875
+                "x": 955.828125,
+                "y": 105.703125
             },
             "post_job_actions": {
                 "HideDatasetActionoutputsam": {
@@ -456,7 +470,12 @@
                     "output_name": "outputsam"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool QualiMap BamQC",
+                    "name": "input1"
+                }
+            ],
             "label": null,
             "name": "QualiMap BamQC",
             "outputs": [
@@ -470,14 +489,14 @@
                 }
             ],
             "position": {
-                "bottom": 600.7499847412109,
-                "height": 205.1999969482422,
-                "left": 747.316650390625,
-                "right": 947.316650390625,
-                "top": 395.54998779296875,
+                "bottom": 188.171875,
+                "height": 205.125,
+                "left": 1230.484375,
+                "right": 1430.484375,
+                "top": -16.953125,
                 "width": 200,
-                "x": 747.316650390625,
-                "y": 395.54998779296875
+                "x": 1230.484375,
+                "y": -16.953125
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_html": {
@@ -498,7 +517,7 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"duplicate_skipping\": [\"0\"], \"input1\": {\"__class__\": \"ConnectedValue\"}, \"per_base_coverage\": \"false\", \"plot_specific\": {\"n_bins\": \"400\", \"paint_chromosome_limits\": \"true\", \"genome_gc_distr\": null, \"homopolymer_size\": \"3\"}, \"stats_regions\": {\"region_select\": \"all\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"duplicate_skipping\": [\"0\"], \"input1\": {\"__class__\": \"RuntimeValue\"}, \"per_base_coverage\": \"false\", \"plot_specific\": {\"n_bins\": \"400\", \"paint_chromosome_limits\": \"true\", \"genome_gc_distr\": null, \"homopolymer_size\": \"3\"}, \"stats_regions\": {\"region_select\": \"all\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.2.2d+galaxy3",
             "type": "tool",
             "uuid": "a0720c38-9db1-494e-8976-8baa83f69613",
@@ -538,14 +557,14 @@
                 }
             ],
             "position": {
-                "bottom": 823.3499908447266,
-                "height": 184.8000030517578,
-                "left": 747.316650390625,
-                "right": 947.316650390625,
-                "top": 638.5499877929688,
+                "bottom": 390.390625,
+                "height": 164.34375,
+                "left": 1230.484375,
+                "right": 1430.484375,
+                "top": 226.046875,
                 "width": 200,
-                "x": 747.316650390625,
-                "y": 638.5499877929688
+                "x": 1230.484375,
+                "y": 226.046875
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy2",
@@ -563,7 +582,7 @@
                 {
                     "label": "primer_trimmed_bam",
                     "output_name": "output_bam",
-                    "uuid": "ebdd8f89-6559-44a9-9616-c57b78e7a915"
+                    "uuid": "51ccbf34-a6a2-4510-bed9-1559b5e67ca5"
                 }
             ]
         },
@@ -580,7 +599,7 @@
             },
             "inputs": [],
             "label": null,
-            "name": "Flatten Collection",
+            "name": "Flatten collection",
             "outputs": [
                 {
                     "name": "output",
@@ -588,14 +607,14 @@
                 }
             ],
             "position": {
-                "bottom": 555.1499786376953,
-                "height": 113.59999084472656,
-                "left": 1025.316650390625,
-                "right": 1225.316650390625,
-                "top": 441.54998779296875,
+                "bottom": 163,
+                "height": 133.953125,
+                "left": 1508.484375,
+                "right": 1708.484375,
+                "top": 29.046875,
                 "width": 200,
-                "x": 1025.316650390625,
-                "y": 441.54998779296875
+                "x": 1508.484375,
+                "y": 29.046875
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -630,11 +649,20 @@
                     "output_name": "output"
                 },
                 "ref": {
-                    "id": 1,
+                    "id": 0,
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool ivar variants",
+                    "name": "input_bam"
+                },
+                {
+                    "description": "runtime parameter for tool ivar variants",
+                    "name": "ref"
+                }
+            ],
             "label": null,
             "name": "ivar variants",
             "outputs": [
@@ -648,14 +676,14 @@
                 }
             ],
             "position": {
-                "bottom": 967.4499816894531,
-                "height": 296.3999938964844,
-                "left": 1047.316650390625,
-                "right": 1247.316650390625,
-                "top": 671.0499877929688,
+                "bottom": 554.84375,
+                "height": 296.296875,
+                "left": 1530.484375,
+                "right": 1730.484375,
+                "top": 258.546875,
                 "width": 200,
-                "x": 1047.316650390625,
-                "y": 671.0499877929688
+                "x": 1530.484375,
+                "y": 258.546875
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_variants_vcf": {
@@ -673,12 +701,12 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_variants/ivar_variants/1.3.1+galaxy2",
             "tool_shed_repository": {
-                "changeset_revision": "aea7008fe1f1",
+                "changeset_revision": "3888bbe7a9ca",
                 "name": "ivar_variants",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"min_freq\": {\"__class__\": \"ConnectedValue\"}, \"min_qual\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": {\"choice\": \"tabular_and_vcf\", \"__current_case__\": 1, \"pass_only\": \"false\"}, \"ref\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input_bam\": {\"__class__\": \"RuntimeValue\"}, \"min_freq\": {\"__class__\": \"ConnectedValue\"}, \"min_qual\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": {\"choice\": \"tabular_and_vcf\", \"__current_case__\": 1, \"pass_only\": \"false\"}, \"ref\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.3.1+galaxy2",
             "type": "tool",
             "uuid": "0b2aa4bf-69dd-4ccc-b0a2-4a734848e2b8",
@@ -686,7 +714,7 @@
                 {
                     "label": "ivar_variants_tabular",
                     "output_name": "output_variants_tabular",
-                    "uuid": "319f50e1-71fb-445e-b3e3-8015d2787f5f"
+                    "uuid": "b00f5800-3821-4f0a-8e4f-0be4ab5856ca"
                 }
             ]
         },
@@ -719,14 +747,14 @@
                 }
             ],
             "position": {
-                "bottom": 1239.1499786376953,
-                "height": 235.59999084472656,
-                "left": 1025.316650390625,
-                "right": 1225.316650390625,
-                "top": 1003.5499877929688,
+                "bottom": 846.953125,
+                "height": 255.90625,
+                "left": 1508.484375,
+                "right": 1708.484375,
+                "top": 591.046875,
                 "width": 200,
-                "x": 1025.316650390625,
-                "y": 1003.5499877929688
+                "x": 1508.484375,
+                "y": 591.046875
             },
             "post_job_actions": {
                 "HideDatasetActionconsensus": {
@@ -737,7 +765,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_consensus/ivar_consensus/1.3.1+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "2d9926ce62be",
+                "changeset_revision": "731182d54f78",
                 "name": "ivar_consensus",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -755,7 +783,7 @@
             "id": 15,
             "input_connections": {
                 "results_0|software_cond|input": {
-                    "id": 5,
+                    "id": 6,
                     "output_name": "report_json"
                 },
                 "results_1|software_cond|output_0|type|input": {
@@ -781,14 +809,14 @@
                 }
             ],
             "position": {
-                "bottom": 606.9499816894531,
-                "height": 286.3999938964844,
-                "left": 1303.316650390625,
-                "right": 1503.316650390625,
-                "top": 320.54998779296875,
+                "bottom": 173.953125,
+                "height": 265.90625,
+                "left": 1786.484375,
+                "right": 1986.484375,
+                "top": -91.953125,
                 "width": 200,
-                "x": 1303.316650390625,
-                "y": 320.54998779296875
+                "x": 1786.484375,
+                "y": -91.953125
             },
             "post_job_actions": {
                 "HideDatasetActionstats": {
@@ -806,20 +834,20 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.9+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "75c93c70d094",
+                "changeset_revision": "9a913cdee30e",
                 "name": "multiqc",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"comment\": \"\", \"export\": \"false\", \"flat\": \"false\", \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastp\", \"__current_case__\": 7, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"samtools\", \"__current_case__\": 24, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"stats\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}}]}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"qualimap\", \"__current_case__\": 20, \"input\": {\"__class__\": \"ConnectedValue\"}}}], \"saveLog\": \"false\", \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.9+galaxy1",
+            "tool_state": "{\"comment\": \"\", \"export\": \"false\", \"flat\": \"false\", \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastp\", \"__current_case__\": 7, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"samtools\", \"__current_case__\": 24, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"stats\", \"__current_case__\": 0, \"input\": {\"__class__\": \"RuntimeValue\"}}}]}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"qualimap\", \"__current_case__\": 20, \"input\": {\"__class__\": \"RuntimeValue\"}}}], \"saveLog\": \"false\", \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.11+galaxy0",
             "type": "tool",
             "uuid": "d03312e1-3b85-4883-b601-6081acf7503d",
             "workflow_outputs": [
                 {
                     "label": "bamqc_report_html",
                     "output_name": "html_report",
-                    "uuid": "0489d543-59ec-4f03-be4c-d13b14b03ac7"
+                    "uuid": "b5b9b049-811f-4420-a7a9-a9e6a1f3812a"
                 }
             ]
         },
@@ -835,6 +863,10 @@
                 }
             },
             "inputs": [
+                {
+                    "description": "runtime parameter for tool SnpEff eff:",
+                    "name": "input"
+                },
                 {
                     "description": "runtime parameter for tool SnpEff eff:",
                     "name": "intervals"
@@ -857,27 +889,20 @@
                 }
             ],
             "position": {
-                "bottom": 997.75,
-                "height": 327.20001220703125,
-                "left": 1807.316650390625,
-                "right": 2007.316650390625,
-                "top": 670.5499877929688,
+                "bottom": 585.125,
+                "height": 327.078125,
+                "left": 2290.484375,
+                "right": 2490.484375,
+                "top": 258.046875,
                 "width": 200,
-                "x": 1807.316650390625,
-                "y": 670.5499877929688
+                "x": 2290.484375,
+                "y": 258.046875
             },
             "post_job_actions": {
                 "HideDatasetActionstatsFile": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
                     "output_name": "statsFile"
-                },
-                "RenameDatasetActionsnpeff_output": {
-                    "action_arguments": {
-                        "newname": "Annotated variants"
-                    },
-                    "action_type": "RenameDatasetAction",
-                    "output_name": "snpeff_output"
                 }
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff_sars_cov_2/snpeff_sars_cov_2/4.5covid19",
@@ -887,7 +912,7 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"annotations\": null, \"chr\": \"\", \"csvStats\": \"false\", \"filter\": {\"specificEffects\": \"no\", \"__current_case__\": 0}, \"filterOut\": null, \"generate_stats\": \"true\", \"genome_version\": \"NC_045512.2\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"inputFormat\": \"vcf\", \"intervals\": {\"__class__\": \"RuntimeValue\"}, \"noLog\": \"true\", \"offset\": \"default\", \"outputConditional\": {\"outputFormat\": \"vcf\", \"__current_case__\": 0}, \"transcripts\": {\"__class__\": \"RuntimeValue\"}, \"udLength\": \"0\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"annotations\": null, \"chr\": \"\", \"csvStats\": \"false\", \"filter\": {\"specificEffects\": \"no\", \"__current_case__\": 0}, \"filterOut\": null, \"generate_stats\": \"true\", \"genome_version\": \"NC_045512.2\", \"input\": {\"__class__\": \"RuntimeValue\"}, \"inputFormat\": \"vcf\", \"intervals\": {\"__class__\": \"RuntimeValue\"}, \"noLog\": \"true\", \"offset\": \"default\", \"outputConditional\": {\"outputFormat\": \"vcf\", \"__current_case__\": 0}, \"transcripts\": {\"__class__\": \"RuntimeValue\"}, \"udLength\": \"0\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "4.5covid19",
             "type": "tool",
             "uuid": "a8b63b67-2795-4e21-8614-f7d24cec2224",
@@ -895,7 +920,7 @@
                 {
                     "label": "snpeff_annotated_vcf",
                     "output_name": "snpeff_output",
-                    "uuid": "8f6057ec-4a34-4c49-ad4b-f0d93ba33878"
+                    "uuid": "4ef62dab-fa01-4951-a99b-10c2b3e8884b"
                 }
             ]
         },
@@ -920,14 +945,14 @@
                 }
             ],
             "position": {
-                "bottom": 1158.550048828125,
-                "height": 134,
-                "left": 1303.316650390625,
-                "right": 1503.316650390625,
-                "top": 1024.550048828125,
+                "bottom": 746,
+                "height": 133.953125,
+                "left": 1786.484375,
+                "right": 1986.484375,
+                "top": 612.046875,
                 "width": 200,
-                "x": 1303.316650390625,
-                "y": 1024.550048828125
+                "x": 1786.484375,
+                "y": 612.046875
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -940,7 +965,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sed_tool/1.1.1",
             "tool_shed_repository": {
-                "changeset_revision": "fb4ff3c42cd3",
+                "changeset_revision": "ddf54b12c295",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -953,7 +978,7 @@
                 {
                     "label": "ivar_consensus_genome",
                     "output_name": "output",
-                    "uuid": "cabe916a-b8ba-49e1-af9d-30dad1bd44ae"
+                    "uuid": "ba000826-68b7-4b33-b1f8-1200814d9df1"
                 }
             ]
         },
@@ -968,12 +993,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Concatenate datasets",
-                    "name": "inputs"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Concatenate datasets",
             "outputs": [
@@ -983,14 +1003,14 @@
                 }
             ],
             "position": {
-                "bottom": 1249.6500396728516,
-                "height": 113.59999084472656,
-                "left": 1546.316650390625,
-                "right": 1746.316650390625,
-                "top": 1136.050048828125,
+                "bottom": 857.5,
+                "height": 133.953125,
+                "left": 2029.484375,
+                "right": 2229.484375,
+                "top": 723.546875,
                 "width": 200,
-                "x": 1546.316650390625,
-                "y": 1136.050048828125
+                "x": 2029.484375,
+                "y": 723.546875
             },
             "post_job_actions": {
                 "RenameDatasetActionout_file1": {
@@ -1008,7 +1028,7 @@
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"inputs\": {\"__class__\": \"RuntimeValue\"}, \"queries\": [], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"inputs\": {\"__class__\": \"ConnectedValue\"}, \"queries\": [], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.1.1",
             "type": "tool",
             "uuid": "87e8ec0a-d8e8-48f3-b943-04c75152fec2",
@@ -1016,7 +1036,7 @@
                 {
                     "label": "combined_multifasta",
                     "output_name": "out_file1",
-                    "uuid": "d58378c8-fe46-4cab-9317-5991a3561221"
+                    "uuid": "90ed92b7-7ac1-4073-aacc-e4ccf9f78e4f"
                 }
             ]
         },
@@ -1046,32 +1066,32 @@
                 }
             ],
             "position": {
-                "bottom": 1166.6500396728516,
-                "height": 113.59999084472656,
-                "left": 1810.316650390625,
-                "right": 2010.316650390625,
-                "top": 1053.050048828125,
+                "bottom": 754.109375,
+                "height": 113.5625,
+                "left": 2293.484375,
+                "right": 2493.484375,
+                "top": 640.546875,
                 "width": 200,
-                "x": 1810.316650390625,
-                "y": 1053.050048828125
+                "x": 2293.484375,
+                "y": 640.546875
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pangolin/pangolin/3.1.14+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "fe3e8506112c",
+                "changeset_revision": "81804a978fc0",
                 "name": "pangolin",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"alignment\": \"false\", \"db\": {\"source\": \"download\", \"__current_case__\": 0}, \"include_header\": \"true\", \"input1\": {\"__class__\": \"RuntimeValue\"}, \"max_ambig\": \"0.5\", \"min_length\": \"10000\", \"usher\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "3.1.14+galaxy0",
+            "tool_state": "{\"alignment\": \"false\", \"db\": {\"source\": \"download\", \"__current_case__\": 0}, \"engine\": {\"analysis_mode\": \"usher\", \"__current_case__\": 0, \"use_assignment_cache\": \"false\"}, \"expanded_lineage\": \"false\", \"include_header\": \"true\", \"input1\": {\"__class__\": \"RuntimeValue\"}, \"max_ambig\": \"0.5\", \"min_length\": \"10000\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "4.0.5+galaxy2",
             "type": "tool",
             "uuid": "15ff9812-4ff9-4ac2-9f95-c65bab4eb070",
             "workflow_outputs": [
                 {
                     "label": "all_samples_pangolin",
                     "output_name": "output1",
-                    "uuid": "a0468d09-08a4-43de-be10-4dc4e6973b99"
+                    "uuid": "e8ec97a7-03ea-4fbe-906f-621cb40503c1"
                 }
             ]
         },
@@ -1101,32 +1121,32 @@
                 }
             ],
             "position": {
-                "bottom": 1355.550048828125,
-                "height": 134,
-                "left": 1809.316650390625,
-                "right": 2009.316650390625,
-                "top": 1221.550048828125,
+                "bottom": 943,
+                "height": 133.953125,
+                "left": 2292.484375,
+                "right": 2492.484375,
+                "top": 809.046875,
                 "width": 200,
-                "x": 1809.316650390625,
-                "y": 1221.550048828125
+                "x": 2292.484375,
+                "y": 809.046875
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/nextclade/nextclade/1.4.1+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "56b1a13d9680",
+                "changeset_revision": "9e10ba792be2",
                 "name": "nextclade",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"adv\": {\"advanced_options\": \"no\", \"__current_case__\": 1}, \"include_header\": \"true\", \"input_fasta\": {\"__class__\": \"RuntimeValue\"}, \"organism\": \"sars-cov-2\", \"outputs\": [\"report_tsv\"], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.4.1+galaxy0",
+            "tool_version": "1.11.0+galaxy0",
             "type": "tool",
             "uuid": "4b821f22-47f8-4251-bc32-5aa167498ba7",
             "workflow_outputs": [
                 {
                     "label": "all_samples_nextclade",
                     "output_name": "report_tsv",
-                    "uuid": "4cd1f6bd-be94-43c3-9d4a-773f178b96c4"
+                    "uuid": "344137e8-2e37-42f9-810f-b9ff07264265"
                 }
             ]
         }
@@ -1136,5 +1156,6 @@
         "ARTIC",
         "iwc"
     ],
-    "uuid": "d784cd9f-b1a1-4a13-8400-5fc5ffa14dd0"
+    "uuid": "feb1b4b7-e8cb-4fdf-9ef9-140fad0faf98",
+    "version": 1
 }


### PR DESCRIPTION
## [sars-cov-2-pe-illumina-artic-ivar-analysis](https://github.com/galaxyproject/iwc/tree/main/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-ivar-analysis) workflow update

### Changes
- Upgrade pangolin to 4.0.5
  - Analysis engine switched to UShER, that is more accurate but slower than the previous default PangoLEARN engine
  - https://github.com/cov-lineages/pangolin/releases
- Upgrade Nextclade to 1.11.0
  - https://github.com/nextstrain/nextclade/releases
- Upgrade MultiQC to 1.11.0
  - Modules updates (notably fastp)
  - https://github.com/ewels/MultiQC/releases
- Upgrade fastp to 0.23.2
  - Improved performances
  - https://github.com/OpenGene/fastp/releases