### PR TITLE
Updating workflows/computational-chemistry/gromacs-mmgbsa from 0.1.3 to 0.1.4

### DIFF
--- a/workflows/computational-chemistry/gromacs-mmgbsa/CHANGELOG.md
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.1.4] 2022-10-31
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2021.3+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2022+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_editconf/gmx_editconf/2021.3+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_editconf/gmx_editconf/2022+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2021.3+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2022+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_em/gmx_em/2021.3+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_em/gmx_em/2022+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2` was updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2022+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/chemteam/md_converter/md_converter/1.9.6+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/chemteam/md_converter/md_converter/1.9.7+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/4.2` was updated to `toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0`
+
 ## [0.1.3] 2022-05-25
 
 ### Changed

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.23",
+    "release": "0.1.24",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -988,7 +988,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "94d9a5fa-0f0a-4fd4-89bd-7149eae99a90"
+                "uuid": "afa728f6-1357-4994-bf7e-0f38234b779d"
             },
             "tool_id": null,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.26",
+    "release": "0.1.27",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -988,7 +988,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "5e8cf367-fca9-46ad-95e5-a93a817cc863"
+                "uuid": "ea8e8c7e-1212-4ea7-a2e8-e0291c4cb1c4"
             },
             "tool_id": null,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.13",
+    "release": "0.1.14",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -963,7 +963,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "e7cac9ad-5240-4b3b-b1ca-80a83b8e1d58"
+                "uuid": "6bbf031b-17a7-425c-bbe8-09b3a8b889e7"
             },
             "tool_id": 3,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.9",
+    "release": "0.1.10",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -963,7 +963,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "77c44791-0674-4afb-b007-c5ad47f6528f"
+                "uuid": "155997fc-b31d-4112-a714-78358571593e"
             },
             "tool_id": 3,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.10",
+    "release": "0.1.11",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -963,7 +963,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "155997fc-b31d-4112-a714-78358571593e"
+                "uuid": "156baa29-76a6-433e-9f7e-a3af71ab60fc"
             },
             "tool_id": 3,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.14",
+    "release": "0.1.15",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -963,9 +963,9 @@
                     }
                 },
                 "tags": "",
-                "uuid": "6bbf031b-17a7-425c-bbe8-09b3a8b889e7"
+                "uuid": "48fc9274-3a1b-45a1-8609-0adf4759d833"
             },
-            "tool_id": 3,
+            "tool_id": null,
             "type": "subworkflow",
             "uuid": "fe2677ce-d0d4-4937-9d34-f9a35db814d8",
             "workflow_outputs": [

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.6",
+    "release": "0.1.7",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -963,7 +963,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "232de8db-2a23-4c89-a049-17b77198dab9"
+                "uuid": "f701ef72-c85c-48e6-b0fa-6d030d98366e"
             },
             "tool_id": 3,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.16",
+    "release": "0.1.17",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -988,7 +988,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "27f6c049-99ca-448f-bcae-caae80d66947"
+                "uuid": "a338cbf6-ca1a-4eaa-b7de-26b745ccf375"
             },
             "tool_id": null,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.7",
+    "release": "0.1.8",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -963,7 +963,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "f701ef72-c85c-48e6-b0fa-6d030d98366e"
+                "uuid": "9b2a9f70-4933-4951-8248-4f375f9afde2"
             },
             "tool_id": 3,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.17",
+    "release": "0.1.18",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -988,7 +988,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "a338cbf6-ca1a-4eaa-b7de-26b745ccf375"
+                "uuid": "bc1c40d3-6be9-453f-a319-f7f4a729d872"
             },
             "tool_id": null,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.5",
+    "release": "0.1.6",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -963,7 +963,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "13a1b124-c96e-48cb-9824-b443bab95070"
+                "uuid": "232de8db-2a23-4c89-a049-17b77198dab9"
             },
             "tool_id": 3,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.11",
+    "release": "0.1.12",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -963,7 +963,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "156baa29-76a6-433e-9f7e-a3af71ab60fc"
+                "uuid": "aac09500-0c2b-41f6-9524-c31b3521b103"
             },
             "tool_id": 3,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.20",
+    "release": "0.1.21",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -988,7 +988,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "0ded9f8b-276f-4576-85e4-ac1df10d60eb"
+                "uuid": "c5dd1376-d879-44a2-8c22-412ea59a3745"
             },
             "tool_id": null,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.24",
+    "release": "0.1.25",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -988,7 +988,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "afa728f6-1357-4994-bf7e-0f38234b779d"
+                "uuid": "78efacb5-f18b-408d-b6a3-629128597172"
             },
             "tool_id": null,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.22",
+    "release": "0.1.23",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -988,7 +988,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "f8b9d2ca-7ec5-43d8-9b76-45aeac44fc8c"
+                "uuid": "94d9a5fa-0f0a-4fd4-89bd-7149eae99a90"
             },
             "tool_id": null,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,45 +11,13 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.3",
+    "release": "0.1.4",
     "steps": {
         "0": {
-            "annotation": "Size of the MMGBSA ensemble",
-            "content_id": null,
-            "errors": null,
-            "id": 0,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "Size of the MMGBSA ensemble",
-                    "name": "Number of simulations"
-                }
-            ],
-            "label": "Number of simulations",
-            "name": "Input parameter",
-            "outputs": [],
-            "position": {
-                "bottom": 128.10000610351562,
-                "height": 102.60000610351562,
-                "left": 1,
-                "right": 201,
-                "top": 25.5,
-                "width": 200,
-                "x": 1,
-                "y": 25.5
-            },
-            "tool_id": null,
-            "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
-            "tool_version": null,
-            "type": "parameter_input",
-            "uuid": "0b26a4eb-6715-4e56-b8c4-1796486f91c5",
-            "workflow_outputs": []
-        },
-        "1": {
             "annotation": "NaCl concentration",
             "content_id": null,
             "errors": null,
-            "id": 1,
+            "id": 0,
             "input_connections": {},
             "inputs": [
                 {
@@ -61,20 +29,40 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 284.6999969482422,
-                "height": 82.19999694824219,
-                "left": -277,
-                "right": -77,
-                "top": 202.5,
-                "width": 200,
-                "x": -277,
-                "y": 202.5
+                "left": 0,
+                "top": 184.0
             },
             "tool_id": null,
             "tool_state": "{\"default\": 0.0, \"parameter_type\": \"float\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "be1f6375-076e-4d61-a780-f867af394809",
+            "workflow_outputs": []
+        },
+        "1": {
+            "annotation": "Size of the MMGBSA ensemble",
+            "content_id": null,
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Size of the MMGBSA ensemble",
+                    "name": "Number of simulations"
+                }
+            ],
+            "label": "Number of simulations",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 278,
+                "top": 7.0
+            },
+            "tool_id": null,
+            "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "0b26a4eb-6715-4e56-b8c4-1796486f91c5",
             "workflow_outputs": []
         },
         "2": {
@@ -93,17 +81,11 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 402.6999969482422,
-                "height": 82.19999694824219,
-                "left": 279,
-                "right": 479,
-                "top": 320.5,
-                "width": 200,
-                "x": 279,
-                "y": 320.5
+                "left": 556,
+                "top": 302.0
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false}",
+            "tool_state": "{\"optional\": false, \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "808dce0b-2da4-4cad-865e-5f264164b9a5",
@@ -125,14 +107,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 502.3000030517578,
-                "height": 61.80000305175781,
-                "left": 279,
-                "right": 479,
-                "top": 440.5,
-                "width": 200,
-                "x": 279,
-                "y": 440.5
+                "left": 556,
+                "top": 422.0
             },
             "tool_id": null,
             "tool_state": "{\"restrictions\": [\"tip3p\", \"tip4p\", \"tips3p\", \"tip5p\", \"spc\", \"spce\", \"none\"], \"parameter_type\": \"text\", \"optional\": false}",
@@ -157,14 +133,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 602.3000030517578,
-                "height": 61.80000305175781,
-                "left": 279,
-                "right": 479,
-                "top": 540.5,
-                "width": 200,
-                "x": 279,
-                "y": 540.5
+                "left": 556,
+                "top": 522.0
             },
             "tool_id": null,
             "tool_state": "{\"default\": -1.0, \"parameter_type\": \"float\", \"optional\": true}",
@@ -189,14 +159,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 702.3000030517578,
-                "height": 61.80000305175781,
-                "left": 279,
-                "right": 479,
-                "top": 640.5,
-                "width": 200,
-                "x": 279,
-                "y": 640.5
+                "left": 556,
+                "top": 622.0
             },
             "tool_id": null,
             "tool_state": "{\"restrictions\": [\"oplsaa\", \"gromos43a1\", \"amber96\", \"gromos53a6\", \"amber99sb\", \"gromos53a5\", \"gromos43a2\", \"amberGS\", \"charmm27\", \"amber03\", \"gromos54a7\", \"gromos45a3\", \"amber99\", \"amber94\"], \"parameter_type\": \"text\", \"optional\": false}",
@@ -221,17 +185,11 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 802.3000030517578,
-                "height": 61.80000305175781,
-                "left": 279,
-                "right": 479,
-                "top": 740.5,
-                "width": 200,
-                "x": 279,
-                "y": 740.5
+                "left": 556,
+                "top": 722.0
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false}",
+            "tool_state": "{\"optional\": false, \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "6c2e18cb-d616-43b3-b655-ff9d6dfc3ac9",
@@ -253,14 +211,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 691.1000061035156,
-                "height": 102.60000610351562,
-                "left": 1451,
-                "right": 1651,
-                "top": 588.5,
-                "width": 200,
-                "x": 1451,
-                "y": 588.5
+                "left": 1728,
+                "top": 570.0
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
@@ -285,14 +237,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 833.1000061035156,
-                "height": 102.60000610351562,
-                "left": 1759,
-                "right": 1959,
-                "top": 730.5,
-                "width": 200,
-                "x": 1759,
-                "y": 730.5
+                "left": 2036,
+                "top": 712.0
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
@@ -317,14 +263,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 811.6999969482422,
-                "height": 82.19999694824219,
-                "left": 2067,
-                "right": 2267,
-                "top": 729.5,
-                "width": 200,
-                "x": 2067,
-                "y": 729.5
+                "left": 2344,
+                "top": 711.0
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
@@ -340,7 +280,7 @@
             "id": 10,
             "input_connections": {
                 "components_0|param_type|component_value": {
-                    "id": 1,
+                    "id": 0,
                     "output_name": "output"
                 }
             },
@@ -354,14 +294,8 @@
                 }
             ],
             "position": {
-                "bottom": 320.8999938964844,
-                "height": 154.39999389648438,
-                "left": 1,
-                "right": 201,
-                "top": 166.5,
-                "width": 200,
-                "x": 1,
-                "y": 166.5
+                "left": 278,
+                "top": 148.0
             },
             "post_job_actions": {
                 "HideDatasetActionout1": {
@@ -418,14 +352,8 @@
             "name": "Create GRO and TOP complex files",
             "outputs": [],
             "position": {
-                "bottom": 648.2999877929688,
-                "height": 336.79998779296875,
-                "left": 597,
-                "right": 797,
-                "top": 311.5,
-                "width": 200,
-                "x": 597,
-                "y": 311.5
+                "left": 874,
+                "top": 293.0
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -442,106 +370,10 @@
                 "name": "Create GRO and TOP complex files",
                 "steps": {
                     "0": {
-                        "annotation": "PDB file for the protein (without ligand, cofactor, waters)",
-                        "content_id": null,
-                        "errors": null,
-                        "id": 0,
-                        "input_connections": {},
-                        "inputs": [
-                            {
-                                "description": "PDB file for the protein (without ligand, cofactor, waters)",
-                                "name": "Apoprotein PDB"
-                            }
-                        ],
-                        "label": "Apoprotein PDB",
-                        "name": "Input dataset",
-                        "outputs": [],
-                        "position": {
-                            "bottom": 202.1999969482422,
-                            "height": 82.19999694824219,
-                            "left": 421,
-                            "right": 621,
-                            "top": 120,
-                            "width": 200,
-                            "x": 421,
-                            "y": 120
-                        },
-                        "tool_id": null,
-                        "tool_state": "{\"optional\": false}",
-                        "tool_version": null,
-                        "type": "data_input",
-                        "uuid": "68f60b7d-13f3-4b21-aedf-986f0f7e48d7",
-                        "workflow_outputs": []
-                    },
-                    "1": {
-                        "annotation": "Model for water molecules (relevant for subsequent solvation)",
-                        "content_id": null,
-                        "errors": null,
-                        "id": 1,
-                        "input_connections": {},
-                        "inputs": [
-                            {
-                                "description": "Model for water molecules (relevant for subsequent solvation)",
-                                "name": "Water model"
-                            }
-                        ],
-                        "label": "Water model",
-                        "name": "Input parameter",
-                        "outputs": [],
-                        "position": {
-                            "bottom": 301.8000030517578,
-                            "height": 61.80000305175781,
-                            "left": 421,
-                            "right": 621,
-                            "top": 240,
-                            "width": 200,
-                            "x": 421,
-                            "y": 240
-                        },
-                        "tool_id": null,
-                        "tool_state": "{\"restrictions\": [\"tip3p\", \"tip4p\", \"tips3p\", \"tip5p\", \"spc\", \"spce\", \"none\"], \"parameter_type\": \"text\", \"optional\": false}",
-                        "tool_version": null,
-                        "type": "parameter_input",
-                        "uuid": "8d29ae78-60de-45ba-b403-cdd2646af030",
-                        "workflow_outputs": []
-                    },
-                    "2": {
-                        "annotation": "Force field for protein modelling. GAFF is used for the ligand.",
-                        "content_id": null,
-                        "errors": null,
-                        "id": 2,
-                        "input_connections": {},
-                        "inputs": [
-                            {
-                                "description": "Force field for protein modelling. GAFF is used for the ligand.",
-                                "name": "Force field"
-                            }
-                        ],
-                        "label": "Force field",
-                        "name": "Input parameter",
-                        "outputs": [],
-                        "position": {
-                            "bottom": 401.8000030517578,
-                            "height": 61.80000305175781,
-                            "left": 421,
-                            "right": 621,
-                            "top": 340,
-                            "width": 200,
-                            "x": 421,
-                            "y": 340
-                        },
-                        "tool_id": null,
-                        "tool_state": "{\"restrictions\": [\"oplsaa\", \"gromos43a1\", \"amber96\", \"gromos53a6\", \"amber99sb\", \"amber99sb\", \"gromos53a5\", \"gromos43a2\", \"amberGS\", \"charmm27\", \"amber03\", \"gromos54a7\", \"gromos45a3\", \"amber99\", \"amber94\"], \"parameter_type\": \"text\", \"optional\": false}",
-                        "tool_version": null,
-                        "type": "parameter_input",
-                        "uuid": "16c399b1-e67c-47a9-acd3-61ddc39473d9",
-                        "workflow_outputs": []
-                    },
-                    "3": {
                         "annotation": "SD-file for the input ligand",
                         "content_id": null,
                         "errors": null,
-                        "id": 3,
+                        "id": 0,
                         "input_connections": {},
                         "inputs": [
                             {
@@ -553,27 +385,21 @@
                         "name": "Input dataset",
                         "outputs": [],
                         "position": {
-                            "bottom": 642.8000030517578,
-                            "height": 61.80000305175781,
-                            "left": -691,
-                            "right": -491,
-                            "top": 581,
-                            "width": 200,
-                            "x": -691,
-                            "y": 581
+                            "left": 0,
+                            "top": 461
                         },
                         "tool_id": null,
-                        "tool_state": "{\"optional\": false, \"format\": [\"sdf\"]}",
+                        "tool_state": "{\"optional\": false, \"format\": [\"sdf\"], \"tag\": null}",
                         "tool_version": null,
                         "type": "data_input",
                         "uuid": "277627e0-eba8-4de5-855b-63711c0db691",
                         "workflow_outputs": []
                     },
-                    "4": {
+                    "1": {
                         "annotation": "pH for protonating the ligand. Set to -1.0 to skip.",
                         "content_id": null,
                         "errors": null,
-                        "id": 4,
+                        "id": 1,
                         "input_connections": {},
                         "inputs": [
                             {
@@ -585,14 +411,8 @@
                         "name": "Input parameter",
                         "outputs": [],
                         "position": {
-                            "bottom": 899.8000030517578,
-                            "height": 61.80000305175781,
-                            "left": -691,
-                            "right": -491,
-                            "top": 838,
-                            "width": 200,
-                            "x": -691,
-                            "y": 838
+                            "left": 0,
+                            "top": 718
                         },
                         "tool_id": null,
                         "tool_state": "{\"default\": -1.0, \"parameter_type\": \"float\", \"optional\": true}",
@@ -601,105 +421,92 @@
                         "uuid": "6893b667-f375-481b-96eb-50d5aceb5030",
                         "workflow_outputs": []
                     },
-                    "5": {
-                        "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2021.3+galaxy0",
+                    "2": {
+                        "annotation": "PDB file for the protein (without ligand, cofactor, waters)",
+                        "content_id": null,
                         "errors": null,
-                        "id": 5,
-                        "input_connections": {
-                            "ff": {
-                                "id": 2,
-                                "output_name": "output"
-                            },
-                            "pdb_input": {
-                                "id": 0,
-                                "output_name": "output"
-                            },
-                            "water": {
-                                "id": 1,
-                                "output_name": "output"
-                            }
-                        },
+                        "id": 2,
+                        "input_connections": {},
                         "inputs": [
                             {
-                                "description": "runtime parameter for tool GROMACS initial setup",
-                                "name": "pdb_input"
+                                "description": "PDB file for the protein (without ligand, cofactor, waters)",
+                                "name": "Apoprotein PDB"
                             }
                         ],
-                        "label": null,
-                        "name": "GROMACS initial setup",
-                        "outputs": [
-                            {
-                                "name": "output1",
-                                "type": "top"
-                            },
-                            {
-                                "name": "output2",
-                                "type": "gro"
-                            },
-                            {
-                                "name": "output3",
-                                "type": "itp"
-                            },
-                            {
-                                "name": "report",
-                                "type": "txt"
-                            }
-                        ],
+                        "label": "Apoprotein PDB",
+                        "name": "Input dataset",
+                        "outputs": [],
                         "position": {
-                            "bottom": 511.20001220703125,
-                            "height": 347.20001220703125,
-                            "left": 695,
-                            "right": 895,
-                            "top": 164,
-                            "width": 200,
-                            "x": 695,
-                            "y": 164
+                            "left": 1112,
+                            "top": 0
                         },
-                        "post_job_actions": {
-                            "HideDatasetActionoutput1": {
-                                "action_arguments": {},
-                                "action_type": "HideDatasetAction",
-                                "output_name": "output1"
-                            },
-                            "HideDatasetActionoutput2": {
-                                "action_arguments": {},
-                                "action_type": "HideDatasetAction",
-                                "output_name": "output2"
-                            },
-                            "HideDatasetActionreport": {
-                                "action_arguments": {},
-                                "action_type": "HideDatasetAction",
-                                "output_name": "report"
-                            }
-                        },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2021.3+galaxy0",
-                        "tool_shed_repository": {
-                            "changeset_revision": "8ad46f918541",
-                            "name": "gmx_setup",
-                            "owner": "chemteam",
-                            "tool_shed": "toolshed.g2.bx.psu.edu"
-                        },
-                        "tool_state": "{\"capture_log\": \"true\", \"ff\": {\"__class__\": \"ConnectedValue\"}, \"ignore_h\": \"false\", \"pdb_input\": {\"__class__\": \"RuntimeValue\"}, \"water\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "2021.3+galaxy0",
-                        "type": "tool",
-                        "uuid": "b922c050-5df2-42b8-a819-1cbf892e06fa",
-                        "workflow_outputs": [
-                            {
-                                "label": "Position restraints file",
-                                "output_name": "output3",
-                                "uuid": "a8969ed8-83f9-4ff3-9634-56f85e7dd4dd"
-                            }
-                        ]
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"tag\": null}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "68f60b7d-13f3-4b21-aedf-986f0f7e48d7",
+                        "workflow_outputs": []
                     },
-                    "6": {
+                    "3": {
+                        "annotation": "Model for water molecules (relevant for subsequent solvation)",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 3,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "Model for water molecules (relevant for subsequent solvation)",
+                                "name": "Water model"
+                            }
+                        ],
+                        "label": "Water model",
+                        "name": "Input parameter",
+                        "outputs": [],
+                        "position": {
+                            "left": 1112,
+                            "top": 120
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"restrictions\": [\"tip3p\", \"tip4p\", \"tips3p\", \"tip5p\", \"spc\", \"spce\", \"none\"], \"parameter_type\": \"text\", \"optional\": false}",
+                        "tool_version": null,
+                        "type": "parameter_input",
+                        "uuid": "8d29ae78-60de-45ba-b403-cdd2646af030",
+                        "workflow_outputs": []
+                    },
+                    "4": {
+                        "annotation": "Force field for protein modelling. GAFF is used for the ligand.",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 4,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "Force field for protein modelling. GAFF is used for the ligand.",
+                                "name": "Force field"
+                            }
+                        ],
+                        "label": "Force field",
+                        "name": "Input parameter",
+                        "outputs": [],
+                        "position": {
+                            "left": 1112,
+                            "top": 220
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"restrictions\": [\"oplsaa\", \"gromos43a1\", \"amber96\", \"gromos53a6\", \"amber99sb\", \"amber99sb\", \"gromos53a5\", \"gromos43a2\", \"amberGS\", \"charmm27\", \"amber03\", \"gromos54a7\", \"gromos45a3\", \"amber99\", \"amber94\"], \"parameter_type\": \"text\", \"optional\": false}",
+                        "tool_version": null,
+                        "type": "parameter_input",
+                        "uuid": "16c399b1-e67c-47a9-acd3-61ddc39473d9",
+                        "workflow_outputs": []
+                    },
+                    "5": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_rdkit_descriptors/ctb_rdkit_descriptors/2020.03.4+galaxy1",
                         "errors": null,
-                        "id": 6,
+                        "id": 5,
                         "input_connections": {
                             "infile": {
-                                "id": 3,
+                                "id": 0,
                                 "output_name": "output"
                             }
                         },
@@ -713,14 +520,8 @@
                             }
                         ],
                         "position": {
-                            "bottom": 658.1999969482422,
-                            "height": 93.19999694824219,
-                            "left": -413,
-                            "right": -213,
-                            "top": 565,
-                            "width": 200,
-                            "x": -413,
-                            "y": 565
+                            "left": 278,
+                            "top": 445
                         },
                         "post_job_actions": {
                             "HideDatasetActionoutfile": {
@@ -731,7 +532,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_rdkit_descriptors/ctb_rdkit_descriptors/2020.03.4+galaxy1",
                         "tool_shed_repository": {
-                            "changeset_revision": "a1c53f0533b0",
+                            "changeset_revision": "0993ac4f4a23",
                             "name": "ctb_rdkit_descriptors",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -742,18 +543,18 @@
                         "uuid": "351397ff-a72d-4c7d-b39a-bc97b8f2c357",
                         "workflow_outputs": []
                     },
-                    "7": {
+                    "6": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_compound_convert/openbabel_compound_convert/3.1.1+galaxy0",
                         "errors": null,
-                        "id": 7,
+                        "id": 6,
                         "input_connections": {
                             "infile": {
-                                "id": 3,
+                                "id": 0,
                                 "output_name": "output"
                             },
                             "ph": {
-                                "id": 4,
+                                "id": 1,
                                 "output_name": "output"
                             }
                         },
@@ -767,14 +568,8 @@
                             }
                         ],
                         "position": {
-                            "bottom": 940.6000061035156,
-                            "height": 225.60000610351562,
-                            "left": -413,
-                            "right": -213,
-                            "top": 715,
-                            "width": 200,
-                            "x": -413,
-                            "y": 715
+                            "left": 278,
+                            "top": 595
                         },
                         "post_job_actions": {
                             "HideDatasetActionoutfile": {
@@ -796,6 +591,86 @@
                         "uuid": "c1f8c291-3b11-4afa-b62d-ee2d2d22b11f",
                         "workflow_outputs": []
                     },
+                    "7": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2022+galaxy0",
+                        "errors": null,
+                        "id": 7,
+                        "input_connections": {
+                            "ff": {
+                                "id": 4,
+                                "output_name": "output"
+                            },
+                            "pdb_input": {
+                                "id": 2,
+                                "output_name": "output"
+                            },
+                            "water": {
+                                "id": 3,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "GROMACS initial setup",
+                        "outputs": [
+                            {
+                                "name": "output1",
+                                "type": "top"
+                            },
+                            {
+                                "name": "output2",
+                                "type": "gro"
+                            },
+                            {
+                                "name": "output3",
+                                "type": "itp"
+                            },
+                            {
+                                "name": "report",
+                                "type": "txt"
+                            }
+                        ],
+                        "position": {
+                            "left": 1386,
+                            "top": 44
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionoutput1": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output1"
+                            },
+                            "HideDatasetActionoutput2": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output2"
+                            },
+                            "HideDatasetActionreport": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "report"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2022+galaxy0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "070e3ecc3fda",
+                            "name": "gmx_setup",
+                            "owner": "chemteam",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"capture_log\": \"true\", \"ff\": {\"__class__\": \"ConnectedValue\"}, \"ignore_h\": \"false\", \"pdb_input\": {\"__class__\": \"ConnectedValue\"}, \"water\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "2022+galaxy0",
+                        "type": "tool",
+                        "uuid": "b922c050-5df2-42b8-a819-1cbf892e06fa",
+                        "workflow_outputs": [
+                            {
+                                "label": "Position restraints file",
+                                "output_name": "output3",
+                                "uuid": "a8969ed8-83f9-4ff3-9634-56f85e7dd4dd"
+                            }
+                        ]
+                    },
                     "8": {
                         "annotation": "",
                         "content_id": "Cut1",
@@ -803,7 +678,7 @@
                         "id": 8,
                         "input_connections": {
                             "input": {
-                                "id": 6,
+                                "id": 5,
                                 "output_name": "outfile"
                             }
                         },
@@ -817,14 +692,8 @@
                             }
                         ],
                         "position": {
-                            "bottom": 658.1999969482422,
-                            "height": 93.19999694824219,
-                            "left": -135,
-                            "right": 65,
-                            "top": 565,
-                            "width": 200,
-                            "x": -135,
-                            "y": 565
+                            "left": 556,
+                            "top": 445
                         },
                         "post_job_actions": {
                             "HideDatasetActionout_file1": {
@@ -847,7 +716,7 @@
                         "id": 9,
                         "input_connections": {
                             "infile": {
-                                "id": 7,
+                                "id": 6,
                                 "output_name": "outfile"
                             }
                         },
@@ -861,14 +730,8 @@
                             }
                         ],
                         "position": {
-                            "bottom": 884.6000061035156,
-                            "height": 113.60000610351562,
-                            "left": -135,
-                            "right": 65,
-                            "top": 771,
-                            "width": 200,
-                            "x": -135,
-                            "y": 771
+                            "left": 556,
+                            "top": 651
                         },
                         "post_job_actions": {
                             "HideDatasetActionoutput": {
@@ -879,7 +742,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/1.1.1",
                         "tool_shed_repository": {
-                            "changeset_revision": "ddf54b12c295",
+                            "changeset_revision": "d698c222f354",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -911,14 +774,8 @@
                             }
                         ],
                         "position": {
-                            "bottom": 689.3999938964844,
-                            "height": 154.39999389648438,
-                            "left": 143,
-                            "right": 343,
-                            "top": 535,
-                            "width": 200,
-                            "x": 143,
-                            "y": 535
+                            "left": 834,
+                            "top": 415
                         },
                         "post_job_actions": {
                             "HideDatasetActioninteger_param": {
@@ -959,14 +816,8 @@
                             }
                         ],
                         "position": {
-                            "bottom": 844.8000030517578,
-                            "height": 184.8000030517578,
-                            "left": 421,
-                            "right": 621,
-                            "top": 660,
-                            "width": 200,
-                            "x": 421,
-                            "y": 660
+                            "left": 1112,
+                            "top": 540
                         },
                         "post_job_actions": {
                             "HideDatasetActionoutput1": {
@@ -977,7 +828,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/ambertools_antechamber/ambertools_antechamber/21.10+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "4fff93efc0f9",
+                            "changeset_revision": "8a839e6a1e3e",
                             "name": "ambertools_antechamber",
                             "owner": "chemteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1017,14 +868,8 @@
                             }
                         ],
                         "position": {
-                            "bottom": 758.1999969482422,
-                            "height": 215.1999969482422,
-                            "left": 699,
-                            "right": 899,
-                            "top": 543,
-                            "width": 200,
-                            "x": 699,
-                            "y": 543
+                            "left": 1390,
+                            "top": 423
                         },
                         "post_job_actions": {
                             "HideDatasetActiongro_output": {
@@ -1040,7 +885,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/ambertools_acpype/ambertools_acpype/21.10+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "a0c154146234",
+                            "changeset_revision": "095ad4d096d1",
                             "name": "ambertools_acpype",
                             "owner": "chemteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1066,11 +911,11 @@
                                 "output_name": "output"
                             },
                             "prot_gro": {
-                                "id": 5,
+                                "id": 7,
                                 "output_name": "output2"
                             },
                             "prot_top": {
-                                "id": 5,
+                                "id": 7,
                                 "output_name": "output1"
                             }
                         },
@@ -1088,19 +933,13 @@
                             }
                         ],
                         "position": {
-                            "bottom": 578.6000061035156,
-                            "height": 255.60000610351562,
-                            "left": 987,
-                            "right": 1187,
-                            "top": 323,
-                            "width": 200,
-                            "x": 987,
-                            "y": 323
+                            "left": 1678,
+                            "top": 203
                         },
                         "post_job_actions": {},
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_merge_topology_files/gmx_merge_topology_files/3.4.3+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "534ff13ea227",
+                            "changeset_revision": "bc31d02be922",
                             "name": "gmx_merge_topology_files",
                             "owner": "chemteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1124,9 +963,9 @@
                     }
                 },
                 "tags": "",
-                "uuid": "6851c802-a9bb-4bee-a762-190ea80f48d2"
+                "uuid": "1ec0445a-31c4-4113-aeee-b52b819b38c2"
             },
-            "tool_id": "d354bc62a13564f8",
+            "tool_id": 3,
             "type": "subworkflow",
             "uuid": "fe2677ce-d0d4-4937-9d34-f9a35db814d8",
             "workflow_outputs": [
@@ -1158,7 +997,7 @@
                     "output_name": "out1"
                 },
                 "token_set_0|repeat_select|times": {
-                    "id": 0,
+                    "id": 1,
                     "output_name": "output"
                 }
             },
@@ -1172,14 +1011,8 @@
                 }
             ],
             "position": {
-                "bottom": 203.3000030517578,
-                "height": 184.8000030517578,
-                "left": 279,
-                "right": 479,
-                "top": 18.5,
-                "width": 200,
-                "x": 279,
-                "y": 18.5
+                "left": 556,
+                "top": 0.0
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -1190,7 +1023,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_text_file_with_recurring_lines/1.1.0",
             "tool_shed_repository": {
-                "changeset_revision": "ddf54b12c295",
+                "changeset_revision": "d698c222f354",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1203,7 +1036,7 @@
         },
         "13": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_editconf/gmx_editconf/2021.3+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_editconf/gmx_editconf/2022+galaxy0",
             "errors": null,
             "id": 13,
             "input_connections": {
@@ -1222,14 +1055,8 @@
                 }
             ],
             "position": {
-                "bottom": 537.1000061035156,
-                "height": 113.60000610351562,
-                "left": 875,
-                "right": 1075,
-                "top": 423.5,
-                "width": 200,
-                "x": 875,
-                "y": 423.5
+                "left": 1152,
+                "top": 405.0
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1238,15 +1065,15 @@
                     "output_name": "output"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_editconf/gmx_editconf/2021.3+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_editconf/gmx_editconf/2022+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "8be9cb12a4fa",
+                "changeset_revision": "88076940fa94",
                 "name": "gmx_editconf",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"box\": {\"config\": \"true\", \"__current_case__\": 0, \"dim\": \"1.0\", \"type\": \"triclinic\"}, \"capture_log\": \"false\", \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"gro\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2021.3+galaxy0",
+            "tool_version": "2022+galaxy0",
             "type": "tool",
             "uuid": "08354f00-bea9-4f56-94cd-35b50dcf57c1",
             "workflow_outputs": []
@@ -1272,14 +1099,8 @@
                 }
             ],
             "position": {
-                "bottom": 168.10000610351562,
-                "height": 113.60000610351562,
-                "left": 597,
-                "right": 797,
-                "top": 54.5,
-                "width": 200,
-                "x": 597,
-                "y": 54.5
+                "left": 874,
+                "top": 36.0
             },
             "post_job_actions": {
                 "HideDatasetActionlist_output_txt": {
@@ -1322,14 +1143,8 @@
                 }
             ],
             "position": {
-                "bottom": 188.89999389648438,
-                "height": 154.39999389648438,
-                "left": 875,
-                "right": 1075,
-                "top": 34.5,
-                "width": 200,
-                "x": 875,
-                "y": 34.5
+                "left": 1152,
+                "top": 16.0
             },
             "post_job_actions": {
                 "HideDatasetActionfloat_param": {
@@ -1347,7 +1162,7 @@
         },
         "16": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2021.3+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2022+galaxy0",
             "errors": null,
             "id": 16,
             "input_connections": {
@@ -1378,14 +1193,8 @@
                 }
             ],
             "position": {
-                "bottom": 361.70001220703125,
-                "height": 327.20001220703125,
-                "left": 1163,
-                "right": 1363,
-                "top": 34.5,
-                "width": 200,
-                "x": 1163,
-                "y": 34.5
+                "left": 1440,
+                "top": 16.0
             },
             "post_job_actions": {
                 "HideDatasetActionoutput1": {
@@ -1399,22 +1208,22 @@
                     "output_name": "output2"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2021.3+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2022+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "61094e01eff9",
+                "changeset_revision": "c4fbab8e03c5",
                 "name": "gmx_solvate",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"capture_log\": \"false\", \"conc\": {\"__class__\": \"ConnectedValue\"}, \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"neutralise\": \"-neutral\", \"seed\": \"1\", \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"water_model\": \"spc216\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2021.3+galaxy1",
+            "tool_state": "{\"capture_log\": \"false\", \"conc\": {\"__class__\": \"ConnectedValue\"}, \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"mxw\": \"0\", \"neutralise\": \"-neutral\", \"seed\": \"1\", \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"water_model\": \"spc216\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2022+galaxy0",
             "type": "tool",
             "uuid": "565a9285-ba79-40c5-86ec-1dbdd9a9de17",
             "workflow_outputs": []
         },
         "17": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_em/gmx_em/2021.3+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_em/gmx_em/2022+galaxy0",
             "errors": null,
             "id": 17,
             "input_connections": {
@@ -1445,14 +1254,8 @@
                 }
             ],
             "position": {
-                "bottom": 478.29998779296875,
-                "height": 306.79998779296875,
-                "left": 1451,
-                "right": 1651,
-                "top": 171.5,
-                "width": 200,
-                "x": 1451,
-                "y": 171.5
+                "left": 1728,
+                "top": 153.0
             },
             "post_job_actions": {
                 "HideDatasetActionoutput1": {
@@ -1471,15 +1274,15 @@
                     "output_name": "report"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_em/gmx_em/2021.3+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_em/gmx_em/2022+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "59c662ca4211",
+                "changeset_revision": "b46d4b4d995c",
                 "name": "gmx_em",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"steep\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": \"50000\", \"emtol\": \"1000.0\", \"emstep\": \"0.01\", \"seed\": \"1\"}, \"mxw\": \"0\", \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2021.3+galaxy1",
+            "tool_version": "2022+galaxy0",
             "type": "tool",
             "uuid": "7c542061-2478-43a3-a3a3-795b20e96b31",
             "workflow_outputs": []
@@ -1521,14 +1324,8 @@
                 }
             ],
             "position": {
-                "bottom": 314.1000061035156,
-                "height": 255.60000610351562,
-                "left": 2643,
-                "right": 2843,
-                "top": 58.5,
-                "width": 200,
-                "x": 2643,
-                "y": 58.5
+                "left": 2920,
+                "top": 40.0
             },
             "post_job_actions": {
                 "HideDatasetActionprmtop_complex": {
@@ -1554,7 +1351,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/parmconv/parmconv/21.10+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "5a97cb53a456",
+                "changeset_revision": "6d0677a148fe",
                 "name": "parmconv",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1567,7 +1364,7 @@
         },
         "19": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2022+galaxy0",
             "errors": null,
             "id": 19,
             "input_connections": {
@@ -1619,14 +1416,8 @@
                 }
             ],
             "position": {
-                "bottom": 691.5,
-                "height": 520,
-                "left": 1759,
-                "right": 1959,
-                "top": 171.5,
-                "width": 200,
-                "x": 1759,
-                "y": 171.5
+                "left": 2036,
+                "top": 153.0
             },
             "post_job_actions": {
                 "HideDatasetActionoutput1": {
@@ -1650,22 +1441,22 @@
                     "output_name": "report"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2022+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "525ca7c8065f",
+                "changeset_revision": "c0c9a5024177",
                 "name": "gmx_sim",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"yes\", \"__current_case__\": 1, \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"RuntimeValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"true\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"false\"}, \"sets\": {\"ensemble\": \"nvt\", \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"h-bonds\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2021.3+galaxy2",
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 1, \"__job_resource__select\": \"yes\", \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"RuntimeValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"true\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"false\"}, \"sets\": {\"ensembleselect\": {\"ensemble\": \"nvt\", \"__current_case__\": 0, \"startvel\": \"false\"}, \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"h-bonds\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"systemTcouple\": \"false\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2022+galaxy0",
             "type": "tool",
             "uuid": "a926430a-b1e4-4e09-861f-ba7005f89e6c",
             "workflow_outputs": []
         },
         "20": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2022+galaxy0",
             "errors": null,
             "id": 20,
             "input_connections": {
@@ -1717,14 +1508,8 @@
                 }
             ],
             "position": {
-                "bottom": 691.5,
-                "height": 520,
-                "left": 2067,
-                "right": 2267,
-                "top": 171.5,
-                "width": 200,
-                "x": 2067,
-                "y": 171.5
+                "left": 2344,
+                "top": 153.0
             },
             "post_job_actions": {
                 "HideDatasetActionoutput1": {
@@ -1748,22 +1533,22 @@
                     "output_name": "report"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2022+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "525ca7c8065f",
+                "changeset_revision": "c0c9a5024177",
                 "name": "gmx_sim",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"yes\", \"__current_case__\": 1, \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"ConnectedValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"true\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"false\"}, \"sets\": {\"ensemble\": \"npt\", \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"h-bonds\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2021.3+galaxy2",
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 1, \"__job_resource__select\": \"yes\", \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"ConnectedValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"true\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"false\"}, \"sets\": {\"ensembleselect\": {\"ensemble\": \"nvt\", \"__current_case__\": 0, \"startvel\": \"false\"}, \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"h-bonds\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"systemTcouple\": \"false\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2022+galaxy0",
             "type": "tool",
             "uuid": "fe91fab0-9a55-4480-9618-43a3e0195500",
             "workflow_outputs": []
         },
         "21": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2022+galaxy0",
             "errors": null,
             "id": 21,
             "input_connections": {
@@ -1811,14 +1596,8 @@
                 }
             ],
             "position": {
-                "bottom": 618.1000061035156,
-                "height": 397.6000061035156,
-                "left": 2365,
-                "right": 2565,
-                "top": 220.5,
-                "width": 200,
-                "x": 2365,
-                "y": 220.5
+                "left": 2642,
+                "top": 202.0
             },
             "post_job_actions": {
                 "HideDatasetActionoutput8": {
@@ -1832,15 +1611,15 @@
                     "output_name": "report"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2022+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "525ca7c8065f",
+                "changeset_revision": "c0c9a5024177",
                 "name": "gmx_sim",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"yes\", \"__current_case__\": 1, \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"ConnectedValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"false\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"true\"}, \"sets\": {\"ensemble\": \"nvt\", \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"none\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2021.3+galaxy2",
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 1, \"__job_resource__select\": \"yes\", \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"ConnectedValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"false\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"true\"}, \"sets\": {\"ensembleselect\": {\"ensemble\": \"nvt\", \"__current_case__\": 0, \"startvel\": \"false\"}, \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"none\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"systemTcouple\": \"false\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2022+galaxy0",
             "type": "tool",
             "uuid": "7750144f-b8a9-4543-a13c-68bca8772d8f",
             "workflow_outputs": [
@@ -1877,14 +1656,8 @@
                 }
             ],
             "position": {
-                "bottom": 486.5,
-                "height": 134,
-                "left": 2643,
-                "right": 2843,
-                "top": 352.5,
-                "width": 200,
-                "x": 2643,
-                "y": 352.5
+                "left": 2920,
+                "top": 334.0
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1951,14 +1724,8 @@
                 }
             ],
             "position": {
-                "bottom": 493.29998779296875,
-                "height": 438.79998779296875,
-                "left": 2921,
-                "right": 3121,
-                "top": 54.5,
-                "width": 200,
-                "x": 2921,
-                "y": 54.5
+                "left": 3198,
+                "top": 36.0
             },
             "post_job_actions": {
                 "HideDatasetActionparameteroutfile": {
@@ -1981,7 +1748,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/mmpbsa_mmgbsa/mmpbsa_mmgbsa/21.10+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "45dc2555933c",
+                "changeset_revision": "608098b3668d",
                 "name": "mmpbsa_mmgbsa",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2019,14 +1786,8 @@
                 }
             ],
             "position": {
-                "bottom": 331.1000061035156,
-                "height": 113.60000610351562,
-                "left": 3199,
-                "right": 3399,
-                "top": 217.5,
-                "width": 200,
-                "x": 3199,
-                "y": 217.5
+                "left": 3476,
+                "top": 199.0
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -2037,7 +1798,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/1.1.1",
             "tool_shed_repository": {
-                "changeset_revision": "ddf54b12c295",
+                "changeset_revision": "d698c222f354",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2050,7 +1811,7 @@
         },
         "25": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/4.2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
             "errors": null,
             "id": 25,
             "input_connections": {
@@ -2069,14 +1830,8 @@
                 }
             ],
             "position": {
-                "bottom": 341.5,
-                "height": 134,
-                "left": 3477,
-                "right": 3677,
-                "top": 207.5,
-                "width": 200,
-                "x": 3477,
-                "y": 207.5
+                "left": 3754,
+                "top": 189.0
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -2085,15 +1840,15 @@
                     "output_name": "output"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/4.2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
             "tool_shed_repository": {
-                "changeset_revision": "830961c48e42",
+                "changeset_revision": "90981f86000f",
                 "name": "collapse_collections",
                 "owner": "nml",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"filename\": {\"add_name\": \"false\", \"__current_case__\": 1}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "4.2",
+            "tool_version": "5.1.0",
             "type": "tool",
             "uuid": "dbf60354-8c38-4735-9dd0-44d776906e02",
             "workflow_outputs": []
@@ -2119,14 +1874,8 @@
                 }
             ],
             "position": {
-                "bottom": 320.6999969482422,
-                "height": 93.19999694824219,
-                "left": 3755,
-                "right": 3955,
-                "top": 227.5,
-                "width": 200,
-                "x": 3755,
-                "y": 227.5
+                "left": 4032,
+                "top": 209.0
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -2163,14 +1912,8 @@
                 }
             ],
             "position": {
-                "bottom": 366.5,
-                "height": 134,
-                "left": 4033,
-                "right": 4233,
-                "top": 232.5,
-                "width": 200,
-                "x": 4033,
-                "y": 232.5
+                "left": 4310,
+                "top": 214.0
             },
             "post_job_actions": {},
             "tool_id": "Summary_Statistics1",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.12",
+    "release": "0.1.13",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -963,7 +963,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "aac09500-0c2b-41f6-9524-c31b3521b103"
+                "uuid": "e7cac9ad-5240-4b3b-b1ca-80a83b8e1d58"
             },
             "tool_id": 3,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.21",
+    "release": "0.1.22",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -988,7 +988,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "c5dd1376-d879-44a2-8c22-412ea59a3745"
+                "uuid": "f8b9d2ca-7ec5-43d8-9b76-45aeac44fc8c"
             },
             "tool_id": null,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.18",
+    "release": "0.1.19",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -988,7 +988,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "bc1c40d3-6be9-453f-a319-f7f4a729d872"
+                "uuid": "1c9aebe0-d8fd-4eaa-91ff-f2a8619dc3d6"
             },
             "tool_id": null,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.4",
+    "release": "0.1.5",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -963,7 +963,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "1ec0445a-31c4-4113-aeee-b52b819b38c2"
+                "uuid": "13a1b124-c96e-48cb-9824-b443bab95070"
             },
             "tool_id": 3,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.15",
+    "release": "0.1.16",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -37,6 +37,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "be1f6375-076e-4d61-a780-f867af394809",
+            "when": null,
             "workflow_outputs": []
         },
         "1": {
@@ -63,6 +64,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "0b26a4eb-6715-4e56-b8c4-1796486f91c5",
+            "when": null,
             "workflow_outputs": []
         },
         "2": {
@@ -89,6 +91,7 @@
             "tool_version": null,
             "type": "data_input",
             "uuid": "808dce0b-2da4-4cad-865e-5f264164b9a5",
+            "when": null,
             "workflow_outputs": []
         },
         "3": {
@@ -115,6 +118,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "c556adbf-d074-4467-95dc-1c1966c5cff2",
+            "when": null,
             "workflow_outputs": []
         },
         "4": {
@@ -141,6 +145,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "a7af9e2f-f236-4ed4-b4e6-472d8542d8b5",
+            "when": null,
             "workflow_outputs": []
         },
         "5": {
@@ -167,6 +172,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "8c2f5860-bd30-4351-8bfb-1f9c42a92c4b",
+            "when": null,
             "workflow_outputs": []
         },
         "6": {
@@ -193,6 +199,7 @@
             "tool_version": null,
             "type": "data_input",
             "uuid": "6c2e18cb-d616-43b3-b655-ff9d6dfc3ac9",
+            "when": null,
             "workflow_outputs": []
         },
         "7": {
@@ -219,6 +226,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "d752a5f0-f16e-4b63-9d2b-139392376e77",
+            "when": null,
             "workflow_outputs": []
         },
         "8": {
@@ -245,6 +253,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "466e4cd0-4bf7-4238-ac5d-dc0d803557a1",
+            "when": null,
             "workflow_outputs": []
         },
         "9": {
@@ -271,6 +280,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "3661db6a-9afa-42d7-8dcd-c43e9cf320ea",
+            "when": null,
             "workflow_outputs": []
         },
         "10": {
@@ -315,6 +325,7 @@
             "tool_version": "0.1.1",
             "type": "tool",
             "uuid": "5ad64e44-e40e-4848-a8b3-cddd18fb0fc1",
+            "when": null,
             "workflow_outputs": []
         },
         "11": {
@@ -393,6 +404,7 @@
                         "tool_version": null,
                         "type": "data_input",
                         "uuid": "277627e0-eba8-4de5-855b-63711c0db691",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "1": {
@@ -419,6 +431,7 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "6893b667-f375-481b-96eb-50d5aceb5030",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "2": {
@@ -445,6 +458,7 @@
                         "tool_version": null,
                         "type": "data_input",
                         "uuid": "68f60b7d-13f3-4b21-aedf-986f0f7e48d7",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "3": {
@@ -471,6 +485,7 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "8d29ae78-60de-45ba-b403-cdd2646af030",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "4": {
@@ -497,6 +512,7 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "16c399b1-e67c-47a9-acd3-61ddc39473d9",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "5": {
@@ -537,10 +553,11 @@
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"header\": \"false\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"select_multiple\": [\"FormalCharge\"], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_state": "{\"header\": false, \"infile\": {\"__class__\": \"ConnectedValue\"}, \"select_multiple\": [\"FormalCharge\"], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
                         "tool_version": "2020.03.4+galaxy1",
                         "type": "tool",
                         "uuid": "351397ff-a72d-4c7d-b39a-bc97b8f2c357",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "6": {
@@ -585,10 +602,11 @@
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"appendtotitle\": \"\", \"dative_bonds\": \"false\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"oformat\": {\"oformat_opts_selector\": \"pdb\", \"__current_case__\": 51}, \"ph\": {\"__class__\": \"ConnectedValue\"}, \"remove_h\": \"false\", \"split\": \"false\", \"unique\": {\"unique_opts_selector\": \"\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_state": "{\"appendtotitle\": \"\", \"dative_bonds\": false, \"infile\": {\"__class__\": \"ConnectedValue\"}, \"oformat\": {\"oformat_opts_selector\": \"pdb\", \"__current_case__\": 51}, \"ph\": {\"__class__\": \"ConnectedValue\"}, \"remove_h\": false, \"split\": false, \"unique\": {\"unique_opts_selector\": \"\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
                         "tool_version": "3.1.1+galaxy0",
                         "type": "tool",
                         "uuid": "c1f8c291-3b11-4afa-b62d-ee2d2d22b11f",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "7": {
@@ -659,10 +677,11 @@
                             "owner": "chemteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"capture_log\": \"true\", \"ff\": {\"__class__\": \"ConnectedValue\"}, \"ignore_h\": \"false\", \"pdb_input\": {\"__class__\": \"ConnectedValue\"}, \"water\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_state": "{\"capture_log\": true, \"ff\": {\"__class__\": \"ConnectedValue\"}, \"ignore_h\": false, \"pdb_input\": {\"__class__\": \"ConnectedValue\"}, \"water\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
                         "tool_version": "2022+galaxy0",
                         "type": "tool",
                         "uuid": "b922c050-5df2-42b8-a819-1cbf892e06fa",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": "Position restraints file",
@@ -707,6 +726,7 @@
                         "tool_version": "1.0.2",
                         "type": "tool",
                         "uuid": "fd7483c3-52b0-489f-a422-2d399e2cd4e5",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "9": {
@@ -751,6 +771,7 @@
                         "tool_version": "1.1.1",
                         "type": "tool",
                         "uuid": "be1e9539-c3ba-4c3c-a06f-a82c5b4d8437",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "10": {
@@ -785,10 +806,11 @@
                             }
                         },
                         "tool_id": "param_value_from_file",
-                        "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"integer\", \"remove_newlines\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"integer\", \"remove_newlines\": true, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
                         "tool_version": "0.1.0",
                         "type": "tool",
                         "uuid": "50d4ab40-a78d-4d97-8740-7e00edacae6b",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "11": {
@@ -833,10 +855,11 @@
                             "owner": "chemteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"allparams\": {\"nc\": {\"__class__\": \"ConnectedValue\"}, \"m\": \"1\", \"resname\": \"UNL\", \"c\": \"bcc\", \"at\": \"gaff\", \"j\": \"4\"}, \"extraparams\": {\"pf\": \"true\", \"usenc\": \"true\"}, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"selected_output_format\": \"mol2\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_state": "{\"allparams\": {\"nc\": {\"__class__\": \"ConnectedValue\"}, \"m\": \"1\", \"resname\": \"UNL\", \"c\": \"bcc\", \"at\": \"gaff\", \"j\": \"4\"}, \"extraparams\": {\"pf\": true, \"usenc\": true}, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"selected_output_format\": \"mol2\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
                         "tool_version": "21.10+galaxy0",
                         "type": "tool",
                         "uuid": "32a50a09-a9c7-4d08-9d7f-7d5c9efaa3bf",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "12": {
@@ -890,10 +913,11 @@
                             "owner": "chemteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"atomtype\": \"gaff\", \"charge\": {\"__class__\": \"ConnectedValue\"}, \"charge_method\": \"user\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"multiplicity\": \"1\", \"save_gro\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_state": "{\"atomtype\": \"gaff\", \"charge\": {\"__class__\": \"ConnectedValue\"}, \"charge_method\": \"user\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"multiplicity\": \"1\", \"save_gro\": true, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
                         "tool_version": "21.10+galaxy0",
                         "type": "tool",
                         "uuid": "3ee8d6ce-e7bc-45c5-ae34-ac0348ac959f",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "13": {
@@ -948,6 +972,7 @@
                         "tool_version": "3.4.3+galaxy0",
                         "type": "tool",
                         "uuid": "2a22a7fd-3e14-4f27-b1a8-a6d66cef292a",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": "Complex topology",
@@ -963,11 +988,12 @@
                     }
                 },
                 "tags": "",
-                "uuid": "48fc9274-3a1b-45a1-8609-0adf4759d833"
+                "uuid": "27f6c049-99ca-448f-bcae-caae80d66947"
             },
             "tool_id": null,
             "type": "subworkflow",
             "uuid": "fe2677ce-d0d4-4937-9d34-f9a35db814d8",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "Complex topology",
@@ -1032,6 +1058,7 @@
             "tool_version": "1.1.0",
             "type": "tool",
             "uuid": "712bd247-7a81-4e77-ab1c-ba0e3f012d20",
+            "when": null,
             "workflow_outputs": []
         },
         "13": {
@@ -1072,10 +1099,11 @@
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"box\": {\"config\": \"true\", \"__current_case__\": 0, \"dim\": \"1.0\", \"type\": \"triclinic\"}, \"capture_log\": \"false\", \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"gro\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"box\": {\"config\": \"true\", \"__current_case__\": 0, \"dim\": \"1.0\", \"type\": \"triclinic\"}, \"capture_log\": false, \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_format\": \"gro\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2022+galaxy0",
             "type": "tool",
             "uuid": "08354f00-bea9-4f56-94cd-35b50dcf57c1",
+            "when": null,
             "workflow_outputs": []
         },
         "14": {
@@ -1120,6 +1148,7 @@
             "tool_version": "0.5.0",
             "type": "tool",
             "uuid": "06f666f0-c2a8-4f18-9ad6-42b0e601c731",
+            "when": null,
             "workflow_outputs": []
         },
         "15": {
@@ -1154,10 +1183,11 @@
                 }
             },
             "tool_id": "param_value_from_file",
-            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"float\", \"remove_newlines\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"float\", \"remove_newlines\": true, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.1.0",
             "type": "tool",
             "uuid": "ad421d25-27f7-445c-aa4f-6b131bdfad6b",
+            "when": null,
             "workflow_outputs": []
         },
         "16": {
@@ -1215,10 +1245,11 @@
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"capture_log\": \"false\", \"conc\": {\"__class__\": \"ConnectedValue\"}, \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"mxw\": \"0\", \"neutralise\": \"-neutral\", \"seed\": \"1\", \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"water_model\": \"spc216\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"capture_log\": false, \"conc\": {\"__class__\": \"ConnectedValue\"}, \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"mxw\": \"0\", \"neutralise\": \"-neutral\", \"seed\": \"1\", \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"water_model\": \"spc216\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2022+galaxy0",
             "type": "tool",
             "uuid": "565a9285-ba79-40c5-86ec-1dbdd9a9de17",
+            "when": null,
             "workflow_outputs": []
         },
         "17": {
@@ -1281,10 +1312,11 @@
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"steep\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": \"50000\", \"emtol\": \"1000.0\", \"emstep\": \"0.01\", \"seed\": \"1\"}, \"mxw\": \"0\", \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"capture_log\": true, \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"steep\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": \"50000\", \"emtol\": \"1000.0\", \"emstep\": \"0.01\", \"seed\": \"1\"}, \"mxw\": \"0\", \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2022+galaxy0",
             "type": "tool",
             "uuid": "7c542061-2478-43a3-a3a3-795b20e96b31",
+            "when": null,
             "workflow_outputs": []
         },
         "18": {
@@ -1356,10 +1388,11 @@
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"param_inputs\": {\"fmt\": \"GROMACS\", \"__current_case__\": 1, \"top_in\": {\"__class__\": \"ConnectedValue\"}, \"str_in\": {\"__class__\": \"ConnectedValue\"}, \"modbehaviour\": {\"removedihe\": \"true\", \"removebox\": \"true\", \"radii\": \"mbondi\"}}, \"stripmask_complex\": \":NA,CL,SOL\", \"stripmask_ligand\": \"!:UNL\", \"stripmask_receptor\": \":NA,CL,SOL,UNL\", \"stripmask_solvatedcomplex\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"param_inputs\": {\"fmt\": \"GROMACS\", \"__current_case__\": 1, \"top_in\": {\"__class__\": \"ConnectedValue\"}, \"str_in\": {\"__class__\": \"ConnectedValue\"}, \"modbehaviour\": {\"removedihe\": true, \"removebox\": true, \"radii\": \"mbondi\"}}, \"stripmask_complex\": \":NA,CL,SOL\", \"stripmask_ligand\": \"!:UNL\", \"stripmask_receptor\": \":NA,CL,SOL,UNL\", \"stripmask_solvatedcomplex\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "21.10+galaxy0",
             "type": "tool",
             "uuid": "9266a7e8-9fad-4d2e-aaf9-1be038313349",
+            "when": null,
             "workflow_outputs": []
         },
         "19": {
@@ -1448,10 +1481,11 @@
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 1, \"__job_resource__select\": \"yes\", \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"RuntimeValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"true\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"false\"}, \"sets\": {\"ensembleselect\": {\"ensemble\": \"nvt\", \"__current_case__\": 0, \"startvel\": \"false\"}, \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"h-bonds\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"systemTcouple\": \"false\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 1, \"__job_resource__select\": \"yes\", \"gpu\": \"1\"}, \"capture_log\": true, \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"RuntimeValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"true\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"false\"}, \"sets\": {\"ensembleselect\": {\"ensemble\": \"nvt\", \"__current_case__\": 0, \"startvel\": \"false\"}, \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"h-bonds\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"systemTcouple\": \"false\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2022+galaxy0",
             "type": "tool",
             "uuid": "a926430a-b1e4-4e09-861f-ba7005f89e6c",
+            "when": null,
             "workflow_outputs": []
         },
         "20": {
@@ -1540,10 +1574,11 @@
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 1, \"__job_resource__select\": \"yes\", \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"ConnectedValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"true\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"false\"}, \"sets\": {\"ensembleselect\": {\"ensemble\": \"nvt\", \"__current_case__\": 0, \"startvel\": \"false\"}, \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"h-bonds\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"systemTcouple\": \"false\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 1, \"__job_resource__select\": \"yes\", \"gpu\": \"1\"}, \"capture_log\": true, \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"ConnectedValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"true\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"false\"}, \"sets\": {\"ensembleselect\": {\"ensemble\": \"nvt\", \"__current_case__\": 0, \"startvel\": \"false\"}, \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"h-bonds\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"systemTcouple\": \"false\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2022+galaxy0",
             "type": "tool",
             "uuid": "fe91fab0-9a55-4480-9618-43a3e0195500",
+            "when": null,
             "workflow_outputs": []
         },
         "21": {
@@ -1618,10 +1653,11 @@
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 1, \"__job_resource__select\": \"yes\", \"gpu\": \"1\"}, \"capture_log\": \"true\", \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"ConnectedValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"false\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"true\"}, \"sets\": {\"ensembleselect\": {\"ensemble\": \"nvt\", \"__current_case__\": 0, \"startvel\": \"false\"}, \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"none\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"systemTcouple\": \"false\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 1, \"__job_resource__select\": \"yes\", \"gpu\": \"1\"}, \"capture_log\": true, \"gro_input\": {\"__class__\": \"ConnectedValue\"}, \"inps\": {\"cpt_in\": {\"__class__\": \"ConnectedValue\"}, \"itp_in\": {\"__class__\": \"ConnectedValue\"}, \"ndx_in\": {\"__class__\": \"RuntimeValue\"}}, \"mxw\": \"0\", \"outps\": {\"traj\": \"xtc\", \"str\": \"gro\", \"cpt_out\": \"false\", \"edr_out\": \"false\", \"xvg_out\": \"false\", \"tpr_out\": \"true\"}, \"sets\": {\"ensembleselect\": {\"ensemble\": \"nvt\", \"__current_case__\": 0, \"startvel\": \"false\"}, \"mdp\": {\"mdpfile\": \"default\", \"__current_case__\": 1, \"integrator\": \"md\", \"constraints\": \"none\", \"cutoffscheme\": \"Verlet\", \"coulombtype\": \"PME\", \"temperature\": \"300\", \"systemTcouple\": \"false\", \"step_length\": \"0.001\", \"write_freq\": \"1000\", \"rcoulomb\": \"1.0\", \"rlist\": \"1.0\", \"rvdw\": \"1.0\", \"md_steps\": {\"__class__\": \"ConnectedValue\"}}}, \"top_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2022+galaxy0",
             "type": "tool",
             "uuid": "7750144f-b8a9-4543-a13c-68bca8772d8f",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "GRO files",
@@ -1677,6 +1713,7 @@
             "tool_version": "1.9.6+galaxy0",
             "type": "tool",
             "uuid": "d98fcd50-1530-4899-820e-ff08b8dde0ae",
+            "when": null,
             "workflow_outputs": []
         },
         "23": {
@@ -1753,10 +1790,11 @@
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"allparams\": {\"startframe\": \"1\", \"endframe\": \"9999999\", \"interval\": \"10\", \"entropy\": \"false\", \"use_sander\": \"false\", \"keep_files\": \"true\", \"strip_mask\": \":NA,CL,SOL\"}, \"calcdetails\": {\"gb_pb_calc\": {\"calctype\": \"gb\", \"__current_case__\": 0, \"igb\": \"5\", \"saltcon\": \"0.1\", \"surfoff\": \"0.0\", \"molsurf\": \"false\", \"probe\": \"1.4\", \"msoffset\": \"0.0\"}, \"decomposition\": {\"decomposition\": \"no\", \"__current_case__\": 1}}, \"input\": {\"simulation\": {\"simtype\": \"single\", \"__current_case__\": 0, \"ligand\": {\"__class__\": \"ConnectedValue\"}, \"receptor\": {\"__class__\": \"ConnectedValue\"}, \"complex\": {\"__class__\": \"ConnectedValue\"}, \"solvatedcomplex\": {\"__class__\": \"ConnectedValue\"}, \"trajcomplex\": {\"__class__\": \"ConnectedValue\"}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"allparams\": {\"startframe\": \"1\", \"endframe\": \"9999999\", \"interval\": \"10\", \"entropy\": false, \"use_sander\": false, \"keep_files\": true, \"strip_mask\": \":NA,CL,SOL\"}, \"calcdetails\": {\"gb_pb_calc\": {\"calctype\": \"gb\", \"__current_case__\": 0, \"igb\": \"5\", \"saltcon\": \"0.1\", \"surfoff\": \"0.0\", \"molsurf\": false, \"probe\": \"1.4\", \"msoffset\": \"0.0\"}, \"decomposition\": {\"decomposition\": \"no\", \"__current_case__\": 1}}, \"input\": {\"simulation\": {\"simtype\": \"single\", \"__current_case__\": 0, \"ligand\": {\"__class__\": \"ConnectedValue\"}, \"receptor\": {\"__class__\": \"ConnectedValue\"}, \"complex\": {\"__class__\": \"ConnectedValue\"}, \"solvatedcomplex\": {\"__class__\": \"ConnectedValue\"}, \"trajcomplex\": {\"__class__\": \"ConnectedValue\"}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "21.10+galaxy0",
             "type": "tool",
             "uuid": "0351786b-5169-450f-8d5f-194dce5e4b77",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "MMGBSA statistics",
@@ -1807,6 +1845,7 @@
             "tool_version": "1.1.1",
             "type": "tool",
             "uuid": "3aba0217-8162-43c3-8d19-1b04dcb3984d",
+            "when": null,
             "workflow_outputs": []
         },
         "25": {
@@ -1847,10 +1886,11 @@
                 "owner": "nml",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filename\": {\"add_name\": \"false\", \"__current_case__\": 1}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"filename\": {\"add_name\": false, \"__current_case__\": 1}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "5.1.0",
             "type": "tool",
             "uuid": "dbf60354-8c38-4735-9dd0-44d776906e02",
+            "when": null,
             "workflow_outputs": []
         },
         "26": {
@@ -1889,6 +1929,7 @@
             "tool_version": "1.0.2",
             "type": "tool",
             "uuid": "073ece68-67cb-497e-bf81-df302004f043",
+            "when": null,
             "workflow_outputs": []
         },
         "27": {
@@ -1921,6 +1962,7 @@
             "tool_version": "1.1.2",
             "type": "tool",
             "uuid": "f5812d99-5d61-40c0-af3a-5f1eb307c755",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "MMGBSA free energy",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.25",
+    "release": "0.1.26",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -988,7 +988,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "78efacb5-f18b-408d-b6a3-629128597172"
+                "uuid": "5e8cf367-fca9-46ad-95e5-a93a817cc863"
             },
             "tool_id": null,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.19",
+    "release": "0.1.20",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -988,7 +988,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "1c9aebe0-d8fd-4eaa-91ff-f2a8619dc3d6"
+                "uuid": "0ded9f8b-276f-4576-85e4-ac1df10d60eb"
             },
             "tool_id": null,
             "type": "subworkflow",

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "MMGBSA calculations with GROMACS",
-    "release": "0.1.8",
+    "release": "0.1.9",
     "steps": {
         "0": {
             "annotation": "NaCl concentration",
@@ -963,7 +963,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "9b2a9f70-4933-4951-8248-4f375f9afde2"
+                "uuid": "77c44791-0674-4afb-b007-c5ad47f6528f"
             },
             "tool_id": 3,
             "type": "subworkflow",


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/computational-chemistry/gromacs-mmgbsa**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2021.3+galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2022+galaxy0`
* `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_editconf/gmx_editconf/2021.3+galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_editconf/gmx_editconf/2022+galaxy0`
* `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2021.3+galaxy1` should be updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_solvate/gmx_solvate/2022+galaxy0`
* `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_em/gmx_em/2021.3+galaxy1` should be updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_em/gmx_em/2022+galaxy0`
* `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2021.3+galaxy2` should be updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_sim/gmx_sim/2022+galaxy0`
* `toolshed.g2.bx.psu.edu/repos/chemteam/md_converter/md_converter/1.9.6+galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/chemteam/md_converter/md_converter/1.9.7+galaxy0`
* `toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/4.2` should be updated to `toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0`

The workflow release number has been updated from 0.1.3 to 0.1.4.
