### PR TITLE
Updating workflows/computational-chemistry/protein-ligand-complex-parameterization from 0.1.3 to 0.1.5

### DIFF
--- a/workflows/computational-chemistry/protein-ligand-complex-parameterization/CHANGELOG.md
+++ b/workflows/computational-chemistry/protein-ligand-complex-parameterization/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.4] 2022-10-31
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2021.3+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2022+galaxy0`
+
 ## [0.1.3] 2022-05-25
 
 ### Changed

--- a/workflows/computational-chemistry/protein-ligand-complex-parameterization/protein-ligand-complex-parameterization.ga
+++ b/workflows/computational-chemistry/protein-ligand-complex-parameterization/protein-ligand-complex-parameterization.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "Create GRO and TOP complex files",
-    "release": "0.1.5",
+    "release": "0.1.6",
     "steps": {
         "0": {
             "annotation": "pH for protonating the ligand. Set to -1.0 to skip.",
@@ -163,16 +163,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Compound conversion",
-                    "name": "infile"
-                },
-                {
-                    "description": "runtime parameter for tool Compound conversion",
-                    "name": "ph"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Compound conversion",
             "outputs": [
@@ -217,12 +208,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Descriptors",
-                    "name": "infile"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Descriptors",
             "outputs": [
@@ -275,20 +261,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool GROMACS initial setup",
-                    "name": "ff"
-                },
-                {
-                    "description": "runtime parameter for tool GROMACS initial setup",
-                    "name": "pdb_input"
-                },
-                {
-                    "description": "runtime parameter for tool GROMACS initial setup",
-                    "name": "water"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "GROMACS initial setup",
             "outputs": [
@@ -352,7 +325,7 @@
         },
         "8": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.3+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.3+galaxy1",
             "errors": null,
             "id": 8,
             "input_connections": {
@@ -361,12 +334,7 @@
                     "output_name": "outfile"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Search in textfiles",
-                    "name": "infile"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Search in textfiles",
             "outputs": [
@@ -386,15 +354,15 @@
                     "output_name": "output"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.3+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.3+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "12615d397df7",
+                "changeset_revision": "fbf99087e067",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"case_sensitive\": \"-i\", \"color\": \"NOCOLOR\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"invert\": \"\", \"lines_after\": \"0\", \"lines_before\": \"0\", \"regex_type\": \"-P\", \"url_paste\": \"HETATM\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "9.3+galaxy0",
+            "tool_version": "9.3+galaxy1",
             "type": "tool",
             "uuid": "be1e9539-c3ba-4c3c-a06f-a82c5b4d8437",
             "when": null,
@@ -411,12 +379,7 @@
                     "output_name": "outfile"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Cut",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Cut",
             "outputs": [
@@ -455,12 +418,7 @@
                     "output_name": "out_file1"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Parse parameter value",
-                    "name": "input1"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Parse parameter value",
             "outputs": [
@@ -507,10 +465,6 @@
                 {
                     "description": "runtime parameter for tool AnteChamber",
                     "name": "allparams"
-                },
-                {
-                    "description": "runtime parameter for tool AnteChamber",
-                    "name": "input1"
                 }
             ],
             "label": null,
@@ -561,16 +515,7 @@
                     "output_name": "output1"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Generate MD topologies for small molecules",
-                    "name": "charge"
-                },
-                {
-                    "description": "runtime parameter for tool Generate MD topologies for small molecules",
-                    "name": "input1"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Generate MD topologies for small molecules",
             "outputs": [
@@ -636,24 +581,7 @@
                     "output_name": "output1"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Merge GROMACS topologies",
-                    "name": "lig_gro"
-                },
-                {
-                    "description": "runtime parameter for tool Merge GROMACS topologies",
-                    "name": "lig_top"
-                },
-                {
-                    "description": "runtime parameter for tool Merge GROMACS topologies",
-                    "name": "prot_gro"
-                },
-                {
-                    "description": "runtime parameter for tool Merge GROMACS topologies",
-                    "name": "prot_top"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Merge GROMACS topologies",
             "outputs": [

--- a/workflows/computational-chemistry/protein-ligand-complex-parameterization/protein-ligand-complex-parameterization.ga
+++ b/workflows/computational-chemistry/protein-ligand-complex-parameterization/protein-ligand-complex-parameterization.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "Create GRO and TOP complex files",
-    "release": "0.1.3",
+    "release": "0.1.4",
     "steps": {
         "0": {
             "annotation": "pH for protonating the ligand. Set to -1.0 to skip.",
@@ -29,14 +29,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 384.8000030517578,
-                "height": 61.80000305175781,
-                "left": -238,
-                "right": -38,
-                "top": 323,
-                "width": 200,
-                "x": -238,
-                "y": 323
+                "left": 0,
+                "top": 279
             },
             "tool_id": null,
             "tool_state": "{\"default\": -1.0, \"parameter_type\": \"float\", \"optional\": true}",
@@ -61,17 +55,11 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 623.8000030517578,
-                "height": 61.80000305175781,
-                "left": -238,
-                "right": -38,
-                "top": 562,
-                "width": 200,
-                "x": -238,
-                "y": 562
+                "left": 0,
+                "top": 518
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"format\": [\"sdf\"]}",
+            "tool_state": "{\"optional\": false, \"format\": [\"sdf\"], \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "277627e0-eba8-4de5-855b-63711c0db691",
@@ -93,17 +81,11 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 105.80000305175781,
-                "height": 61.80000305175781,
-                "left": 874,
-                "right": 1074,
-                "top": 44,
-                "width": 200,
-                "x": 874,
-                "y": 44
+                "left": 1112,
+                "top": 0
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false}",
+            "tool_state": "{\"optional\": false, \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "68f60b7d-13f3-4b21-aedf-986f0f7e48d7",
@@ -125,14 +107,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 205.8000030517578,
-                "height": 61.80000305175781,
-                "left": 874,
-                "right": 1074,
-                "top": 144,
-                "width": 200,
-                "x": 874,
-                "y": 144
+                "left": 1112,
+                "top": 100
             },
             "tool_id": null,
             "tool_state": "{\"restrictions\": [\"tip3p\", \"tip4p\", \"tips3p\", \"tip5p\", \"spc\", \"spce\", \"none\"], \"parameter_type\": \"text\", \"optional\": false}",
@@ -157,14 +133,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 305.8000030517578,
-                "height": 61.80000305175781,
-                "left": 874,
-                "right": 1074,
-                "top": 244,
-                "width": 200,
-                "x": 874,
-                "y": 244
+                "left": 1112,
+                "top": 200
             },
             "tool_id": null,
             "tool_state": "{\"restrictions\": [\"oplsaa\", \"gromos43a1\", \"amber96\", \"gromos53a6\", \"amber99sb\", \"amber99sb\", \"gromos53a5\", \"gromos43a2\", \"amberGS\", \"charmm27\", \"amber03\", \"gromos54a7\", \"gromos45a3\", \"amber99\", \"amber94\"], \"parameter_type\": \"text\", \"optional\": false}",
@@ -198,14 +168,8 @@
                 }
             ],
             "position": {
-                "bottom": 507.6000061035156,
-                "height": 225.60000610351562,
-                "left": 40,
-                "right": 240,
-                "top": 282,
-                "width": 200,
-                "x": 40,
-                "y": 282
+                "left": 278,
+                "top": 238
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -248,14 +212,8 @@
                 }
             ],
             "position": {
-                "bottom": 639.1999969482422,
-                "height": 93.19999694824219,
-                "left": 40,
-                "right": 240,
-                "top": 546,
-                "width": 200,
-                "x": 40,
-                "y": 546
+                "left": 278,
+                "top": 502
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -266,7 +224,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/ctb_rdkit_descriptors/ctb_rdkit_descriptors/2020.03.4+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "a1c53f0533b0",
+                "changeset_revision": "0993ac4f4a23",
                 "name": "ctb_rdkit_descriptors",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -279,7 +237,7 @@
         },
         "7": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2021.3+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2022+galaxy0",
             "errors": null,
             "id": 7,
             "input_connections": {
@@ -318,14 +276,8 @@
                 }
             ],
             "position": {
-                "bottom": 409.20001220703125,
-                "height": 347.20001220703125,
-                "left": 1152,
-                "right": 1352,
-                "top": 62,
-                "width": 200,
-                "x": 1152,
-                "y": 62
+                "left": 1390,
+                "top": 18
             },
             "post_job_actions": {
                 "HideDatasetActionoutput1": {
@@ -344,15 +296,15 @@
                     "output_name": "report"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2021.3+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2022+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "1d4dd4f908d4",
+                "changeset_revision": "070e3ecc3fda",
                 "name": "gmx_setup",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"capture_log\": \"true\", \"ff\": {\"__class__\": \"ConnectedValue\"}, \"ignore_h\": \"false\", \"pdb_input\": {\"__class__\": \"ConnectedValue\"}, \"water\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2021.3+galaxy0",
+            "tool_version": "2022+galaxy0",
             "type": "tool",
             "uuid": "b922c050-5df2-42b8-a819-1cbf892e06fa",
             "workflow_outputs": [
@@ -384,14 +336,8 @@
                 }
             ],
             "position": {
-                "bottom": 451.6000061035156,
-                "height": 113.60000610351562,
-                "left": 596,
-                "right": 796,
-                "top": 338,
-                "width": 200,
-                "x": 596,
-                "y": 338
+                "left": 834,
+                "top": 294
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -402,7 +348,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/1.1.1",
             "tool_shed_repository": {
-                "changeset_revision": "ddf54b12c295",
+                "changeset_revision": "d698c222f354",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -434,14 +380,8 @@
                 }
             ],
             "position": {
-                "bottom": 639.1999969482422,
-                "height": 93.19999694824219,
-                "left": 318,
-                "right": 518,
-                "top": 546,
-                "width": 200,
-                "x": 318,
-                "y": 546
+                "left": 556,
+                "top": 502
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -478,14 +418,8 @@
                 }
             ],
             "position": {
-                "bottom": 670.3999938964844,
-                "height": 154.39999389648438,
-                "left": 596,
-                "right": 796,
-                "top": 516,
-                "width": 200,
-                "x": 596,
-                "y": 516
+                "left": 834,
+                "top": 472
             },
             "post_job_actions": {
                 "HideDatasetActioninteger_param": {
@@ -526,14 +460,8 @@
                 }
             ],
             "position": {
-                "bottom": 574.3999938964844,
-                "height": 164.39999389648438,
-                "left": 874,
-                "right": 1074,
-                "top": 410,
-                "width": 200,
-                "x": 874,
-                "y": 410
+                "left": 1112,
+                "top": 366
             },
             "post_job_actions": {
                 "HideDatasetActionoutput1": {
@@ -544,7 +472,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/ambertools_antechamber/ambertools_antechamber/21.10+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "4fff93efc0f9",
+                "changeset_revision": "8a839e6a1e3e",
                 "name": "ambertools_antechamber",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -584,14 +512,8 @@
                 }
             ],
             "position": {
-                "bottom": 662.1999969482422,
-                "height": 215.1999969482422,
-                "left": 1152,
-                "right": 1352,
-                "top": 447,
-                "width": 200,
-                "x": 1152,
-                "y": 447
+                "left": 1390,
+                "top": 403
             },
             "post_job_actions": {
                 "HideDatasetActiongro_output": {
@@ -607,7 +529,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/ambertools_acpype/ambertools_acpype/21.10+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "a0c154146234",
+                "changeset_revision": "095ad4d096d1",
                 "name": "ambertools_acpype",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -641,24 +563,7 @@
                     "output_name": "output1"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Merge GROMACS topologies",
-                    "name": "lig_gro"
-                },
-                {
-                    "description": "runtime parameter for tool Merge GROMACS topologies",
-                    "name": "lig_top"
-                },
-                {
-                    "description": "runtime parameter for tool Merge GROMACS topologies",
-                    "name": "prot_gro"
-                },
-                {
-                    "description": "runtime parameter for tool Merge GROMACS topologies",
-                    "name": "prot_top"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Merge GROMACS topologies",
             "outputs": [
@@ -672,14 +577,8 @@
                 }
             ],
             "position": {
-                "bottom": 482.6000061035156,
-                "height": 255.60000610351562,
-                "left": 1440,
-                "right": 1640,
-                "top": 227,
-                "width": 200,
-                "x": 1440,
-                "y": 227
+                "left": 1678,
+                "top": 183
             },
             "post_job_actions": {
                 "RenameDatasetActioncomplex_gro": {
@@ -699,12 +598,12 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/chemteam/gmx_merge_topology_files/gmx_merge_topology_files/3.4.3+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "9389cd867cf2",
+                "changeset_revision": "bc31d02be922",
                 "name": "gmx_merge_topology_files",
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"lig_gro\": {\"__class__\": \"RuntimeValue\"}, \"lig_top\": {\"__class__\": \"RuntimeValue\"}, \"prot_gro\": {\"__class__\": \"RuntimeValue\"}, \"prot_top\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"lig_gro\": {\"__class__\": \"ConnectedValue\"}, \"lig_top\": {\"__class__\": \"ConnectedValue\"}, \"prot_gro\": {\"__class__\": \"ConnectedValue\"}, \"prot_top\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "3.4.3+galaxy0",
             "type": "tool",
             "uuid": "2a22a7fd-3e14-4f27-b1a8-a6d66cef292a",

--- a/workflows/computational-chemistry/protein-ligand-complex-parameterization/protein-ligand-complex-parameterization.ga
+++ b/workflows/computational-chemistry/protein-ligand-complex-parameterization/protein-ligand-complex-parameterization.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "Create GRO and TOP complex files",
-    "release": "0.1.4",
+    "release": "0.1.5",
     "steps": {
         "0": {
             "annotation": "pH for protonating the ligand. Set to -1.0 to skip.",
@@ -37,6 +37,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "6893b667-f375-481b-96eb-50d5aceb5030",
+            "when": null,
             "workflow_outputs": []
         },
         "1": {
@@ -63,6 +64,7 @@
             "tool_version": null,
             "type": "data_input",
             "uuid": "277627e0-eba8-4de5-855b-63711c0db691",
+            "when": null,
             "workflow_outputs": []
         },
         "2": {
@@ -89,6 +91,7 @@
             "tool_version": null,
             "type": "data_input",
             "uuid": "68f60b7d-13f3-4b21-aedf-986f0f7e48d7",
+            "when": null,
             "workflow_outputs": []
         },
         "3": {
@@ -115,6 +118,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "8d29ae78-60de-45ba-b403-cdd2646af030",
+            "when": null,
             "workflow_outputs": []
         },
         "4": {
@@ -141,6 +145,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "16c399b1-e67c-47a9-acd3-61ddc39473d9",
+            "when": null,
             "workflow_outputs": []
         },
         "5": {
@@ -158,7 +163,16 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Compound conversion",
+                    "name": "infile"
+                },
+                {
+                    "description": "runtime parameter for tool Compound conversion",
+                    "name": "ph"
+                }
+            ],
             "label": null,
             "name": "Compound conversion",
             "outputs": [
@@ -185,10 +199,11 @@
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"appendtotitle\": \"\", \"dative_bonds\": \"false\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"oformat\": {\"oformat_opts_selector\": \"pdb\", \"__current_case__\": 51}, \"ph\": {\"__class__\": \"ConnectedValue\"}, \"remove_h\": \"false\", \"split\": \"false\", \"unique\": {\"unique_opts_selector\": \"\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"appendtotitle\": \"\", \"dative_bonds\": false, \"infile\": {\"__class__\": \"ConnectedValue\"}, \"oformat\": {\"oformat_opts_selector\": \"pdb\", \"__current_case__\": 51}, \"ph\": {\"__class__\": \"ConnectedValue\"}, \"remove_h\": false, \"split\": false, \"unique\": {\"unique_opts_selector\": \"\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "3.1.1+galaxy0",
             "type": "tool",
             "uuid": "c1f8c291-3b11-4afa-b62d-ee2d2d22b11f",
+            "when": null,
             "workflow_outputs": []
         },
         "6": {
@@ -202,7 +217,12 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Descriptors",
+                    "name": "infile"
+                }
+            ],
             "label": null,
             "name": "Descriptors",
             "outputs": [
@@ -229,10 +249,11 @@
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"header\": \"false\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"select_multiple\": [\"FormalCharge\"], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"header\": false, \"infile\": {\"__class__\": \"ConnectedValue\"}, \"select_multiple\": [\"FormalCharge\"], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2020.03.4+galaxy1",
             "type": "tool",
             "uuid": "351397ff-a72d-4c7d-b39a-bc97b8f2c357",
+            "when": null,
             "workflow_outputs": []
         },
         "7": {
@@ -254,7 +275,20 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool GROMACS initial setup",
+                    "name": "ff"
+                },
+                {
+                    "description": "runtime parameter for tool GROMACS initial setup",
+                    "name": "pdb_input"
+                },
+                {
+                    "description": "runtime parameter for tool GROMACS initial setup",
+                    "name": "water"
+                }
+            ],
             "label": null,
             "name": "GROMACS initial setup",
             "outputs": [
@@ -303,10 +337,11 @@
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"capture_log\": \"true\", \"ff\": {\"__class__\": \"ConnectedValue\"}, \"ignore_h\": \"false\", \"pdb_input\": {\"__class__\": \"ConnectedValue\"}, \"water\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"capture_log\": true, \"ff\": {\"__class__\": \"ConnectedValue\"}, \"ignore_h\": false, \"pdb_input\": {\"__class__\": \"ConnectedValue\"}, \"water\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2022+galaxy0",
             "type": "tool",
             "uuid": "b922c050-5df2-42b8-a819-1cbf892e06fa",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "Position restraints file",
@@ -317,7 +352,7 @@
         },
         "8": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/1.1.1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.3+galaxy0",
             "errors": null,
             "id": 8,
             "input_connections": {
@@ -326,7 +361,12 @@
                     "output_name": "outfile"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Search in textfiles",
+                    "name": "infile"
+                }
+            ],
             "label": null,
             "name": "Search in textfiles",
             "outputs": [
@@ -346,17 +386,18 @@
                     "output_name": "output"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/1.1.1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.3+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "d698c222f354",
+                "changeset_revision": "12615d397df7",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"case_sensitive\": \"-i\", \"color\": \"NOCOLOR\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"invert\": \"\", \"lines_after\": \"0\", \"lines_before\": \"0\", \"regex_type\": \"-P\", \"url_paste\": \"HETATM\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.1.1",
+            "tool_version": "9.3+galaxy0",
             "type": "tool",
             "uuid": "be1e9539-c3ba-4c3c-a06f-a82c5b4d8437",
+            "when": null,
             "workflow_outputs": []
         },
         "9": {
@@ -370,7 +411,12 @@
                     "output_name": "outfile"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Cut",
+                    "name": "input"
+                }
+            ],
             "label": null,
             "name": "Cut",
             "outputs": [
@@ -395,6 +441,7 @@
             "tool_version": "1.0.2",
             "type": "tool",
             "uuid": "fd7483c3-52b0-489f-a422-2d399e2cd4e5",
+            "when": null,
             "workflow_outputs": []
         },
         "10": {
@@ -408,7 +455,12 @@
                     "output_name": "out_file1"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Parse parameter value",
+                    "name": "input1"
+                }
+            ],
             "label": null,
             "name": "Parse parameter value",
             "outputs": [
@@ -429,10 +481,11 @@
                 }
             },
             "tool_id": "param_value_from_file",
-            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"integer\", \"remove_newlines\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"integer\", \"remove_newlines\": true, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.1.0",
             "type": "tool",
             "uuid": "50d4ab40-a78d-4d97-8740-7e00edacae6b",
+            "when": null,
             "workflow_outputs": []
         },
         "11": {
@@ -450,7 +503,16 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool AnteChamber",
+                    "name": "allparams"
+                },
+                {
+                    "description": "runtime parameter for tool AnteChamber",
+                    "name": "input1"
+                }
+            ],
             "label": null,
             "name": "AnteChamber",
             "outputs": [
@@ -477,10 +539,11 @@
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"allparams\": {\"nc\": {\"__class__\": \"ConnectedValue\"}, \"m\": \"1\", \"resname\": \"UNL\", \"c\": \"bcc\", \"at\": \"gaff\", \"j\": \"4\"}, \"extraparams\": {\"pf\": \"true\", \"usenc\": \"true\"}, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"selected_output_format\": \"mol2\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"allparams\": {\"nc\": {\"__class__\": \"ConnectedValue\"}, \"m\": \"1\", \"resname\": \"UNL\", \"c\": \"bcc\", \"at\": \"gaff\", \"j\": \"4\"}, \"extraparams\": {\"pf\": true, \"usenc\": true}, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"selected_output_format\": \"mol2\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "21.10+galaxy0",
             "type": "tool",
             "uuid": "32a50a09-a9c7-4d08-9d7f-7d5c9efaa3bf",
+            "when": null,
             "workflow_outputs": []
         },
         "12": {
@@ -498,7 +561,16 @@
                     "output_name": "output1"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Generate MD topologies for small molecules",
+                    "name": "charge"
+                },
+                {
+                    "description": "runtime parameter for tool Generate MD topologies for small molecules",
+                    "name": "input1"
+                }
+            ],
             "label": null,
             "name": "Generate MD topologies for small molecules",
             "outputs": [
@@ -534,10 +606,11 @@
                 "owner": "chemteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"atomtype\": \"gaff\", \"charge\": {\"__class__\": \"ConnectedValue\"}, \"charge_method\": \"user\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"multiplicity\": \"1\", \"save_gro\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"atomtype\": \"gaff\", \"charge\": {\"__class__\": \"ConnectedValue\"}, \"charge_method\": \"user\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"multiplicity\": \"1\", \"save_gro\": true, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "21.10+galaxy0",
             "type": "tool",
             "uuid": "3ee8d6ce-e7bc-45c5-ae34-ac0348ac959f",
+            "when": null,
             "workflow_outputs": []
         },
         "13": {
@@ -563,7 +636,24 @@
                     "output_name": "output1"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Merge GROMACS topologies",
+                    "name": "lig_gro"
+                },
+                {
+                    "description": "runtime parameter for tool Merge GROMACS topologies",
+                    "name": "lig_top"
+                },
+                {
+                    "description": "runtime parameter for tool Merge GROMACS topologies",
+                    "name": "prot_gro"
+                },
+                {
+                    "description": "runtime parameter for tool Merge GROMACS topologies",
+                    "name": "prot_top"
+                }
+            ],
             "label": null,
             "name": "Merge GROMACS topologies",
             "outputs": [
@@ -607,6 +697,7 @@
             "tool_version": "3.4.3+galaxy0",
             "type": "tool",
             "uuid": "2a22a7fd-3e14-4f27-b1a8-a6d66cef292a",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "Complex topology",


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/computational-chemistry/protein-ligand-complex-parameterization**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2021.3+galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/chemteam/gmx_setup/gmx_setup/2022+galaxy0`

The workflow release number has been updated from 0.1.3 to 0.1.4.
