### PR TITLE
Updating workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation from 0.4 to 0.5

### DIFF
--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/CHANGELOG.md
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5] 2022-10-31
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.29.2` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.30.0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3.0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3+t.galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3.0`
+
 ## [0.4] 2022-10-21
 
 ### Fixed

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: consensus construction",
-    "release": "0.4",
+    "release": "0.5",
     "steps": {
         "0": {
             "annotation": "Collection of VCFs produced by upstream workflows for variation analysis",
@@ -29,11 +29,11 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "left": 348.04998779296875,
-                "top": 524.63330078125
+                "left": 0.0,
+                "top": 306.13330078125
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"collection_type\": \"list\"}",
+            "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\"}",
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "fca4e710-87a7-4cb6-9ff1-f9a8dc84ca37",
@@ -55,8 +55,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 348.5,
-                "top": 687.5
+                "left": 0.45001220703125,
+                "top": 469.0
             },
             "tool_id": null,
             "tool_state": "{\"default\": 0.75, \"parameter_type\": \"float\", \"optional\": true}",
@@ -87,8 +87,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 348.5,
-                "top": 859.1500244140625
+                "left": 0.45001220703125,
+                "top": 640.6500244140625
             },
             "tool_id": null,
             "tool_state": "{\"default\": 0.25, \"parameter_type\": \"float\", \"optional\": true}",
@@ -119,11 +119,11 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "left": 929.36669921875,
-                "top": 613.6666870117188
+                "left": 581.3167114257812,
+                "top": 395.16668701171875
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"format\": [\"bam\"], \"collection_type\": \"list\"}",
+            "tool_state": "{\"optional\": false, \"format\": [\"bam\"], \"tag\": null, \"collection_type\": \"list\"}",
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "23ae69ea-f9a7-4d5f-85f5-63b9d2bd2c50",
@@ -145,8 +145,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 933.2999877929688,
-                "top": 776.3499755859375
+                "left": 585.25,
+                "top": 557.8499755859375
             },
             "tool_id": null,
             "tool_state": "{\"default\": 5, \"parameter_type\": \"integer\", \"optional\": true}",
@@ -177,11 +177,11 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 2631.86669921875,
-                "top": 564.6500244140625
+                "left": 2283.8167114257812,
+                "top": 346.1500244140625
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false}",
+            "tool_state": "{\"optional\": false, \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "4a2c6df2-fb1e-42d8-96d5-6765ca85c214",
@@ -208,8 +208,8 @@
                 }
             ],
             "position": {
-                "left": 630.8499755859375,
-                "top": 503.8500061035156
+                "left": 282.79998779296875,
+                "top": 285.3500061035156
             },
             "post_job_actions": {
                 "HideDatasetActionout1": {
@@ -256,8 +256,8 @@
                 }
             ],
             "position": {
-                "left": 581.0499877929688,
-                "top": 1020.5166625976562
+                "left": 233.0,
+                "top": 802.0166625976562
             },
             "post_job_actions": {
                 "HideDatasetActionout1": {
@@ -281,7 +281,7 @@
         },
         "8": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.29.2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.30.0",
             "errors": null,
             "id": 8,
             "input_connections": {
@@ -300,8 +300,8 @@
                 }
             ],
             "position": {
-                "left": 1228.8499755859375,
-                "top": 621.8499755859375
+                "left": 880.7999877929688,
+                "top": 403.3499755859375
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -312,15 +312,15 @@
                     "output_name": "output"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.29.2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.30.0",
             "tool_shed_repository": {
-                "changeset_revision": "0a5c785ac6db",
+                "changeset_revision": "07e8b80f278c",
                 "name": "bedtools",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"d\": \"false\", \"dz\": \"false\", \"five\": \"false\", \"input_type\": {\"input_type_select\": \"bam\", \"__current_case__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}}, \"report\": {\"report_select\": \"bg\", \"__current_case__\": 0, \"zero_regions\": \"true\", \"scale\": \"1.0\"}, \"split\": \"true\", \"strand\": \"\", \"three\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.29.2",
+            "tool_version": "2.30.0",
             "type": "tool",
             "uuid": "d89684f5-5a49-4b4c-821b-6c8a87f3a46e",
             "workflow_outputs": [
@@ -352,8 +352,8 @@
                 }
             ],
             "position": {
-                "left": 1227.36669921875,
-                "top": 778.3499755859375
+                "left": 879.3167114257812,
+                "top": 559.8499755859375
             },
             "post_job_actions": {
                 "HideDatasetActionout1": {
@@ -400,8 +400,8 @@
                 }
             ],
             "position": {
-                "left": 833.3333129882812,
-                "top": 218.5
+                "left": 485.2833251953125,
+                "top": 0.0
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -456,8 +456,8 @@
                 }
             ],
             "position": {
-                "left": 804.7166748046875,
-                "top": 951.8499755859375
+                "left": 456.66668701171875,
+                "top": 733.3499755859375
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -512,8 +512,8 @@
                 }
             ],
             "position": {
-                "left": 1561.88330078125,
-                "top": 645.8499755859375
+                "left": 1213.8333129882812,
+                "top": 427.3499755859375
             },
             "post_job_actions": {
                 "RenameDatasetActionout_file1": {
@@ -558,8 +558,8 @@
                 }
             ],
             "position": {
-                "left": 1155.5,
-                "top": 401.5
+                "left": 807.4500122070312,
+                "top": 183.0
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -610,8 +610,8 @@
                 }
             ],
             "position": {
-                "left": 1022,
-                "top": 1117.5
+                "left": 673.9500122070312,
+                "top": 899.0
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -652,12 +652,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Compute",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Compute",
             "outputs": [
@@ -667,8 +662,8 @@
                 }
             ],
             "position": {
-                "left": 1496.183349609375,
-                "top": 468.1499938964844
+                "left": 1148.1333618164062,
+                "top": 249.64999389648438
             },
             "post_job_actions": {
                 "ChangeDatatypeActionout_file1": {
@@ -693,7 +688,7 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"avoid_scientific_notation\": \"false\", \"error_handling\": {\"auto_col_types\": \"false\", \"fail_on_non_existent_columns\": \"true\", \"non_computable\": {\"action\": \"--skip-non-computable\", \"__current_case__\": 1}}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"ops\": {\"header_lines_select\": \"no\", \"__current_case__\": 0, \"expressions\": [{\"__index__\": 0, \"cond\": \"int(c2) - (len(c3) == 1)\", \"add_column\": {\"mode\": \"R\", \"__current_case__\": 2, \"pos\": \"2\"}}, {\"__index__\": 1, \"cond\": \"int(c2) + ((len(c3) - 1) or 1)\", \"add_column\": {\"mode\": \"R\", \"__current_case__\": 2, \"pos\": \"3\"}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"avoid_scientific_notation\": \"false\", \"error_handling\": {\"auto_col_types\": \"false\", \"fail_on_non_existent_columns\": \"true\", \"non_computable\": {\"action\": \"--skip-non-computable\", \"__current_case__\": 1}}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"ops\": {\"header_lines_select\": \"no\", \"__current_case__\": 0, \"expressions\": [{\"__index__\": 0, \"cond\": \"int(c2) - (len(c3) == 1)\", \"add_column\": {\"mode\": \"R\", \"__current_case__\": 2, \"pos\": \"2\"}}, {\"__index__\": 1, \"cond\": \"int(c2) + ((len(c3) - 1) or 1)\", \"add_column\": {\"mode\": \"R\", \"__current_case__\": 2, \"pos\": \"3\"}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.0",
             "type": "tool",
             "uuid": "fd260e32-723d-4a22-8d64-4795557f8159",
@@ -716,12 +711,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Compute",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Compute",
             "outputs": [
@@ -731,8 +721,8 @@
                 }
             ],
             "position": {
-                "left": 1249.6666259765625,
-                "top": 1137.6500244140625
+                "left": 901.6166381835938,
+                "top": 919.1500244140625
             },
             "post_job_actions": {
                 "ChangeDatatypeActionout_file1": {
@@ -757,7 +747,7 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"avoid_scientific_notation\": \"false\", \"error_handling\": {\"auto_col_types\": \"false\", \"fail_on_non_existent_columns\": \"true\", \"non_computable\": {\"action\": \"--skip-non-computable\", \"__current_case__\": 1}}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"ops\": {\"header_lines_select\": \"no\", \"__current_case__\": 0, \"expressions\": [{\"__index__\": 0, \"cond\": \"int(c2) - (len(c3) == 1)\", \"add_column\": {\"mode\": \"R\", \"__current_case__\": 2, \"pos\": \"2\"}}, {\"__index__\": 1, \"cond\": \"int(c2) + ((len(c3) - 1) or 1)\", \"add_column\": {\"mode\": \"R\", \"__current_case__\": 2, \"pos\": \"3\"}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"avoid_scientific_notation\": \"false\", \"error_handling\": {\"auto_col_types\": \"false\", \"fail_on_non_existent_columns\": \"true\", \"non_computable\": {\"action\": \"--skip-non-computable\", \"__current_case__\": 1}}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"ops\": {\"header_lines_select\": \"no\", \"__current_case__\": 0, \"expressions\": [{\"__index__\": 0, \"cond\": \"int(c2) - (len(c3) == 1)\", \"add_column\": {\"mode\": \"R\", \"__current_case__\": 2, \"pos\": \"2\"}}, {\"__index__\": 1, \"cond\": \"int(c2) + ((len(c3) - 1) or 1)\", \"add_column\": {\"mode\": \"R\", \"__current_case__\": 2, \"pos\": \"3\"}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.0",
             "type": "tool",
             "uuid": "116e8e99-53ca-4366-a7e1-e3a9fb0bcfc3",
@@ -794,8 +784,8 @@
                 }
             ],
             "position": {
-                "left": 1816.933349609375,
-                "top": 755.9166870117188
+                "left": 1468.8833618164062,
+                "top": 537.4166870117188
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -808,7 +798,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/concat/gops_concat_1/1.0.1",
             "tool_shed_repository": {
-                "changeset_revision": "35a89f8cc96e",
+                "changeset_revision": "73ca13a7ec5f",
                 "name": "concat",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -846,8 +836,8 @@
                 }
             ],
             "position": {
-                "left": 2051.36669921875,
-                "top": 752.1666870117188
+                "left": 1703.3167114257812,
+                "top": 533.6666870117188
             },
             "post_job_actions": {
                 "ChangeDatatypeActionoutput": {
@@ -867,7 +857,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/merge/gops_merge_1/1.0.0",
             "tool_shed_repository": {
-                "changeset_revision": "381cd27bf67a",
+                "changeset_revision": "debffd27642d",
                 "name": "merge",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -909,8 +899,8 @@
                 }
             ],
             "position": {
-                "left": 2307.5166015625,
-                "top": 626.5
+                "left": 1959.4666137695312,
+                "top": 408.0
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -923,7 +913,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/subtract/gops_subtract_1/1.0.0",
             "tool_shed_repository": {
-                "changeset_revision": "0145969324c4",
+                "changeset_revision": "0427ca314f3d",
                 "name": "subtract",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -951,12 +941,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Compute",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Compute",
             "outputs": [
@@ -966,8 +951,8 @@
                 }
             ],
             "position": {
-                "left": 2492.88330078125,
-                "top": 804.1666870117188
+                "left": 2144.8333129882812,
+                "top": 585.6666870117188
             },
             "post_job_actions": {
                 "ChangeDatatypeActionout_file1": {
@@ -992,7 +977,7 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"avoid_scientific_notation\": \"false\", \"error_handling\": {\"auto_col_types\": \"true\", \"fail_on_non_existent_columns\": \"true\", \"non_computable\": {\"action\": \"--fail-on-non-computable\", \"__current_case__\": 0}}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"ops\": {\"header_lines_select\": \"no\", \"__current_case__\": 0, \"expressions\": [{\"__index__\": 0, \"cond\": \"int(c2) + 1\", \"add_column\": {\"mode\": \"R\", \"__current_case__\": 2, \"pos\": \"2\"}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"avoid_scientific_notation\": \"false\", \"error_handling\": {\"auto_col_types\": \"true\", \"fail_on_non_existent_columns\": \"true\", \"non_computable\": {\"action\": \"--fail-on-non-computable\", \"__current_case__\": 0}}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"ops\": {\"header_lines_select\": \"no\", \"__current_case__\": 0, \"expressions\": [{\"__index__\": 0, \"cond\": \"int(c2) + 1\", \"add_column\": {\"mode\": \"R\", \"__current_case__\": 2, \"pos\": \"2\"}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.0",
             "type": "tool",
             "uuid": "e06fe045-f0f0-4c32-80ad-a8e070946a2f",
@@ -1033,8 +1018,8 @@
                 }
             ],
             "position": {
-                "left": 2951.88330078125,
-                "top": 462.16668701171875
+                "left": 2603.8333129882812,
+                "top": 243.66668701171875
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput_file": {
@@ -1052,7 +1037,7 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"absent\": \"\", \"chain\": \"false\", \"input_file\": {\"__class__\": \"RuntimeValue\"}, \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"fasta_ref\": {\"__class__\": \"RuntimeValue\"}}, \"rename\": \"true\", \"sec_default\": {\"mask\": {\"__class__\": \"RuntimeValue\"}, \"iupac_codes\": \"false\", \"sample\": \"\", \"select_haplotype\": null, \"mark_del\": \"\", \"mark_ins\": null, \"mark_snv\": null, \"conditional_mask\": {\"selector\": \"disabled\", \"__current_case__\": 0}}, \"sec_restrict\": {\"include\": \"\", \"exclude\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"absent\": \"\", \"chain\": \"false\", \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"fasta_ref\": {\"__class__\": \"ConnectedValue\"}}, \"rename\": \"true\", \"sec_default\": {\"mask\": {\"__class__\": \"ConnectedValue\"}, \"iupac_codes\": \"false\", \"sample\": \"\", \"select_haplotype\": null, \"mark_del\": \"\", \"mark_ins\": null, \"mark_snv\": null, \"conditional_mask\": {\"selector\": \"disabled\", \"__current_case__\": 0}}, \"sec_restrict\": {\"include\": \"\", \"exclude\": \"\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.15.1+galaxy2",
             "type": "tool",
             "uuid": "698a9a8c-f6fe-430b-a7e0-cf9e1d058d02",
@@ -1085,8 +1070,8 @@
                 }
             ],
             "position": {
-                "left": 3211.550048828125,
-                "top": 486
+                "left": 2863.5000610351562,
+                "top": 267.5
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.29.2` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.30.0`
* `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3.0`
* `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3+t.galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3.0`

The workflow release number has been updated from 0.4 to 0.5.
