### PR TITLE
Updating workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling from 0.5 to 0.12

### DIFF
--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/CHANGELOG.md
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.6] 2022-10-31
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.9+galaxy2` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.15.1+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.2+galaxy2` was updated to `toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.4`
+- `toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy1`
+- `toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy2` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy4`
+- `toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy2`
+- `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3.0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.1+galaxy2` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.1+galaxy3`
+- `toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.10` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.15.1+galaxy2`
+
 ## [0.5] - 2022-02-08
 
 ### Fixed

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: variation analysis on ARTIC PE data",
-    "release": "0.8",
+    "release": "0.9",
     "steps": {
         "0": {
             "annotation": "Illumina reads from ARTIC assay with fastqsanger encoding",
@@ -627,7 +627,7 @@
         },
         "16": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy5",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.2+galaxy0",
             "errors": null,
             "id": 16,
             "input_connections": {
@@ -666,15 +666,15 @@
                     "output_name": "output_bam"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy5",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "e3bb03cf207a",
+                "changeset_revision": "bcaa0d571ce2",
                 "name": "ivar_trim",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"amplicons\": {\"filter_by\": \"yes\", \"__current_case__\": 1, \"amplicon_info\": {\"__class__\": \"ConnectedValue\"}}, \"inc_primers\": \"true\", \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"min_len\": \"1\", \"min_qual\": \"0\", \"primer\": {\"source\": \"history\", \"__current_case__\": 0, \"input_bed\": {\"__class__\": \"ConnectedValue\"}}, \"primer_pos_wiggle\": \"0\", \"window_width\": \"4\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.3.1+galaxy5",
+            "tool_version": "1.3.2+galaxy0",
             "type": "tool",
             "uuid": "7730e635-853f-4f9f-9451-bffbe6aedd15",
             "workflow_outputs": [
@@ -922,7 +922,7 @@
         },
         "22": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.1+galaxy4",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.2+galaxy0",
             "errors": null,
             "id": 22,
             "input_connections": {
@@ -957,15 +957,15 @@
                 "top": 48.96875
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.1+galaxy4",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "7f1cfa4c0e32",
+                "changeset_revision": "8c05afb547fa",
                 "name": "ivar_removereads",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"amplicons\": {\"computed\": \"no\", \"__current_case__\": 1, \"amplicon_info\": {\"__class__\": \"ConnectedValue\"}}, \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"input_bed\": {\"__class__\": \"ConnectedValue\"}, \"variants_tsv\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.3.1+galaxy4",
+            "tool_version": "1.3.2+galaxy0",
             "type": "tool",
             "uuid": "af7d3b75-d16c-43c7-82e4-3f1388edd22c",
             "workflow_outputs": [

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: variation analysis on ARTIC PE data",
-    "release": "0.10",
+    "release": "0.11",
     "steps": {
         "0": {
             "annotation": "Illumina reads from ARTIC assay with fastqsanger encoding",
@@ -643,7 +643,7 @@
         },
         "16": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.4.0+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.4.2+galaxy0",
             "errors": null,
             "id": 16,
             "input_connections": {
@@ -682,15 +682,15 @@
                     "output_name": "output_bam"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.4.0+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.4.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "a2b94388d00d",
+                "changeset_revision": "28e4bcbc86e7",
                 "name": "ivar_trim",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"amplicons\": {\"filter_by\": \"yes\", \"__current_case__\": 1, \"amplicon_info\": {\"__class__\": \"ConnectedValue\"}}, \"inc_primers\": true, \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"min_len\": \"1\", \"min_qual\": \"0\", \"primer\": {\"source\": \"history\", \"__current_case__\": 0, \"input_bed\": {\"__class__\": \"ConnectedValue\"}}, \"primer_pos_wiggle\": \"0\", \"trimmed_length\": {\"filter\": \"auto\", \"__current_case__\": 1}, \"window_width\": \"4\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.4.0+galaxy0",
+            "tool_version": "1.4.2+galaxy0",
             "type": "tool",
             "uuid": "7730e635-853f-4f9f-9451-bffbe6aedd15",
             "when": null,
@@ -944,7 +944,7 @@
         },
         "22": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.4.0+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.4.2+galaxy0",
             "errors": null,
             "id": 22,
             "input_connections": {
@@ -979,15 +979,15 @@
                 "top": 48.96875
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.4.0+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.4.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "6a1515bb0687",
+                "changeset_revision": "f57ce5d5c997",
                 "name": "ivar_removereads",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"amplicons\": {\"computed\": \"no\", \"__current_case__\": 1, \"amplicon_info\": {\"__class__\": \"ConnectedValue\"}}, \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"input_bed\": {\"__class__\": \"ConnectedValue\"}, \"variants_tsv\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.4.0+galaxy0",
+            "tool_version": "1.4.2+galaxy0",
             "type": "tool",
             "uuid": "af7d3b75-d16c-43c7-82e4-3f1388edd22c",
             "when": null,

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: variation analysis on ARTIC PE data",
-    "release": "0.5",
+    "release": "0.6",
     "steps": {
         "0": {
             "annotation": "Illumina reads from ARTIC assay with fastqsanger encoding",
@@ -29,17 +29,11 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "bottom": 606.734375,
-                "height": 102.5625,
-                "left": -334.703125,
-                "right": -134.703125,
-                "top": 504.171875,
-                "width": 200,
-                "x": -334.703125,
-                "y": 504.171875
+                "left": 0.0,
+                "top": 506.796875
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"format\": [\"fastqsanger\", \"fastqsanger.gz\"], \"collection_type\": \"list:paired\"}",
+            "tool_state": "{\"optional\": false, \"format\": [\"fastqsanger\", \"fastqsanger.gz\"], \"tag\": null, \"collection_type\": \"list:paired\"}",
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "dfab5b21-4abb-4269-978d-7c7e24479e4a",
@@ -61,17 +55,11 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 983.5,
-                "height": 102.5625,
-                "left": -64.921875,
-                "right": 135.078125,
-                "top": 880.9375,
-                "width": 200,
-                "x": -64.921875,
-                "y": 880.9375
+                "left": 269.78125,
+                "top": 883.5625
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"format\": [\"fasta\", \"fasta.gz\"]}",
+            "tool_state": "{\"optional\": false, \"format\": [\"fasta\", \"fasta.gz\"], \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "03043a6d-ee9e-4af5-abf4-f960beb6b4e9",
@@ -93,17 +81,11 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 406.453125,
-                "height": 82.171875,
-                "left": 627.46875,
-                "right": 827.46875,
-                "top": 324.28125,
-                "width": 200,
-                "x": 627.46875,
-                "y": 324.28125
+                "left": 962.171875,
+                "top": 326.90625
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"format\": [\"bed\"]}",
+            "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "cd6caddf-88ee-47a2-b91d-141fd90b046f",
@@ -125,59 +107,21 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "bottom": 531.5,
-                "height": 102.5625,
-                "left": 626.921875,
-                "right": 826.921875,
-                "top": 428.9375,
-                "width": 200,
-                "x": 626.921875,
-                "y": 428.9375
+                "left": 961.625,
+                "top": 431.5625
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"format\": [\"tabular\"]}",
+            "tool_state": "{\"optional\": false, \"format\": [\"tabular\"], \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "686cdb4d-a3da-468f-af92-8b04e1824ae0",
             "workflow_outputs": []
         },
         "4": {
-            "annotation": "Maximum allele-frequency allowed for a primer binding site mutation to trigger amplicon removal. Variants with AF values above this threshold are treated as fixed variants, which won't generate amplicon bias.",
-            "content_id": null,
-            "errors": null,
-            "id": 4,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "Maximum allele-frequency allowed for a primer binding site mutation to trigger amplicon removal. Variants with AF values above this threshold are treated as fixed variants, which won't generate amplicon bias.",
-                    "name": "Read removal maximum AF"
-                }
-            ],
-            "label": "Read removal maximum AF",
-            "name": "Input parameter",
-            "outputs": [],
-            "position": {
-                "bottom": 236.1875,
-                "height": 82.171875,
-                "left": 759.8125,
-                "right": 959.8125,
-                "top": 154.015625,
-                "width": 200,
-                "x": 759.8125,
-                "y": 154.015625
-            },
-            "tool_id": null,
-            "tool_state": "{\"default\": 1, \"parameter_type\": \"float\", \"optional\": true}",
-            "tool_version": null,
-            "type": "parameter_input",
-            "uuid": "b13941c0-31c0-419d-a619-7474c24a582c",
-            "workflow_outputs": []
-        },
-        "5": {
             "annotation": "Minimum allele-frequency required for a candidate primer binding site mutation to trigger amplicon removal. Variants with AF values below this threshold are treated as possible false-positives, which are not worth the coverage loss associated with amplicon removal.",
             "content_id": null,
             "errors": null,
-            "id": 5,
+            "id": 4,
             "input_connections": {},
             "inputs": [
                 {
@@ -189,20 +133,40 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 126.1875,
-                "height": 82.171875,
-                "left": 758.5625,
-                "right": 958.5625,
-                "top": 44.015625,
-                "width": 200,
-                "x": 758.5625,
-                "y": 44.015625
+                "left": 1093.265625,
+                "top": 46.640625
             },
             "tool_id": null,
             "tool_state": "{\"default\": 0.1, \"parameter_type\": \"float\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "29f15ec0-8fa4-4476-b649-cf68ea096744",
+            "workflow_outputs": []
+        },
+        "5": {
+            "annotation": "Maximum allele-frequency allowed for a primer binding site mutation to trigger amplicon removal. Variants with AF values above this threshold are treated as fixed variants, which won't generate amplicon bias.",
+            "content_id": null,
+            "errors": null,
+            "id": 5,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Maximum allele-frequency allowed for a primer binding site mutation to trigger amplicon removal. Variants with AF values above this threshold are treated as fixed variants, which won't generate amplicon bias.",
+                    "name": "Read removal maximum AF"
+                }
+            ],
+            "label": "Read removal maximum AF",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 1094.515625,
+                "top": 156.640625
+            },
+            "tool_id": null,
+            "tool_state": "{\"default\": 1.0, \"parameter_type\": \"float\", \"optional\": true}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "b13941c0-31c0-419d-a619-7474c24a582c",
             "workflow_outputs": []
         },
         "6": {
@@ -221,14 +185,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 99.9375,
-                "height": 102.5625,
-                "left": 1836.859375,
-                "right": 2036.859375,
-                "top": -2.625,
-                "width": 200,
-                "x": 1836.859375,
-                "y": -2.625
+                "left": 2171.5625,
+                "top": 0.0
             },
             "tool_id": null,
             "tool_state": "{\"default\": 1, \"parameter_type\": \"integer\", \"optional\": true}",
@@ -253,14 +211,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 217.734375,
-                "height": 102.5625,
-                "left": 1837.640625,
-                "right": 2037.640625,
-                "top": 115.171875,
-                "width": 200,
-                "x": 1837.640625,
-                "y": 115.171875
+                "left": 2172.34375,
+                "top": 117.796875
             },
             "tool_id": null,
             "tool_state": "{\"default\": 10, \"parameter_type\": \"integer\", \"optional\": true}",
@@ -271,63 +223,9 @@
         },
         "8": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
-            "errors": null,
-            "id": 8,
-            "input_connections": {
-                "components_1|param_type|component_value": {
-                    "id": 5,
-                    "output_name": "output"
-                },
-                "components_3|param_type|component_value": {
-                    "id": 4,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Compose text parameter value",
-            "outputs": [
-                {
-                    "name": "out1",
-                    "type": "expression.json"
-                }
-            ],
-            "position": {
-                "bottom": 267.9375,
-                "height": 225.515625,
-                "left": 996.6875,
-                "right": 1196.6875,
-                "top": 42.421875,
-                "width": 200,
-                "x": 996.6875,
-                "y": 42.421875
-            },
-            "post_job_actions": {
-                "HideDatasetActionout1": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "out1"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
-            "tool_shed_repository": {
-                "changeset_revision": "e188c9826e0f",
-                "name": "compose_text_param",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \"( ( DP4[2] + DP4[3] ) >= ( \"}}, {\"__index__\": 1, \"param_type\": {\"select_param_type\": \"float\", \"__current_case__\": 2, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \" * DP ) ) & ( ( DP4[2] + DP4[3] ) <= ( \"}}, {\"__index__\": 3, \"param_type\": {\"select_param_type\": \"float\", \"__current_case__\": 2, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 4, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \" * DP ) )\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.1.1",
-            "type": "tool",
-            "uuid": "d163b9b9-ee13-4b2b-8d64-b6d77758fac9",
-            "workflow_outputs": []
-        },
-        "9": {
-            "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.2+galaxy0",
             "errors": null,
-            "id": 9,
+            "id": 8,
             "input_connections": {
                 "single_paired|paired_input": {
                     "id": 0,
@@ -352,14 +250,8 @@
                 }
             ],
             "position": {
-                "bottom": 790.453125,
-                "height": 174.34375,
-                "left": -116.9375,
-                "right": 83.0625,
-                "top": 616.109375,
-                "width": 200,
-                "x": -116.9375,
-                "y": 616.109375
+                "left": 217.765625,
+                "top": 618.734375
             },
             "post_job_actions": {
                 "HideDatasetActionreport_json": {
@@ -397,14 +289,110 @@
                 }
             ]
         },
+        "9": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
+            "errors": null,
+            "id": 9,
+            "input_connections": {
+                "components_1|param_type|component_value": {
+                    "id": 4,
+                    "output_name": "output"
+                },
+                "components_3|param_type|component_value": {
+                    "id": 5,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Compose text parameter value",
+            "outputs": [
+                {
+                    "name": "out1",
+                    "type": "expression.json"
+                }
+            ],
+            "position": {
+                "left": 1331.390625,
+                "top": 45.046875
+            },
+            "post_job_actions": {
+                "HideDatasetActionout1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out1"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
+            "tool_shed_repository": {
+                "changeset_revision": "e188c9826e0f",
+                "name": "compose_text_param",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \"( ( DP4[2] + DP4[3] ) >= ( \"}}, {\"__index__\": 1, \"param_type\": {\"select_param_type\": \"float\", \"__current_case__\": 2, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \" * DP ) ) & ( ( DP4[2] + DP4[3] ) <= ( \"}}, {\"__index__\": 3, \"param_type\": {\"select_param_type\": \"float\", \"__current_case__\": 2, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 4, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \" * DP ) )\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.1.1",
+            "type": "tool",
+            "uuid": "d163b9b9-ee13-4b2b-8d64-b6d77758fac9",
+            "workflow_outputs": []
+        },
         "10": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
             "errors": null,
             "id": 10,
             "input_connections": {
+                "components_1|param_type|component_value": {
+                    "id": 6,
+                    "output_name": "output"
+                },
+                "components_3|param_type|component_value": {
+                    "id": 7,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Compose text parameter value",
+            "outputs": [
+                {
+                    "name": "out1",
+                    "type": "expression.json"
+                }
+            ],
+            "position": {
+                "left": 2400.96875,
+                "top": 39.765625
+            },
+            "post_job_actions": {
+                "HideDatasetActionout1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out1"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
+            "tool_shed_repository": {
+                "changeset_revision": "e188c9826e0f",
+                "name": "compose_text_param",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \"( DP > \"}}, {\"__index__\": 1, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 1, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \" ) & ( ( AF * DP ) >= ( \"}}, {\"__index__\": 3, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 1, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 4, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \" - 0.5 ) )\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.1.1",
+            "type": "tool",
+            "uuid": "258a1a99-145b-42a0-b858-5220b4199946",
+            "workflow_outputs": []
+        },
+        "11": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2",
+            "errors": null,
+            "id": 11,
+            "input_connections": {
                 "fastq_input|fastq_input1": {
-                    "id": 9,
+                    "id": 8,
                     "output_name": "output_paired_coll"
                 },
                 "reference_source|ref_file": {
@@ -422,19 +410,13 @@
                 }
             ],
             "position": {
-                "bottom": 555.0625,
-                "height": 205.125,
-                "left": 120.390625,
-                "right": 320.390625,
-                "top": 349.9375,
-                "width": 200,
-                "x": 120.390625,
-                "y": 349.9375
+                "left": 455.09375,
+                "top": 352.5625
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2",
             "tool_shed_repository": {
-                "changeset_revision": "64f11cf59c6e",
+                "changeset_revision": "e188dc7a68e6",
                 "name": "bwa",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -451,14 +433,14 @@
                 }
             ]
         },
-        "11": {
+        "12": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.9+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.15.1+galaxy0",
             "errors": null,
-            "id": 11,
+            "id": 12,
             "input_connections": {
                 "input": {
-                    "id": 10,
+                    "id": 11,
                     "output_name": "bam_output"
                 }
             },
@@ -472,14 +454,8 @@
                 }
             ],
             "position": {
-                "bottom": 701.25,
-                "height": 133.953125,
-                "left": 329.984375,
-                "right": 529.984375,
-                "top": 567.296875,
-                "width": 200,
-                "x": 329.984375,
-                "y": 567.296875
+                "left": 664.6875,
+                "top": 569.921875
             },
             "post_job_actions": {
                 "RenameDatasetActionoutputsam": {
@@ -490,15 +466,15 @@
                     "output_name": "outputsam"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.9+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.15.1+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "bf328cec6a42",
+                "changeset_revision": "5826298f6a73",
                 "name": "samtools_view",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"mode\": {\"outtype\": \"selected_reads\", \"__current_case__\": 1, \"filter_config\": {\"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cond_rg\": {\"select_rg\": \"no\", \"__current_case__\": 0}, \"quality\": \"20\", \"library\": \"\", \"cigarcons\": null, \"inclusive_filter\": [\"1\"], \"exclusive_filter\": [\"4\", \"8\", \"256\"], \"exclusive_filter_all\": null}, \"subsample_config\": {\"subsampling_mode\": {\"select_subsample\": \"fraction\", \"__current_case__\": 0, \"factor\": \"1.0\", \"seed\": null}}, \"output_options\": {\"reads_report_type\": \"retained\", \"__current_case__\": 0, \"complementary_output\": \"false\", \"adv_output\": {\"readtags\": [], \"collapsecigar\": \"false\"}, \"output_format\": {\"oformat\": \"bam\", \"__current_case__\": 2}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.9+galaxy2",
+            "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"mode\": {\"outtype\": \"selected_reads\", \"__current_case__\": 1, \"filter_config\": {\"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cond_rg\": {\"select_rg\": \"no\", \"__current_case__\": 0}, \"quality\": \"20\", \"library\": \"\", \"cigarcons\": null, \"inclusive_filter\": [\"1\"], \"exclusive_filter\": [\"4\", \"8\", \"256\"], \"exclusive_filter_all\": null, \"tag\": null, \"qname_file\": {\"__class__\": \"RuntimeValue\"}}, \"subsample_config\": {\"subsampling_mode\": {\"select_subsample\": \"fraction\", \"__current_case__\": 0, \"factor\": \"1.0\", \"seed\": null}}, \"output_options\": {\"reads_report_type\": \"retained\", \"__current_case__\": 0, \"complementary_output\": \"false\", \"adv_output\": {\"readtags\": [], \"collapsecigar\": \"false\"}, \"output_format\": {\"oformat\": \"bam\", \"__current_case__\": 2}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.15.1+galaxy0",
             "type": "tool",
             "uuid": "2f7744df-3811-4b7f-8f1f-cf8bf0ec7a0b",
             "workflow_outputs": [
@@ -509,56 +485,6 @@
                 }
             ]
         },
-        "12": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.2+galaxy2",
-            "errors": null,
-            "id": 12,
-            "input_connections": {
-                "input": {
-                    "id": 11,
-                    "output_name": "outputsam"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Samtools stats",
-            "outputs": [
-                {
-                    "name": "output",
-                    "type": "tabular"
-                }
-            ],
-            "position": {
-                "bottom": 1054.234375,
-                "height": 133.953125,
-                "left": 584.109375,
-                "right": 784.109375,
-                "top": 920.28125,
-                "width": 200,
-                "x": 584.109375,
-                "y": 920.28125
-            },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.2+galaxy2",
-            "tool_shed_repository": {
-                "changeset_revision": "145f6d74ff5e",
-                "name": "samtools_stats",
-                "owner": "devteam",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cov_threshold\": null, \"coverage_cond\": {\"coverage_select\": \"no\", \"__current_case__\": 0}, \"filter_by_flags\": {\"filter_flags\": \"nofilter\", \"__current_case__\": 1}, \"gc_depth\": null, \"input\": {\"__class__\": \"ConnectedValue\"}, \"insert_size\": null, \"most_inserts\": null, \"read_length\": null, \"remove_dups\": \"false\", \"remove_overlaps\": \"false\", \"sparse\": \"false\", \"split_output_cond\": {\"split_output_selector\": \"no\", \"__current_case__\": 0}, \"trim_quality\": null, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.0.2+galaxy2",
-            "type": "tool",
-            "uuid": "271efb08-46c0-4801-9869-b9948dfdebb4",
-            "workflow_outputs": [
-                {
-                    "label": "mapped_reads_stats",
-                    "output_name": "output",
-                    "uuid": "7d923dc5-84b5-4f32-90ce-5d97b87ec3e1"
-                }
-            ]
-        },
         "13": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_viterbi/lofreq_viterbi/2.1.5+galaxy0",
@@ -566,7 +492,7 @@
             "id": 13,
             "input_connections": {
                 "reads": {
-                    "id": 11,
+                    "id": 12,
                     "output_name": "outputsam"
                 },
                 "reference_source|ref": {
@@ -584,14 +510,8 @@
                 }
             ],
             "position": {
-                "bottom": 798.640625,
-                "height": 184.734375,
-                "left": 558.796875,
-                "right": 758.796875,
-                "top": 613.90625,
-                "width": 200,
-                "x": 558.796875,
-                "y": 613.90625
+                "left": 893.5,
+                "top": 616.53125
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_viterbi/lofreq_viterbi/2.1.5+galaxy0",
@@ -615,9 +535,53 @@
         },
         "14": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.4",
             "errors": null,
             "id": 14,
+            "input_connections": {
+                "input": {
+                    "id": 12,
+                    "output_name": "outputsam"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Samtools stats",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 918.8125,
+                "top": 922.90625
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.4",
+            "tool_shed_repository": {
+                "changeset_revision": "3a0efe14891f",
+                "name": "samtools_stats",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cov_threshold\": null, \"coverage_cond\": {\"coverage_select\": \"no\", \"__current_case__\": 0}, \"filter_by_flags\": {\"filter_flags\": \"nofilter\", \"__current_case__\": 1}, \"gc_depth\": null, \"input\": {\"__class__\": \"ConnectedValue\"}, \"insert_size\": null, \"most_inserts\": null, \"read_group\": null, \"read_length\": null, \"remove_dups\": \"false\", \"remove_overlaps\": \"false\", \"sparse\": \"false\", \"split_output_cond\": {\"split_output_selector\": \"no\", \"__current_case__\": 0}, \"trim_quality\": null, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.0.4",
+            "type": "tool",
+            "uuid": "271efb08-46c0-4801-9869-b9948dfdebb4",
+            "workflow_outputs": [
+                {
+                    "label": "mapped_reads_stats",
+                    "output_name": "output",
+                    "uuid": "7d923dc5-84b5-4f32-90ce-5d97b87ec3e1"
+                }
+            ]
+        },
+        "15": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy1",
+            "errors": null,
+            "id": 15,
             "input_connections": {
                 "reads": {
                     "id": 13,
@@ -638,25 +602,19 @@
                 }
             ],
             "position": {
-                "bottom": 800.15625,
-                "height": 184.734375,
-                "left": 788.171875,
-                "right": 988.171875,
-                "top": 615.421875,
-                "width": 200,
-                "x": 788.171875,
-                "y": 615.421875
+                "left": 1122.875,
+                "top": 618.046875
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "426d707dfc47",
+                "changeset_revision": "971e07ca4456",
                 "name": "lofreq_indelqual",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"reads\": {\"__class__\": \"ConnectedValue\"}, \"strategy\": {\"selector\": \"dindel\", \"__current_case__\": 1, \"reference_source\": {\"ref_selector\": \"history\", \"__current_case__\": 1, \"ref\": {\"__class__\": \"ConnectedValue\"}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.1.5+galaxy0",
+            "tool_version": "2.1.5+galaxy1",
             "type": "tool",
             "uuid": "70897728-2744-4a82-9b7d-38190594fec6",
             "workflow_outputs": [
@@ -667,18 +625,18 @@
                 }
             ]
         },
-        "15": {
+        "16": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy4",
             "errors": null,
-            "id": 15,
+            "id": 16,
             "input_connections": {
                 "amplicons|amplicon_info": {
                     "id": 3,
                     "output_name": "output"
                 },
                 "input_bam": {
-                    "id": 14,
+                    "id": 15,
                     "output_name": "output"
                 },
                 "primer|input_bed": {
@@ -696,14 +654,8 @@
                 }
             ],
             "position": {
-                "bottom": 557.046875,
-                "height": 194.734375,
-                "left": 990.984375,
-                "right": 1190.984375,
-                "top": 362.3125,
-                "width": 200,
-                "x": 990.984375,
-                "y": 362.3125
+                "left": 1325.6875,
+                "top": 364.9375
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput_bam": {
@@ -714,15 +666,15 @@
                     "output_name": "output_bam"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy4",
             "tool_shed_repository": {
-                "changeset_revision": "c092052ed673",
+                "changeset_revision": "5671e1d3d5ee",
                 "name": "ivar_trim",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"amplicons\": {\"filter_by\": \"yes\", \"__current_case__\": 1, \"amplicon_info\": {\"__class__\": \"ConnectedValue\"}}, \"inc_primers\": \"true\", \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"min_len\": \"1\", \"min_qual\": \"0\", \"primer\": {\"source\": \"history\", \"__current_case__\": 0, \"input_bed\": {\"__class__\": \"ConnectedValue\"}}, \"primer_pos_wiggle\": \"0\", \"window_width\": \"4\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.3.1+galaxy2",
+            "tool_version": "1.3.1+galaxy4",
             "type": "tool",
             "uuid": "7730e635-853f-4f9f-9451-bffbe6aedd15",
             "workflow_outputs": [
@@ -733,14 +685,14 @@
                 }
             ]
         },
-        "16": {
+        "17": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy2",
             "errors": null,
-            "id": 16,
+            "id": 17,
             "input_connections": {
                 "reads": {
-                    "id": 15,
+                    "id": 16,
                     "output_name": "output_bam"
                 },
                 "reference_source|ref": {
@@ -758,25 +710,19 @@
                 }
             ],
             "position": {
-                "bottom": 668.828125,
-                "height": 143.953125,
-                "left": 1225.75,
-                "right": 1425.75,
-                "top": 524.875,
-                "width": 200,
-                "x": 1225.75,
-                "y": 524.875
+                "left": 1560.453125,
+                "top": 527.5
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy2",
             "tool_shed_repository": {
-                "changeset_revision": "e1461b5c52a0",
+                "changeset_revision": "4805fe3d8fda",
                 "name": "lofreq_call",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"call_control\": {\"set_call_options\": \"yes\", \"__current_case__\": 1, \"coverage\": {\"min_cov\": \"5\", \"max_depth\": \"1000000\"}, \"pe\": {\"use_orphan\": \"false\"}, \"bc_quals\": {\"min_bq\": \"30\", \"min_alt_bq\": \"30\", \"alt_bq\": {\"modify\": \"\", \"__current_case__\": 0}}, \"align_quals\": {\"alnqual\": {\"use_alnqual\": \"\", \"__current_case__\": 0, \"alnqual_choice\": {\"alnquals_to_use\": \"\", \"__current_case__\": 1, \"extended_baq\": \"true\"}}}, \"map_quals\": {\"min_mq\": \"20\", \"use_mq\": {\"no_mq\": \"\", \"__current_case__\": 0, \"max_mq\": \"255\"}}, \"source_qual\": {\"use_src_qual\": {\"src_qual\": \"\", \"__current_case__\": 0}}, \"joint_qual\": {\"min_jq\": \"0\", \"min_alt_jq\": \"0\", \"def_alt_jq\": \"0\"}}, \"filter_control\": {\"filter_type\": \"set_custom\", \"__current_case__\": 3, \"sig\": \"0.0005\", \"bonf\": \"0\", \"others\": \"false\"}, \"reads\": {\"__class__\": \"ConnectedValue\"}, \"reference_source\": {\"ref_selector\": \"history\", \"__current_case__\": 1, \"ref\": {\"__class__\": \"ConnectedValue\"}}, \"regions\": {\"restrict_to_region\": \"genome\", \"__current_case__\": 0}, \"variant_types\": \"--call-indels\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.1.5+galaxy1",
+            "tool_version": "2.1.5+galaxy2",
             "type": "tool",
             "uuid": "422c7955-7768-4745-95db-b6882f37cd4b",
             "workflow_outputs": [
@@ -787,14 +733,14 @@
                 }
             ]
         },
-        "17": {
+        "18": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/qualimap_bamqc/qualimap_bamqc/2.2.2d+galaxy3",
             "errors": null,
-            "id": 17,
+            "id": 18,
             "input_connections": {
                 "input1": {
-                    "id": 15,
+                    "id": 16,
                     "output_name": "output_bam"
                 }
             },
@@ -812,14 +758,8 @@
                 }
             ],
             "position": {
-                "bottom": 954.109375,
-                "height": 184.734375,
-                "left": 1162.859375,
-                "right": 1362.859375,
-                "top": 769.375,
-                "width": 200,
-                "x": 1162.859375,
-                "y": 769.375
+                "left": 1497.5625,
+                "top": 772.0
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/qualimap_bamqc/qualimap_bamqc/2.2.2d+galaxy3",
@@ -846,60 +786,6 @@
                 }
             ]
         },
-        "18": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
-            "errors": null,
-            "id": 18,
-            "input_connections": {
-                "components_1|param_type|component_value": {
-                    "id": 6,
-                    "output_name": "output"
-                },
-                "components_3|param_type|component_value": {
-                    "id": 7,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Compose text parameter value",
-            "outputs": [
-                {
-                    "name": "out1",
-                    "type": "expression.json"
-                }
-            ],
-            "position": {
-                "bottom": 262.65625,
-                "height": 225.515625,
-                "left": 2066.265625,
-                "right": 2266.265625,
-                "top": 37.140625,
-                "width": 200,
-                "x": 2066.265625,
-                "y": 37.140625
-            },
-            "post_job_actions": {
-                "HideDatasetActionout1": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "out1"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
-            "tool_shed_repository": {
-                "changeset_revision": "e188c9826e0f",
-                "name": "compose_text_param",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \"( DP > \"}}, {\"__index__\": 1, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 1, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \" ) & ( ( AF * DP ) >= ( \"}}, {\"__index__\": 3, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 1, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 4, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \" - 0.5 ) )\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.1.1",
-            "type": "tool",
-            "uuid": "258a1a99-145b-42a0-b858-5220b4199946",
-            "workflow_outputs": []
-        },
         "19": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1",
@@ -907,20 +793,15 @@
             "id": 19,
             "input_connections": {
                 "filter_expression|expr": {
-                    "id": 8,
+                    "id": 9,
                     "output_name": "out1"
                 },
                 "input": {
-                    "id": 16,
+                    "id": 17,
                     "output_name": "variants"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool SnpSift Filter",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "SnpSift Filter",
             "outputs": [
@@ -930,14 +811,8 @@
                 }
             ],
             "position": {
-                "bottom": 487.984375,
-                "height": 164.34375,
-                "left": 1418.484375,
-                "right": 1618.484375,
-                "top": 323.640625,
-                "width": 200,
-                "x": 1418.484375,
-                "y": 323.640625
+                "left": 1753.1875,
+                "top": 326.265625
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1",
@@ -947,7 +822,7 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filter_expression\": {\"type\": \"simple\", \"__current_case__\": 0, \"expr\": {\"__class__\": \"ConnectedValue\"}}, \"filtering\": {\"mode\": \"entries\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"inverse\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"filter_expression\": {\"type\": \"simple\", \"__current_case__\": 0, \"expr\": {\"__class__\": \"ConnectedValue\"}}, \"filtering\": {\"mode\": \"entries\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"inverse\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "4.3+t.galaxy1",
             "type": "tool",
             "uuid": "a2b784b0-28c1-45e3-93b8-d1d9d598de01",
@@ -966,11 +841,11 @@
             "id": 20,
             "input_connections": {
                 "filter_expression|expr": {
-                    "id": 18,
+                    "id": 10,
                     "output_name": "out1"
                 },
                 "input": {
-                    "id": 16,
+                    "id": 17,
                     "output_name": "variants"
                 }
             },
@@ -984,14 +859,8 @@
                 }
             ],
             "position": {
-                "bottom": 693.265625,
-                "height": 164.34375,
-                "left": 2314,
-                "right": 2514,
-                "top": 528.921875,
-                "width": 200,
-                "x": 2314,
-                "y": 528.921875
+                "left": 2648.703125,
+                "top": 531.546875
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1",
@@ -1020,16 +889,11 @@
             "id": 21,
             "input_connections": {
                 "input": {
-                    "id": 17,
+                    "id": 18,
                     "output_name": "raw_data"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Filter failed datasets",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Filter failed datasets",
             "outputs": [
@@ -1039,14 +903,8 @@
                 }
             ],
             "position": {
-                "bottom": 915.125,
-                "height": 133.953125,
-                "left": 1395.515625,
-                "right": 1595.515625,
-                "top": 781.171875,
-                "width": 200,
-                "x": 1395.515625,
-                "y": 781.171875
+                "left": 1730.21875,
+                "top": 783.796875
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1056,7 +914,7 @@
                 }
             },
             "tool_id": "__FILTER_FAILED_DATASETS__",
-            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
             "uuid": "e4e04a37-f4bf-41d7-9470-5c96125ebc49",
@@ -1064,60 +922,16 @@
         },
         "22": {
             "annotation": "",
-            "content_id": "__FLATTEN__",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.1+galaxy3",
             "errors": null,
             "id": 22,
-            "input_connections": {
-                "input": {
-                    "id": 21,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Flatten Collection",
-            "outputs": [
-                {
-                    "name": "output",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "bottom": 920.828125,
-                "height": 133.953125,
-                "left": 1620.953125,
-                "right": 1820.953125,
-                "top": 786.875,
-                "width": 200,
-                "x": 1620.953125,
-                "y": 786.875
-            },
-            "post_job_actions": {},
-            "tool_id": "__FLATTEN__",
-            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"join_identifier\": \"_\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.0",
-            "type": "tool",
-            "uuid": "396c9b85-8ec7-405a-a742-5b47e40cf0de",
-            "workflow_outputs": [
-                {
-                    "label": "bamqc_raw_output_flattened",
-                    "output_name": "output",
-                    "uuid": "b3942cb8-ac12-4b37-88d2-6c25dc58b636"
-                }
-            ]
-        },
-        "23": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.1+galaxy2",
-            "errors": null,
-            "id": 23,
             "input_connections": {
                 "amplicons|amplicon_info": {
                     "id": 3,
                     "output_name": "output"
                 },
                 "input_bam": {
-                    "id": 15,
+                    "id": 16,
                     "output_name": "output_bam"
                 },
                 "input_bed": {
@@ -1139,25 +953,19 @@
                 }
             ],
             "position": {
-                "bottom": 312.25,
-                "height": 265.90625,
-                "left": 1614.84375,
-                "right": 1814.84375,
-                "top": 46.34375,
-                "width": 200,
-                "x": 1614.84375,
-                "y": 46.34375
+                "left": 1949.546875,
+                "top": 48.96875
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.1+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.1+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "8d36959b000d",
+                "changeset_revision": "ee29337f905c",
                 "name": "ivar_removereads",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"amplicons\": {\"computed\": \"no\", \"__current_case__\": 1, \"amplicon_info\": {\"__class__\": \"ConnectedValue\"}}, \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"input_bed\": {\"__class__\": \"ConnectedValue\"}, \"variants_tsv\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.3.1+galaxy2",
+            "tool_version": "1.3.1+galaxy3",
             "type": "tool",
             "uuid": "af7d3b75-d16c-43c7-82e4-3f1388edd22c",
             "workflow_outputs": [
@@ -1168,22 +976,108 @@
                 }
             ]
         },
+        "23": {
+            "annotation": "",
+            "content_id": "__FLATTEN__",
+            "errors": null,
+            "id": 23,
+            "input_connections": {
+                "input": {
+                    "id": 21,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Flatten collection",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1955.65625,
+                "top": 789.5
+            },
+            "post_job_actions": {},
+            "tool_id": "__FLATTEN__",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"join_identifier\": \"_\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "396c9b85-8ec7-405a-a742-5b47e40cf0de",
+            "workflow_outputs": [
+                {
+                    "label": "bamqc_raw_output_flattened",
+                    "output_name": "output",
+                    "uuid": "b3942cb8-ac12-4b37-88d2-6c25dc58b636"
+                }
+            ]
+        },
         "24": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy2",
             "errors": null,
             "id": 24,
             "input_connections": {
+                "reads": {
+                    "id": 22,
+                    "output_name": "output_bam"
+                },
+                "reference_source|ref": {
+                    "id": 1,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Call variants",
+            "outputs": [
+                {
+                    "name": "variants",
+                    "type": "vcf"
+                }
+            ],
+            "position": {
+                "left": 2204.984375,
+                "top": 334.296875
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "4805fe3d8fda",
+                "name": "lofreq_call",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"call_control\": {\"set_call_options\": \"yes\", \"__current_case__\": 1, \"coverage\": {\"min_cov\": \"5\", \"max_depth\": \"1000000\"}, \"pe\": {\"use_orphan\": \"false\"}, \"bc_quals\": {\"min_bq\": \"30\", \"min_alt_bq\": \"30\", \"alt_bq\": {\"modify\": \"\", \"__current_case__\": 0}}, \"align_quals\": {\"alnqual\": {\"use_alnqual\": \"\", \"__current_case__\": 0, \"alnqual_choice\": {\"alnquals_to_use\": \"\", \"__current_case__\": 1, \"extended_baq\": \"true\"}}}, \"map_quals\": {\"min_mq\": \"20\", \"use_mq\": {\"no_mq\": \"\", \"__current_case__\": 0, \"max_mq\": \"255\"}}, \"source_qual\": {\"use_src_qual\": {\"src_qual\": \"\", \"__current_case__\": 0}}, \"joint_qual\": {\"min_jq\": \"0\", \"min_alt_jq\": \"0\", \"def_alt_jq\": \"0\"}}, \"filter_control\": {\"filter_type\": \"set_custom\", \"__current_case__\": 3, \"sig\": \"0.0005\", \"bonf\": \"0\", \"others\": \"false\"}, \"reads\": {\"__class__\": \"ConnectedValue\"}, \"reference_source\": {\"ref_selector\": \"history\", \"__current_case__\": 1, \"ref\": {\"__class__\": \"ConnectedValue\"}}, \"regions\": {\"restrict_to_region\": \"genome\", \"__current_case__\": 0}, \"variant_types\": \"--call-indels\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.1.5+galaxy2",
+            "type": "tool",
+            "uuid": "bef93d5b-c023-459c-888c-ac3382515322",
+            "workflow_outputs": [
+                {
+                    "label": "preliminary_variants_2",
+                    "output_name": "variants",
+                    "uuid": "6a59b687-340f-4ef6-b908-31fd69bd081e"
+                }
+            ]
+        },
+        "25": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy0",
+            "errors": null,
+            "id": 25,
+            "input_connections": {
                 "results_0|software_cond|input": {
-                    "id": 9,
+                    "id": 8,
                     "output_name": "report_json"
                 },
                 "results_1|software_cond|output_0|type|input": {
-                    "id": 12,
+                    "id": 14,
                     "output_name": "output"
                 },
                 "results_2|software_cond|input": {
-                    "id": 22,
+                    "id": 23,
                     "output_name": "output"
                 }
             },
@@ -1205,14 +1099,8 @@
                 }
             ],
             "position": {
-                "bottom": 1239.828125,
-                "height": 316.6875,
-                "left": 1851.8125,
-                "right": 2051.8125,
-                "top": 923.140625,
-                "width": 200,
-                "x": 1851.8125,
-                "y": 923.140625
+                "left": 2186.515625,
+                "top": 925.765625
             },
             "post_job_actions": {
                 "HideDatasetActionstats": {
@@ -1252,76 +1140,35 @@
                 }
             ]
         },
-        "25": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy1",
-            "errors": null,
-            "id": 25,
-            "input_connections": {
-                "reads": {
-                    "id": 23,
-                    "output_name": "output_bam"
-                },
-                "reference_source|ref": {
-                    "id": 1,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Call variants",
-            "outputs": [
-                {
-                    "name": "variants",
-                    "type": "vcf"
-                }
-            ],
-            "position": {
-                "bottom": 475.625,
-                "height": 143.953125,
-                "left": 1870.28125,
-                "right": 2070.28125,
-                "top": 331.671875,
-                "width": 200,
-                "x": 1870.28125,
-                "y": 331.671875
-            },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy1",
-            "tool_shed_repository": {
-                "changeset_revision": "e1461b5c52a0",
-                "name": "lofreq_call",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"call_control\": {\"set_call_options\": \"yes\", \"__current_case__\": 1, \"coverage\": {\"min_cov\": \"5\", \"max_depth\": \"1000000\"}, \"pe\": {\"use_orphan\": \"false\"}, \"bc_quals\": {\"min_bq\": \"30\", \"min_alt_bq\": \"30\", \"alt_bq\": {\"modify\": \"\", \"__current_case__\": 0}}, \"align_quals\": {\"alnqual\": {\"use_alnqual\": \"\", \"__current_case__\": 0, \"alnqual_choice\": {\"alnquals_to_use\": \"\", \"__current_case__\": 1, \"extended_baq\": \"true\"}}}, \"map_quals\": {\"min_mq\": \"20\", \"use_mq\": {\"no_mq\": \"\", \"__current_case__\": 0, \"max_mq\": \"255\"}}, \"source_qual\": {\"use_src_qual\": {\"src_qual\": \"\", \"__current_case__\": 0}}, \"joint_qual\": {\"min_jq\": \"0\", \"min_alt_jq\": \"0\", \"def_alt_jq\": \"0\"}}, \"filter_control\": {\"filter_type\": \"set_custom\", \"__current_case__\": 3, \"sig\": \"0.0005\", \"bonf\": \"0\", \"others\": \"false\"}, \"reads\": {\"__class__\": \"ConnectedValue\"}, \"reference_source\": {\"ref_selector\": \"history\", \"__current_case__\": 1, \"ref\": {\"__class__\": \"ConnectedValue\"}}, \"regions\": {\"restrict_to_region\": \"genome\", \"__current_case__\": 0}, \"variant_types\": \"--call-indels\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.1.5+galaxy1",
-            "type": "tool",
-            "uuid": "bef93d5b-c023-459c-888c-ac3382515322",
-            "workflow_outputs": [
-                {
-                    "label": "preliminary_variants_2",
-                    "output_name": "variants",
-                    "uuid": "6a59b687-340f-4ef6-b908-31fd69bd081e"
-                }
-            ]
-        },
         "26": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.10",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.15.1+galaxy2",
             "errors": null,
             "id": 26,
             "input_connections": {
                 "input_file": {
-                    "id": 16,
+                    "id": 17,
                     "output_name": "variants"
                 },
                 "sec_annofile|annofile|annotations": {
-                    "id": 25,
+                    "id": 24,
                     "output_name": "variants"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool bcftools annotate",
+                    "name": "sec_annotate"
+                },
+                {
+                    "description": "runtime parameter for tool bcftools annotate",
+                    "name": "sec_annotate"
+                },
+                {
+                    "description": "runtime parameter for tool bcftools annotate",
+                    "name": "sec_restrict"
+                }
+            ],
             "label": null,
             "name": "bcftools annotate",
             "outputs": [
@@ -1331,25 +1178,19 @@
                 }
             ],
             "position": {
-                "bottom": 911.9375,
-                "height": 225.125,
-                "left": 2074.515625,
-                "right": 2274.515625,
-                "top": 686.8125,
-                "width": 200,
-                "x": 2074.515625,
-                "y": 686.8125
+                "left": 2409.21875,
+                "top": 689.4375
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.10",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.15.1+galaxy2",
             "tool_shed_repository": {
-                "changeset_revision": "2436e3bef247",
+                "changeset_revision": "b7ea370b8f5d",
                 "name": "bcftools_annotate",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_file\": {\"__class__\": \"RuntimeValue\"}, \"output_type\": \"v\", \"sec_annofile\": {\"columns\": \"QUAL,INFO\", \"annofile\": {\"anno_fmt\": \"vcf\", \"__current_case__\": 1, \"annotations\": {\"__class__\": \"ConnectedValue\"}}, \"mark_sites\": \"-AmpliconBias\", \"set_id\": \"\"}, \"sec_annotate\": {\"remove\": \"\", \"rename_chrs\": {\"__class__\": \"RuntimeValue\"}}, \"sec_restrict\": {\"include\": \"\", \"exclude\": \"\", \"collapse\": null, \"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"samples\": \"\", \"invert_samples\": \"false\", \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.10",
+            "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_type\": \"v\", \"sec_annofile\": {\"columns\": \"QUAL,INFO\", \"annofile\": {\"anno_fmt\": \"vcf\", \"__current_case__\": 1, \"annotations\": {\"__class__\": \"ConnectedValue\"}}, \"mark_sites\": \"-AmpliconBias\", \"min_overlap\": \"\", \"set_id\": \"\"}, \"sec_annotate\": {\"remove\": \"\", \"rename_chrs\": {\"__class__\": \"RuntimeValue\"}, \"rename_annots\": {\"__class__\": \"RuntimeValue\"}}, \"sec_restrict\": {\"include\": \"\", \"exclude\": \"\", \"collapse\": null, \"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"regions_overlap\": null, \"samples\": \"\", \"invert_samples\": \"false\", \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.15.1+galaxy2",
             "type": "tool",
             "uuid": "c466b7da-f50c-4093-9eb5-c014ba41c1b8",
             "workflow_outputs": [
@@ -1367,11 +1208,11 @@
             "id": 27,
             "input_connections": {
                 "filter_expression|expr": {
-                    "id": 18,
+                    "id": 10,
                     "output_name": "out1"
                 },
                 "input": {
-                    "id": 25,
+                    "id": 24,
                     "output_name": "variants"
                 }
             },
@@ -1385,14 +1226,8 @@
                 }
             ],
             "position": {
-                "bottom": 510.765625,
-                "height": 164.34375,
-                "left": 2321,
-                "right": 2521,
-                "top": 346.421875,
-                "width": 200,
-                "x": 2321,
-                "y": 346.421875
+                "left": 2655.703125,
+                "top": 349.046875
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1",
@@ -1443,14 +1278,8 @@
                 }
             ],
             "position": {
-                "bottom": 693.109375,
-                "height": 194.734375,
-                "left": 2551.15625,
-                "right": 2751.15625,
-                "top": 498.375,
-                "width": 200,
-                "x": 2551.15625,
-                "y": 498.375
+                "left": 2885.859375,
+                "top": 501.0
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/vcfvcfintersect/vcfvcfintersect/1.0.0_rc3+galaxy0",
@@ -1474,7 +1303,7 @@
         },
         "29": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.10",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.15.1+galaxy2",
             "errors": null,
             "id": 29,
             "input_connections": {
@@ -1487,7 +1316,20 @@
                     "output_name": "out_file1"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool bcftools annotate",
+                    "name": "sec_annotate"
+                },
+                {
+                    "description": "runtime parameter for tool bcftools annotate",
+                    "name": "sec_annotate"
+                },
+                {
+                    "description": "runtime parameter for tool bcftools annotate",
+                    "name": "sec_restrict"
+                }
+            ],
             "label": null,
             "name": "bcftools annotate",
             "outputs": [
@@ -1497,25 +1339,19 @@
                 }
             ],
             "position": {
-                "bottom": 878.78125,
-                "height": 225.125,
-                "left": 2778.25,
-                "right": 2978.25,
-                "top": 653.65625,
-                "width": 200,
-                "x": 2778.25,
-                "y": 653.65625
+                "left": 3112.953125,
+                "top": 656.28125
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.10",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.15.1+galaxy2",
             "tool_shed_repository": {
-                "changeset_revision": "2436e3bef247",
+                "changeset_revision": "b7ea370b8f5d",
                 "name": "bcftools_annotate",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_type\": \"v\", \"sec_annofile\": {\"columns\": \"QUAL,INFO\", \"annofile\": {\"anno_fmt\": \"vcf\", \"__current_case__\": 1, \"annotations\": {\"__class__\": \"ConnectedValue\"}}, \"mark_sites\": \"+AmpliconBias\", \"set_id\": \"\"}, \"sec_annotate\": {\"remove\": \"\", \"rename_chrs\": {\"__class__\": \"RuntimeValue\"}}, \"sec_restrict\": {\"include\": \"\", \"exclude\": \"\", \"collapse\": null, \"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"samples\": \"\", \"invert_samples\": \"false\", \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.10",
+            "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_type\": \"v\", \"sec_annofile\": {\"columns\": \"QUAL,INFO\", \"annofile\": {\"anno_fmt\": \"vcf\", \"__current_case__\": 1, \"annotations\": {\"__class__\": \"ConnectedValue\"}}, \"mark_sites\": \"+AmpliconBias\", \"min_overlap\": \"\", \"set_id\": \"\"}, \"sec_annotate\": {\"remove\": \"\", \"rename_chrs\": {\"__class__\": \"RuntimeValue\"}, \"rename_annots\": {\"__class__\": \"RuntimeValue\"}}, \"sec_restrict\": {\"include\": \"\", \"exclude\": \"\", \"collapse\": null, \"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"regions_overlap\": null, \"samples\": \"\", \"invert_samples\": \"false\", \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.15.1+galaxy2",
             "type": "tool",
             "uuid": "c466b7da-f50c-4093-9eb5-c014ba41c1b7",
             "workflow_outputs": [
@@ -1547,19 +1383,13 @@
                 }
             ],
             "position": {
-                "bottom": 856.484375,
-                "height": 113.5625,
-                "left": 3003.578125,
-                "right": 3203.578125,
-                "top": 742.921875,
-                "width": 200,
-                "x": 3003.578125,
-                "y": 742.921875
+                "left": 3338.28125,
+                "top": 745.546875
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.2",
             "tool_shed_repository": {
-                "changeset_revision": "ddf54b12c295",
+                "changeset_revision": "d698c222f354",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1587,7 +1417,16 @@
                     "output_name": "outfile"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool SnpEff eff:",
+                    "name": "intervals"
+                },
+                {
+                    "description": "runtime parameter for tool SnpEff eff:",
+                    "name": "transcripts"
+                }
+            ],
             "label": "SnpEff eff covid19 version",
             "name": "SnpEff eff:",
             "outputs": [
@@ -1601,14 +1440,8 @@
                 }
             ],
             "position": {
-                "bottom": 903.03125,
-                "height": 306.6875,
-                "left": 3231.546875,
-                "right": 3431.546875,
-                "top": 596.34375,
-                "width": 200,
-                "x": 3231.546875,
-                "y": 596.34375
+                "left": 3566.25,
+                "top": 598.96875
             },
             "post_job_actions": {
                 "RenameDatasetActionsnpeff_output": {
@@ -1664,14 +1497,8 @@
                 }
             ],
             "position": {
-                "bottom": 725.5625,
-                "height": 113.5625,
-                "left": 3467.796875,
-                "right": 3667.796875,
-                "top": 612,
-                "width": 200,
-                "x": 3467.796875,
-                "y": 612
+                "left": 3802.5,
+                "top": 614.625
             },
             "post_job_actions": {
                 "RenameDatasetActionoutvcf": {

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: variation analysis on ARTIC PE data",
-    "release": "0.7",
+    "release": "0.8",
     "steps": {
         "0": {
             "annotation": "Illumina reads from ARTIC assay with fastqsanger encoding",
@@ -627,7 +627,7 @@
         },
         "16": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy4",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy5",
             "errors": null,
             "id": 16,
             "input_connections": {
@@ -666,15 +666,15 @@
                     "output_name": "output_bam"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy4",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy5",
             "tool_shed_repository": {
-                "changeset_revision": "5671e1d3d5ee",
+                "changeset_revision": "e3bb03cf207a",
                 "name": "ivar_trim",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"amplicons\": {\"filter_by\": \"yes\", \"__current_case__\": 1, \"amplicon_info\": {\"__class__\": \"ConnectedValue\"}}, \"inc_primers\": \"true\", \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"min_len\": \"1\", \"min_qual\": \"0\", \"primer\": {\"source\": \"history\", \"__current_case__\": 0, \"input_bed\": {\"__class__\": \"ConnectedValue\"}}, \"primer_pos_wiggle\": \"0\", \"window_width\": \"4\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.3.1+galaxy4",
+            "tool_version": "1.3.1+galaxy5",
             "type": "tool",
             "uuid": "7730e635-853f-4f9f-9451-bffbe6aedd15",
             "workflow_outputs": [
@@ -922,7 +922,7 @@
         },
         "22": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.1+galaxy3",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.1+galaxy4",
             "errors": null,
             "id": 22,
             "input_connections": {
@@ -957,15 +957,15 @@
                 "top": 48.96875
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.1+galaxy3",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.1+galaxy4",
             "tool_shed_repository": {
-                "changeset_revision": "ee29337f905c",
+                "changeset_revision": "7f1cfa4c0e32",
                 "name": "ivar_removereads",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"amplicons\": {\"computed\": \"no\", \"__current_case__\": 1, \"amplicon_info\": {\"__class__\": \"ConnectedValue\"}}, \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"input_bed\": {\"__class__\": \"ConnectedValue\"}, \"variants_tsv\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.3.1+galaxy3",
+            "tool_version": "1.3.1+galaxy4",
             "type": "tool",
             "uuid": "af7d3b75-d16c-43c7-82e4-3f1388edd22c",
             "workflow_outputs": [
@@ -1142,7 +1142,7 @@
         },
         "26": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.15.1+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.15.1+galaxy3",
             "errors": null,
             "id": 26,
             "input_connections": {
@@ -1182,15 +1182,15 @@
                 "top": 689.4375
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.15.1+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.15.1+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "b7ea370b8f5d",
+                "changeset_revision": "3f62d4939d54",
                 "name": "bcftools_annotate",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_type\": \"v\", \"sec_annofile\": {\"columns\": \"QUAL,INFO\", \"annofile\": {\"anno_fmt\": \"vcf\", \"__current_case__\": 1, \"annotations\": {\"__class__\": \"ConnectedValue\"}}, \"mark_sites\": \"-AmpliconBias\", \"min_overlap\": \"\", \"set_id\": \"\"}, \"sec_annotate\": {\"remove\": \"\", \"rename_chrs\": {\"__class__\": \"RuntimeValue\"}, \"rename_annots\": {\"__class__\": \"RuntimeValue\"}}, \"sec_restrict\": {\"include\": \"\", \"exclude\": \"\", \"collapse\": null, \"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"regions_overlap\": null, \"samples\": \"\", \"invert_samples\": \"false\", \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.15.1+galaxy2",
+            "tool_version": "1.15.1+galaxy3",
             "type": "tool",
             "uuid": "c466b7da-f50c-4093-9eb5-c014ba41c1b8",
             "workflow_outputs": [
@@ -1303,7 +1303,7 @@
         },
         "29": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.15.1+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.15.1+galaxy3",
             "errors": null,
             "id": 29,
             "input_connections": {
@@ -1343,15 +1343,15 @@
                 "top": 656.28125
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.15.1+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.15.1+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "b7ea370b8f5d",
+                "changeset_revision": "3f62d4939d54",
                 "name": "bcftools_annotate",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_type\": \"v\", \"sec_annofile\": {\"columns\": \"QUAL,INFO\", \"annofile\": {\"anno_fmt\": \"vcf\", \"__current_case__\": 1, \"annotations\": {\"__class__\": \"ConnectedValue\"}}, \"mark_sites\": \"+AmpliconBias\", \"min_overlap\": \"\", \"set_id\": \"\"}, \"sec_annotate\": {\"remove\": \"\", \"rename_chrs\": {\"__class__\": \"RuntimeValue\"}, \"rename_annots\": {\"__class__\": \"RuntimeValue\"}}, \"sec_restrict\": {\"include\": \"\", \"exclude\": \"\", \"collapse\": null, \"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"regions_overlap\": null, \"samples\": \"\", \"invert_samples\": \"false\", \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.15.1+galaxy2",
+            "tool_version": "1.15.1+galaxy3",
             "type": "tool",
             "uuid": "c466b7da-f50c-4093-9eb5-c014ba41c1b7",
             "workflow_outputs": [

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: variation analysis on ARTIC PE data",
-    "release": "0.9",
+    "release": "0.10",
     "steps": {
         "0": {
             "annotation": "Illumina reads from ARTIC assay with fastqsanger encoding",
@@ -37,6 +37,7 @@
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "dfab5b21-4abb-4269-978d-7c7e24479e4a",
+            "when": null,
             "workflow_outputs": []
         },
         "1": {
@@ -63,6 +64,7 @@
             "tool_version": null,
             "type": "data_input",
             "uuid": "03043a6d-ee9e-4af5-abf4-f960beb6b4e9",
+            "when": null,
             "workflow_outputs": []
         },
         "2": {
@@ -89,6 +91,7 @@
             "tool_version": null,
             "type": "data_input",
             "uuid": "cd6caddf-88ee-47a2-b91d-141fd90b046f",
+            "when": null,
             "workflow_outputs": []
         },
         "3": {
@@ -115,6 +118,7 @@
             "tool_version": null,
             "type": "data_input",
             "uuid": "686cdb4d-a3da-468f-af92-8b04e1824ae0",
+            "when": null,
             "workflow_outputs": []
         },
         "4": {
@@ -141,6 +145,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "29f15ec0-8fa4-4476-b649-cf68ea096744",
+            "when": null,
             "workflow_outputs": []
         },
         "5": {
@@ -167,6 +172,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "b13941c0-31c0-419d-a619-7474c24a582c",
+            "when": null,
             "workflow_outputs": []
         },
         "6": {
@@ -193,6 +199,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "e33b575d-e44e-451e-a2ba-5c253fdc9e5a",
+            "when": null,
             "workflow_outputs": []
         },
         "7": {
@@ -219,6 +226,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "07e46388-c546-4425-8702-caf5d19667c1",
+            "when": null,
             "workflow_outputs": []
         },
         "8": {
@@ -267,10 +275,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": \"false\", \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": \"false\", \"length_required\": null, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": \"false\", \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": \"true\", \"report_json\": \"true\"}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": \"false\", \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": \"false\", \"umi_loc\": \"\", \"umi_len\": null, \"umi_prefix\": \"\"}, \"cutting_by_quality_options\": {\"cut_by_quality5\": \"false\", \"cut_by_quality3\": \"false\", \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": \"false\"}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 2, \"paired_input\": {\"__class__\": \"ConnectedValue\"}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": \"false\", \"adapter_sequence1\": \"\", \"adapter_sequence2\": \"\"}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": null, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": \"\", \"umi_len\": null, \"umi_prefix\": \"\"}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": false}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 2, \"paired_input\": {\"__class__\": \"ConnectedValue\"}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": \"\", \"adapter_sequence2\": \"\"}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.23.2+galaxy0",
             "type": "tool",
             "uuid": "849d9cac-14b8-4e45-823d-5747709e8b60",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "fastp_html_report",
@@ -335,6 +344,7 @@
             "tool_version": "0.1.1",
             "type": "tool",
             "uuid": "d163b9b9-ee13-4b2b-8d64-b6d77758fac9",
+            "when": null,
             "workflow_outputs": []
         },
         "10": {
@@ -383,6 +393,7 @@
             "tool_version": "0.1.1",
             "type": "tool",
             "uuid": "258a1a99-145b-42a0-b858-5220b4199946",
+            "when": null,
             "workflow_outputs": []
         },
         "11": {
@@ -425,6 +436,7 @@
             "tool_version": "0.7.17.2",
             "type": "tool",
             "uuid": "3b5d7080-c168-4bf7-946d-9045c0a4bc4c",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "mapped_reads",
@@ -473,10 +485,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"mode\": {\"outtype\": \"selected_reads\", \"__current_case__\": 1, \"filter_config\": {\"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cond_rg\": {\"select_rg\": \"no\", \"__current_case__\": 0}, \"quality\": \"20\", \"library\": \"\", \"cigarcons\": null, \"inclusive_filter\": [\"1\"], \"exclusive_filter\": [\"4\", \"8\", \"256\"], \"exclusive_filter_all\": null, \"tag\": null, \"qname_file\": {\"__class__\": \"RuntimeValue\"}}, \"subsample_config\": {\"subsampling_mode\": {\"select_subsample\": \"fraction\", \"__current_case__\": 0, \"factor\": \"1.0\", \"seed\": null}}, \"output_options\": {\"reads_report_type\": \"retained\", \"__current_case__\": 0, \"complementary_output\": \"false\", \"adv_output\": {\"readtags\": [], \"collapsecigar\": \"false\"}, \"output_format\": {\"oformat\": \"bam\", \"__current_case__\": 2}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"mode\": {\"outtype\": \"selected_reads\", \"__current_case__\": 1, \"filter_config\": {\"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cond_rg\": {\"select_rg\": \"no\", \"__current_case__\": 0}, \"quality\": \"20\", \"library\": \"\", \"cigarcons\": null, \"inclusive_filter\": [\"1\"], \"exclusive_filter\": [\"4\", \"8\", \"256\"], \"exclusive_filter_all\": null, \"tag\": null, \"qname_file\": {\"__class__\": \"RuntimeValue\"}}, \"subsample_config\": {\"subsampling_mode\": {\"select_subsample\": \"fraction\", \"__current_case__\": 0, \"factor\": \"1.0\", \"seed\": null}}, \"output_options\": {\"reads_report_type\": \"retained\", \"__current_case__\": 0, \"complementary_output\": false, \"adv_output\": {\"readtags\": [], \"collapsecigar\": false}, \"output_format\": {\"oformat\": \"bam\", \"__current_case__\": 2}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.15.1+galaxy0",
             "type": "tool",
             "uuid": "2f7744df-3811-4b7f-8f1f-cf8bf0ec7a0b",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "filtered_mapped_reads",
@@ -521,10 +534,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"adv_options\": {\"keepflags\": \"false\", \"bq2_handling\": {\"replace_bq2\": \"keep\", \"__current_case__\": 0, \"defqual\": \"2\"}}, \"reads\": {\"__class__\": \"ConnectedValue\"}, \"reference_source\": {\"ref_selector\": \"history\", \"__current_case__\": 1, \"ref\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"adv_options\": {\"keepflags\": false, \"bq2_handling\": {\"replace_bq2\": \"keep\", \"__current_case__\": 0, \"defqual\": \"2\"}}, \"reads\": {\"__class__\": \"ConnectedValue\"}, \"reference_source\": {\"ref_selector\": \"history\", \"__current_case__\": 1, \"ref\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.1.5+galaxy0",
             "type": "tool",
             "uuid": "67b3fe84-0164-4494-9cfc-0bd0c86d7a2a",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "realigned_primer_trimmed_filtered_mapped_reads",
@@ -565,10 +579,11 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cov_threshold\": null, \"coverage_cond\": {\"coverage_select\": \"no\", \"__current_case__\": 0}, \"filter_by_flags\": {\"filter_flags\": \"nofilter\", \"__current_case__\": 1}, \"gc_depth\": null, \"input\": {\"__class__\": \"ConnectedValue\"}, \"insert_size\": null, \"most_inserts\": null, \"read_group\": null, \"read_length\": null, \"remove_dups\": \"false\", \"remove_overlaps\": \"false\", \"sparse\": \"false\", \"split_output_cond\": {\"split_output_selector\": \"no\", \"__current_case__\": 0}, \"trim_quality\": null, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cov_threshold\": null, \"coverage_cond\": {\"coverage_select\": \"no\", \"__current_case__\": 0}, \"filter_by_flags\": {\"filter_flags\": \"nofilter\", \"__current_case__\": 1}, \"gc_depth\": null, \"input\": {\"__class__\": \"ConnectedValue\"}, \"insert_size\": null, \"most_inserts\": null, \"read_group\": null, \"read_length\": null, \"remove_dups\": false, \"remove_overlaps\": false, \"sparse\": false, \"split_output_cond\": {\"split_output_selector\": \"no\", \"__current_case__\": 0}, \"trim_quality\": null, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.0.4",
             "type": "tool",
             "uuid": "271efb08-46c0-4801-9869-b9948dfdebb4",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "mapped_reads_stats",
@@ -617,6 +632,7 @@
             "tool_version": "2.1.5+galaxy1",
             "type": "tool",
             "uuid": "70897728-2744-4a82-9b7d-38190594fec6",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "realigned_primer_trimmed_filtered_mapped_reads_with_indel_quals",
@@ -627,7 +643,7 @@
         },
         "16": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.2+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.4.0+galaxy0",
             "errors": null,
             "id": 16,
             "input_connections": {
@@ -666,17 +682,18 @@
                     "output_name": "output_bam"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.2+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.4.0+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "bcaa0d571ce2",
+                "changeset_revision": "a2b94388d00d",
                 "name": "ivar_trim",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"amplicons\": {\"filter_by\": \"yes\", \"__current_case__\": 1, \"amplicon_info\": {\"__class__\": \"ConnectedValue\"}}, \"inc_primers\": \"true\", \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"min_len\": \"1\", \"min_qual\": \"0\", \"primer\": {\"source\": \"history\", \"__current_case__\": 0, \"input_bed\": {\"__class__\": \"ConnectedValue\"}}, \"primer_pos_wiggle\": \"0\", \"window_width\": \"4\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.3.2+galaxy0",
+            "tool_state": "{\"amplicons\": {\"filter_by\": \"yes\", \"__current_case__\": 1, \"amplicon_info\": {\"__class__\": \"ConnectedValue\"}}, \"inc_primers\": true, \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"min_len\": \"1\", \"min_qual\": \"0\", \"primer\": {\"source\": \"history\", \"__current_case__\": 0, \"input_bed\": {\"__class__\": \"ConnectedValue\"}}, \"primer_pos_wiggle\": \"0\", \"trimmed_length\": {\"filter\": \"auto\", \"__current_case__\": 1}, \"window_width\": \"4\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.4.0+galaxy0",
             "type": "tool",
             "uuid": "7730e635-853f-4f9f-9451-bffbe6aedd15",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "primer_trimmed_filtered_mapped_reads",
@@ -721,10 +738,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"call_control\": {\"set_call_options\": \"yes\", \"__current_case__\": 1, \"coverage\": {\"min_cov\": \"5\", \"max_depth\": \"1000000\"}, \"pe\": {\"use_orphan\": \"false\"}, \"bc_quals\": {\"min_bq\": \"30\", \"min_alt_bq\": \"30\", \"alt_bq\": {\"modify\": \"\", \"__current_case__\": 0}}, \"align_quals\": {\"alnqual\": {\"use_alnqual\": \"\", \"__current_case__\": 0, \"alnqual_choice\": {\"alnquals_to_use\": \"\", \"__current_case__\": 1, \"extended_baq\": \"true\"}}}, \"map_quals\": {\"min_mq\": \"20\", \"use_mq\": {\"no_mq\": \"\", \"__current_case__\": 0, \"max_mq\": \"255\"}}, \"source_qual\": {\"use_src_qual\": {\"src_qual\": \"\", \"__current_case__\": 0}}, \"joint_qual\": {\"min_jq\": \"0\", \"min_alt_jq\": \"0\", \"def_alt_jq\": \"0\"}}, \"filter_control\": {\"filter_type\": \"set_custom\", \"__current_case__\": 3, \"sig\": \"0.0005\", \"bonf\": \"0\", \"others\": \"false\"}, \"reads\": {\"__class__\": \"ConnectedValue\"}, \"reference_source\": {\"ref_selector\": \"history\", \"__current_case__\": 1, \"ref\": {\"__class__\": \"ConnectedValue\"}}, \"regions\": {\"restrict_to_region\": \"genome\", \"__current_case__\": 0}, \"variant_types\": \"--call-indels\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"call_control\": {\"set_call_options\": \"yes\", \"__current_case__\": 1, \"coverage\": {\"min_cov\": \"5\", \"max_depth\": \"1000000\"}, \"pe\": {\"use_orphan\": false}, \"bc_quals\": {\"min_bq\": \"30\", \"min_alt_bq\": \"30\", \"alt_bq\": {\"modify\": \"\", \"__current_case__\": 0}}, \"align_quals\": {\"alnqual\": {\"use_alnqual\": \"\", \"__current_case__\": 0, \"alnqual_choice\": {\"alnquals_to_use\": \"\", \"__current_case__\": 1, \"extended_baq\": true}}}, \"map_quals\": {\"min_mq\": \"20\", \"use_mq\": {\"no_mq\": \"\", \"__current_case__\": 0, \"max_mq\": \"255\"}}, \"source_qual\": {\"use_src_qual\": {\"src_qual\": \"\", \"__current_case__\": 0}}, \"joint_qual\": {\"min_jq\": \"0\", \"min_alt_jq\": \"0\", \"def_alt_jq\": \"0\"}}, \"filter_control\": {\"filter_type\": \"set_custom\", \"__current_case__\": 3, \"sig\": \"0.0005\", \"bonf\": \"0\", \"others\": false}, \"reads\": {\"__class__\": \"ConnectedValue\"}, \"reference_source\": {\"ref_selector\": \"history\", \"__current_case__\": 1, \"ref\": {\"__class__\": \"ConnectedValue\"}}, \"regions\": {\"restrict_to_region\": \"genome\", \"__current_case__\": 0}, \"variant_types\": \"--call-indels\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.1.5+galaxy2",
             "type": "tool",
             "uuid": "422c7955-7768-4745-95db-b6882f37cd4b",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "preliminary_variants_1",
@@ -769,10 +787,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"duplicate_skipping\": [\"0\"], \"input1\": {\"__class__\": \"ConnectedValue\"}, \"per_base_coverage\": \"false\", \"plot_specific\": {\"n_bins\": \"400\", \"paint_chromosome_limits\": \"true\", \"genome_gc_distr\": null, \"homopolymer_size\": \"3\"}, \"stats_regions\": {\"region_select\": \"all\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"duplicate_skipping\": [\"0\"], \"input1\": {\"__class__\": \"ConnectedValue\"}, \"per_base_coverage\": false, \"plot_specific\": {\"n_bins\": \"400\", \"paint_chromosome_limits\": true, \"genome_gc_distr\": null, \"homopolymer_size\": \"3\"}, \"stats_regions\": {\"region_select\": \"all\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.2.2d+galaxy3",
             "type": "tool",
             "uuid": "e2c69f7d-e6fd-4c9a-bbfd-05b70e5b2129",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "bamqc_raw_output",
@@ -822,10 +841,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filter_expression\": {\"type\": \"simple\", \"__current_case__\": 0, \"expr\": {\"__class__\": \"ConnectedValue\"}}, \"filtering\": {\"mode\": \"entries\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"inverse\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"filter_expression\": {\"type\": \"simple\", \"__current_case__\": 0, \"expr\": {\"__class__\": \"ConnectedValue\"}}, \"filtering\": {\"mode\": \"entries\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"inverse\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "4.3+t.galaxy1",
             "type": "tool",
             "uuid": "a2b784b0-28c1-45e3-93b8-d1d9d598de01",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "filtered_preliminary_variants",
@@ -870,10 +890,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filter_expression\": {\"type\": \"simple\", \"__current_case__\": 0, \"expr\": {\"__class__\": \"ConnectedValue\"}}, \"filtering\": {\"mode\": \"entries\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"inverse\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"filter_expression\": {\"type\": \"simple\", \"__current_case__\": 0, \"expr\": {\"__class__\": \"ConnectedValue\"}}, \"filtering\": {\"mode\": \"entries\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"inverse\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "4.3+t.galaxy1",
             "type": "tool",
             "uuid": "b96f89fd-30c1-4e70-ae70-ca37121e3c61",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "preliminary_variants_1_filtered",
@@ -918,11 +939,12 @@
             "tool_version": "1.0.0",
             "type": "tool",
             "uuid": "e4e04a37-f4bf-41d7-9470-5c96125ebc49",
+            "when": null,
             "workflow_outputs": []
         },
         "22": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.2+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.4.0+galaxy0",
             "errors": null,
             "id": 22,
             "input_connections": {
@@ -957,17 +979,18 @@
                 "top": 48.96875
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.2+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.4.0+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "8c05afb547fa",
+                "changeset_revision": "6a1515bb0687",
                 "name": "ivar_removereads",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"amplicons\": {\"computed\": \"no\", \"__current_case__\": 1, \"amplicon_info\": {\"__class__\": \"ConnectedValue\"}}, \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"input_bed\": {\"__class__\": \"ConnectedValue\"}, \"variants_tsv\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.3.2+galaxy0",
+            "tool_version": "1.4.0+galaxy0",
             "type": "tool",
             "uuid": "af7d3b75-d16c-43c7-82e4-3f1388edd22c",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "amplicon_removal_output",
@@ -1006,6 +1029,7 @@
             "tool_version": "1.0.0",
             "type": "tool",
             "uuid": "396c9b85-8ec7-405a-a742-5b47e40cf0de",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "bamqc_raw_output_flattened",
@@ -1050,10 +1074,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"call_control\": {\"set_call_options\": \"yes\", \"__current_case__\": 1, \"coverage\": {\"min_cov\": \"5\", \"max_depth\": \"1000000\"}, \"pe\": {\"use_orphan\": \"false\"}, \"bc_quals\": {\"min_bq\": \"30\", \"min_alt_bq\": \"30\", \"alt_bq\": {\"modify\": \"\", \"__current_case__\": 0}}, \"align_quals\": {\"alnqual\": {\"use_alnqual\": \"\", \"__current_case__\": 0, \"alnqual_choice\": {\"alnquals_to_use\": \"\", \"__current_case__\": 1, \"extended_baq\": \"true\"}}}, \"map_quals\": {\"min_mq\": \"20\", \"use_mq\": {\"no_mq\": \"\", \"__current_case__\": 0, \"max_mq\": \"255\"}}, \"source_qual\": {\"use_src_qual\": {\"src_qual\": \"\", \"__current_case__\": 0}}, \"joint_qual\": {\"min_jq\": \"0\", \"min_alt_jq\": \"0\", \"def_alt_jq\": \"0\"}}, \"filter_control\": {\"filter_type\": \"set_custom\", \"__current_case__\": 3, \"sig\": \"0.0005\", \"bonf\": \"0\", \"others\": \"false\"}, \"reads\": {\"__class__\": \"ConnectedValue\"}, \"reference_source\": {\"ref_selector\": \"history\", \"__current_case__\": 1, \"ref\": {\"__class__\": \"ConnectedValue\"}}, \"regions\": {\"restrict_to_region\": \"genome\", \"__current_case__\": 0}, \"variant_types\": \"--call-indels\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"call_control\": {\"set_call_options\": \"yes\", \"__current_case__\": 1, \"coverage\": {\"min_cov\": \"5\", \"max_depth\": \"1000000\"}, \"pe\": {\"use_orphan\": false}, \"bc_quals\": {\"min_bq\": \"30\", \"min_alt_bq\": \"30\", \"alt_bq\": {\"modify\": \"\", \"__current_case__\": 0}}, \"align_quals\": {\"alnqual\": {\"use_alnqual\": \"\", \"__current_case__\": 0, \"alnqual_choice\": {\"alnquals_to_use\": \"\", \"__current_case__\": 1, \"extended_baq\": true}}}, \"map_quals\": {\"min_mq\": \"20\", \"use_mq\": {\"no_mq\": \"\", \"__current_case__\": 0, \"max_mq\": \"255\"}}, \"source_qual\": {\"use_src_qual\": {\"src_qual\": \"\", \"__current_case__\": 0}}, \"joint_qual\": {\"min_jq\": \"0\", \"min_alt_jq\": \"0\", \"def_alt_jq\": \"0\"}}, \"filter_control\": {\"filter_type\": \"set_custom\", \"__current_case__\": 3, \"sig\": \"0.0005\", \"bonf\": \"0\", \"others\": false}, \"reads\": {\"__class__\": \"ConnectedValue\"}, \"reference_source\": {\"ref_selector\": \"history\", \"__current_case__\": 1, \"ref\": {\"__class__\": \"ConnectedValue\"}}, \"regions\": {\"restrict_to_region\": \"genome\", \"__current_case__\": 0}, \"variant_types\": \"--call-indels\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.1.5+galaxy2",
             "type": "tool",
             "uuid": "bef93d5b-c023-459c-888c-ac3382515322",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "preliminary_variants_2",
@@ -1123,10 +1148,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"comment\": \"\", \"export\": \"true\", \"flat\": \"false\", \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastp\", \"__current_case__\": 7, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"samtools\", \"__current_case__\": 24, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"stats\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}}]}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"qualimap\", \"__current_case__\": 20, \"input\": {\"__class__\": \"ConnectedValue\"}}}], \"saveLog\": \"false\", \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"comment\": \"\", \"export\": true, \"flat\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastp\", \"__current_case__\": 7, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"samtools\", \"__current_case__\": 24, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"stats\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}}]}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"qualimap\", \"__current_case__\": 20, \"input\": {\"__class__\": \"ConnectedValue\"}}}], \"saveLog\": false, \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.11+galaxy1",
             "type": "tool",
             "uuid": "ee2b164f-213b-4d95-9ab7-febdf5a71085",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "preprocessing_and_mapping_reports",
@@ -1189,10 +1215,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_type\": \"v\", \"sec_annofile\": {\"columns\": \"QUAL,INFO\", \"annofile\": {\"anno_fmt\": \"vcf\", \"__current_case__\": 1, \"annotations\": {\"__class__\": \"ConnectedValue\"}}, \"mark_sites\": \"-AmpliconBias\", \"min_overlap\": \"\", \"set_id\": \"\"}, \"sec_annotate\": {\"remove\": \"\", \"rename_chrs\": {\"__class__\": \"RuntimeValue\"}, \"rename_annots\": {\"__class__\": \"RuntimeValue\"}}, \"sec_restrict\": {\"include\": \"\", \"exclude\": \"\", \"collapse\": null, \"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"regions_overlap\": null, \"samples\": \"\", \"invert_samples\": \"false\", \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_type\": \"v\", \"sec_annofile\": {\"columns\": \"QUAL,INFO\", \"annofile\": {\"anno_fmt\": \"vcf\", \"__current_case__\": 1, \"annotations\": {\"__class__\": \"ConnectedValue\"}}, \"mark_sites\": \"-AmpliconBias\", \"min_overlap\": \"\", \"set_id\": \"\"}, \"sec_annotate\": {\"remove\": \"\", \"rename_chrs\": {\"__class__\": \"RuntimeValue\"}, \"rename_annots\": {\"__class__\": \"RuntimeValue\"}}, \"sec_restrict\": {\"include\": \"\", \"exclude\": \"\", \"collapse\": null, \"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"regions_overlap\": null, \"samples\": \"\", \"invert_samples\": false, \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": false}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.15.1+galaxy3",
             "type": "tool",
             "uuid": "c466b7da-f50c-4093-9eb5-c014ba41c1b8",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "variants_fixed_partial",
@@ -1237,10 +1264,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filter_expression\": {\"type\": \"simple\", \"__current_case__\": 0, \"expr\": {\"__class__\": \"ConnectedValue\"}}, \"filtering\": {\"mode\": \"entries\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"inverse\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"filter_expression\": {\"type\": \"simple\", \"__current_case__\": 0, \"expr\": {\"__class__\": \"ConnectedValue\"}}, \"filtering\": {\"mode\": \"entries\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"inverse\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "4.3+t.galaxy1",
             "type": "tool",
             "uuid": "c3d5ad01-385e-4405-bdc1-51f01dee4071",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "preliminary_variants_2_filtered",
@@ -1289,10 +1317,11 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"adv_options\": {\"adv_options_selector\": \"no\", \"__current_case__\": 0}, \"invert\": \"true\", \"isect_union\": \"-i\", \"loci\": \"false\", \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"ConnectedValue\"}}, \"vcf_input1\": {\"__class__\": \"ConnectedValue\"}, \"vcf_input2\": {\"__class__\": \"ConnectedValue\"}, \"window_size\": \"0\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"adv_options\": {\"adv_options_selector\": \"no\", \"__current_case__\": 0}, \"invert\": true, \"isect_union\": \"-i\", \"loci\": false, \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"ConnectedValue\"}}, \"vcf_input1\": {\"__class__\": \"ConnectedValue\"}, \"vcf_input2\": {\"__class__\": \"ConnectedValue\"}, \"window_size\": \"0\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0_rc3+galaxy0",
             "type": "tool",
             "uuid": "816eeae7-4ad5-4f2d-b709-285931d2be4b",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "lost_filter_passing_variants",
@@ -1350,10 +1379,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_type\": \"v\", \"sec_annofile\": {\"columns\": \"QUAL,INFO\", \"annofile\": {\"anno_fmt\": \"vcf\", \"__current_case__\": 1, \"annotations\": {\"__class__\": \"ConnectedValue\"}}, \"mark_sites\": \"+AmpliconBias\", \"min_overlap\": \"\", \"set_id\": \"\"}, \"sec_annotate\": {\"remove\": \"\", \"rename_chrs\": {\"__class__\": \"RuntimeValue\"}, \"rename_annots\": {\"__class__\": \"RuntimeValue\"}}, \"sec_restrict\": {\"include\": \"\", \"exclude\": \"\", \"collapse\": null, \"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"regions_overlap\": null, \"samples\": \"\", \"invert_samples\": \"false\", \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_type\": \"v\", \"sec_annofile\": {\"columns\": \"QUAL,INFO\", \"annofile\": {\"anno_fmt\": \"vcf\", \"__current_case__\": 1, \"annotations\": {\"__class__\": \"ConnectedValue\"}}, \"mark_sites\": \"+AmpliconBias\", \"min_overlap\": \"\", \"set_id\": \"\"}, \"sec_annotate\": {\"remove\": \"\", \"rename_chrs\": {\"__class__\": \"RuntimeValue\"}, \"rename_annots\": {\"__class__\": \"RuntimeValue\"}}, \"sec_restrict\": {\"include\": \"\", \"exclude\": \"\", \"collapse\": null, \"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"regions_overlap\": null, \"samples\": \"\", \"invert_samples\": false, \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": false}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.15.1+galaxy3",
             "type": "tool",
             "uuid": "c466b7da-f50c-4093-9eb5-c014ba41c1b7",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "variants_fixed",
@@ -1398,6 +1428,7 @@
             "tool_version": "1.1.2",
             "type": "tool",
             "uuid": "490dbabb-04ee-426d-a8e5-e2ec9e59de3a",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "variants_fixed_header",
@@ -1459,10 +1490,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"annotations\": [\"-formatEff\", \"-classic\"], \"chr\": \"\", \"csvStats\": \"false\", \"filter\": {\"specificEffects\": \"no\", \"__current_case__\": 0}, \"filterOut\": [\"-no-downstream\", \"-no-intergenic\", \"-no-upstream\"], \"generate_stats\": \"true\", \"genome_version\": \"NC_045512.2\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"inputFormat\": \"vcf\", \"intervals\": {\"__class__\": \"RuntimeValue\"}, \"noLog\": \"true\", \"offset\": \"default\", \"outputConditional\": {\"outputFormat\": \"vcf\", \"__current_case__\": 0}, \"transcripts\": {\"__class__\": \"RuntimeValue\"}, \"udLength\": \"0\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"annotations\": [\"-formatEff\", \"-classic\"], \"chr\": \"\", \"csvStats\": false, \"filter\": {\"specificEffects\": \"no\", \"__current_case__\": 0}, \"filterOut\": [\"-no-downstream\", \"-no-intergenic\", \"-no-upstream\"], \"generate_stats\": true, \"genome_version\": \"NC_045512.2\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"inputFormat\": \"vcf\", \"intervals\": {\"__class__\": \"RuntimeValue\"}, \"noLog\": true, \"offset\": \"default\", \"outputConditional\": {\"outputFormat\": \"vcf\", \"__current_case__\": 0}, \"transcripts\": {\"__class__\": \"RuntimeValue\"}, \"udLength\": \"0\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "4.5covid19",
             "type": "tool",
             "uuid": "a6b0b8e1-a914-4f59-95d4-87fc47ed4171",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "annotated_variants",
@@ -1516,10 +1548,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"af\": {\"af_min\": \"0.0\", \"af_max\": \"0.0\"}, \"coverage\": {\"cov_min\": \"0\", \"cov_max\": \"0\"}, \"filter_by_type\": {\"keep_only\": \"\", \"__current_case__\": 0, \"qual\": {\"snvqual_filter\": {\"snvqual\": \"no\", \"__current_case__\": 0}, \"indelqual_filter\": {\"indelqual\": \"no\", \"__current_case__\": 0}}}, \"flag_or_drop\": \"--print-all\", \"invcf\": {\"__class__\": \"ConnectedValue\"}, \"sb\": {\"sb_filter\": {\"strand_bias\": \"mtc\", \"__current_case__\": 2, \"sb_alpha\": \"0.001\", \"sb_mtc\": \"fdr\", \"sb_compound\": \"true\", \"sb_indels\": \"false\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"af\": {\"af_min\": \"0.0\", \"af_max\": \"0.0\"}, \"coverage\": {\"cov_min\": \"0\", \"cov_max\": \"0\"}, \"filter_by_type\": {\"keep_only\": \"\", \"__current_case__\": 0, \"qual\": {\"snvqual_filter\": {\"snvqual\": \"no\", \"__current_case__\": 0}, \"indelqual_filter\": {\"indelqual\": \"no\", \"__current_case__\": 0}}}, \"flag_or_drop\": \"--print-all\", \"invcf\": {\"__class__\": \"ConnectedValue\"}, \"sb\": {\"sb_filter\": {\"strand_bias\": \"mtc\", \"__current_case__\": 2, \"sb_alpha\": \"0.001\", \"sb_mtc\": \"fdr\", \"sb_compound\": true, \"sb_indels\": false}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.1.5+galaxy0",
             "type": "tool",
             "uuid": "4c9e8621-e930-4593-b0be-d84304f86ad4",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "annotated_softfiltered_variants",

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: variation analysis on ARTIC PE data",
-    "release": "0.6",
+    "release": "0.7",
     "steps": {
         "0": {
             "annotation": "Illumina reads from ARTIC assay with fastqsanger encoding",
@@ -1064,7 +1064,7 @@
         },
         "25": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy1",
             "errors": null,
             "id": 25,
             "input_connections": {
@@ -1116,15 +1116,15 @@
                     "output_name": "html_report"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "9a913cdee30e",
+                "changeset_revision": "abfd8a6544d7",
                 "name": "multiqc",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"comment\": \"\", \"export\": \"true\", \"flat\": \"false\", \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastp\", \"__current_case__\": 7, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"samtools\", \"__current_case__\": 24, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"stats\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}}]}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"qualimap\", \"__current_case__\": 20, \"input\": {\"__class__\": \"ConnectedValue\"}}}], \"saveLog\": \"false\", \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.11+galaxy0",
+            "tool_version": "1.11+galaxy1",
             "type": "tool",
             "uuid": "ee2b164f-213b-4d95-9ab7-febdf5a71085",
             "workflow_outputs": [

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: variation analysis on ARTIC PE data",
-    "release": "0.11",
+    "release": "0.12",
     "steps": {
         "0": {
             "annotation": "Illumina reads from ARTIC assay with fastqsanger encoding",
@@ -447,7 +447,7 @@
         },
         "12": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.15.1+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.15.1+galaxy2",
             "errors": null,
             "id": 12,
             "input_connections": {
@@ -478,15 +478,15 @@
                     "output_name": "outputsam"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.15.1+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.15.1+galaxy2",
             "tool_shed_repository": {
-                "changeset_revision": "5826298f6a73",
+                "changeset_revision": "6be888be75f9",
                 "name": "samtools_view",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"mode\": {\"outtype\": \"selected_reads\", \"__current_case__\": 1, \"filter_config\": {\"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cond_rg\": {\"select_rg\": \"no\", \"__current_case__\": 0}, \"quality\": \"20\", \"library\": \"\", \"cigarcons\": null, \"inclusive_filter\": [\"1\"], \"exclusive_filter\": [\"4\", \"8\", \"256\"], \"exclusive_filter_all\": null, \"tag\": null, \"qname_file\": {\"__class__\": \"RuntimeValue\"}}, \"subsample_config\": {\"subsampling_mode\": {\"select_subsample\": \"fraction\", \"__current_case__\": 0, \"factor\": \"1.0\", \"seed\": null}}, \"output_options\": {\"reads_report_type\": \"retained\", \"__current_case__\": 0, \"complementary_output\": false, \"adv_output\": {\"readtags\": [], \"collapsecigar\": false}, \"output_format\": {\"oformat\": \"bam\", \"__current_case__\": 2}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.15.1+galaxy0",
+            "tool_version": "1.15.1+galaxy2",
             "type": "tool",
             "uuid": "2f7744df-3811-4b7f-8f1f-cf8bf0ec7a0b",
             "when": null,
@@ -549,7 +549,7 @@
         },
         "14": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.4",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.5",
             "errors": null,
             "id": 14,
             "input_connections": {
@@ -572,15 +572,15 @@
                 "top": 922.90625
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.4",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.5",
             "tool_shed_repository": {
-                "changeset_revision": "3a0efe14891f",
+                "changeset_revision": "fed4aa48ba09",
                 "name": "samtools_stats",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cov_threshold\": null, \"coverage_cond\": {\"coverage_select\": \"no\", \"__current_case__\": 0}, \"filter_by_flags\": {\"filter_flags\": \"nofilter\", \"__current_case__\": 1}, \"gc_depth\": null, \"input\": {\"__class__\": \"ConnectedValue\"}, \"insert_size\": null, \"most_inserts\": null, \"read_group\": null, \"read_length\": null, \"remove_dups\": false, \"remove_overlaps\": false, \"sparse\": false, \"split_output_cond\": {\"split_output_selector\": \"no\", \"__current_case__\": 0}, \"trim_quality\": null, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.0.4",
+            "tool_version": "2.0.5",
             "type": "tool",
             "uuid": "271efb08-46c0-4801-9869-b9948dfdebb4",
             "when": null,
@@ -684,7 +684,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.4.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "28e4bcbc86e7",
+                "changeset_revision": "0893a1dbb807",
                 "name": "ivar_trim",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -981,7 +981,7 @@
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.4.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "f57ce5d5c997",
+                "changeset_revision": "69797fa273c3",
                 "name": "ivar_removereads",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: variation analysis on ARTIC PE data",
-    "release": "0.12",
+    "release": "0.13",
     "steps": {
         "0": {
             "annotation": "Illumina reads from ARTIC assay with fastqsanger encoding",
@@ -231,7 +231,7 @@
         },
         "8": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.2+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.4+galaxy0",
             "errors": null,
             "id": 8,
             "input_connections": {
@@ -240,7 +240,12 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool fastp",
+                    "name": "single_paired"
+                }
+            ],
             "label": null,
             "name": "fastp",
             "outputs": [
@@ -268,15 +273,15 @@
                     "output_name": "report_json"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.2+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.4+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "65b93b623c77",
+                "changeset_revision": "c59d48774d03",
                 "name": "fastp",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": null, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": \"\", \"umi_len\": null, \"umi_prefix\": \"\"}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": false}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 2, \"paired_input\": {\"__class__\": \"ConnectedValue\"}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": \"\", \"adapter_sequence2\": \"\"}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.23.2+galaxy0",
+            "tool_version": "0.23.4+galaxy0",
             "type": "tool",
             "uuid": "849d9cac-14b8-4e45-823d-5747709e8b60",
             "when": null,
@@ -411,7 +416,16 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Map with BWA-MEM",
+                    "name": "fastq_input"
+                },
+                {
+                    "description": "runtime parameter for tool Map with BWA-MEM",
+                    "name": "reference_source"
+                }
+            ],
             "label": null,
             "name": "Map with BWA-MEM",
             "outputs": [
@@ -456,7 +470,12 @@
                     "output_name": "bam_output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Samtools view",
+                    "name": "input"
+                }
+            ],
             "label": null,
             "name": "Samtools view",
             "outputs": [
@@ -513,7 +532,16 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Realign reads",
+                    "name": "reads"
+                },
+                {
+                    "description": "runtime parameter for tool Realign reads",
+                    "name": "reference_source"
+                }
+            ],
             "label": null,
             "name": "Realign reads",
             "outputs": [
@@ -558,7 +586,12 @@
                     "output_name": "outputsam"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Samtools stats",
+                    "name": "input"
+                }
+            ],
             "label": null,
             "name": "Samtools stats",
             "outputs": [
@@ -607,7 +640,12 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Insert indel qualities",
+                    "name": "reads"
+                }
+            ],
             "label": null,
             "name": "Insert indel qualities",
             "outputs": [
@@ -660,7 +698,20 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool ivar trim",
+                    "name": "amplicons"
+                },
+                {
+                    "description": "runtime parameter for tool ivar trim",
+                    "name": "input_bam"
+                },
+                {
+                    "description": "runtime parameter for tool ivar trim",
+                    "name": "primer"
+                }
+            ],
             "label": null,
             "name": "ivar trim",
             "outputs": [
@@ -717,7 +768,16 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Call variants",
+                    "name": "reads"
+                },
+                {
+                    "description": "runtime parameter for tool Call variants",
+                    "name": "reference_source"
+                }
+            ],
             "label": null,
             "name": "Call variants",
             "outputs": [
@@ -762,7 +822,12 @@
                     "output_name": "output_bam"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool QualiMap BamQC",
+                    "name": "input1"
+                }
+            ],
             "label": null,
             "name": "QualiMap BamQC",
             "outputs": [
@@ -820,7 +885,16 @@
                     "output_name": "variants"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool SnpSift Filter",
+                    "name": "filter_expression"
+                },
+                {
+                    "description": "runtime parameter for tool SnpSift Filter",
+                    "name": "input"
+                }
+            ],
             "label": null,
             "name": "SnpSift Filter",
             "outputs": [
@@ -869,7 +943,16 @@
                     "output_name": "variants"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool SnpSift Filter",
+                    "name": "filter_expression"
+                },
+                {
+                    "description": "runtime parameter for tool SnpSift Filter",
+                    "name": "input"
+                }
+            ],
             "label": null,
             "name": "SnpSift Filter",
             "outputs": [
@@ -914,7 +997,12 @@
                     "output_name": "raw_data"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Filter failed datasets",
+                    "name": "input"
+                }
+            ],
             "label": null,
             "name": "Filter failed datasets",
             "outputs": [
@@ -965,7 +1053,24 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool ivar removereads",
+                    "name": "amplicons"
+                },
+                {
+                    "description": "runtime parameter for tool ivar removereads",
+                    "name": "input_bam"
+                },
+                {
+                    "description": "runtime parameter for tool ivar removereads",
+                    "name": "input_bed"
+                },
+                {
+                    "description": "runtime parameter for tool ivar removereads",
+                    "name": "variants_tsv"
+                }
+            ],
             "label": null,
             "name": "ivar removereads",
             "outputs": [
@@ -1010,7 +1115,12 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Flatten collection",
+                    "name": "input"
+                }
+            ],
             "label": null,
             "name": "Flatten collection",
             "outputs": [
@@ -1053,7 +1163,16 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Call variants",
+                    "name": "reads"
+                },
+                {
+                    "description": "runtime parameter for tool Call variants",
+                    "name": "reference_source"
+                }
+            ],
             "label": null,
             "name": "Call variants",
             "outputs": [
@@ -1184,6 +1303,10 @@
             "inputs": [
                 {
                     "description": "runtime parameter for tool bcftools annotate",
+                    "name": "input_file"
+                },
+                {
+                    "description": "runtime parameter for tool bcftools annotate",
                     "name": "sec_annotate"
                 },
                 {
@@ -1243,7 +1366,16 @@
                     "output_name": "variants"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool SnpSift Filter",
+                    "name": "filter_expression"
+                },
+                {
+                    "description": "runtime parameter for tool SnpSift Filter",
+                    "name": "input"
+                }
+            ],
             "label": null,
             "name": "SnpSift Filter",
             "outputs": [
@@ -1296,7 +1428,20 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool VCF-VCFintersect:",
+                    "name": "reference_source"
+                },
+                {
+                    "description": "runtime parameter for tool VCF-VCFintersect:",
+                    "name": "vcf_input1"
+                },
+                {
+                    "description": "runtime parameter for tool VCF-VCFintersect:",
+                    "name": "vcf_input2"
+                }
+            ],
             "label": null,
             "name": "VCF-VCFintersect:",
             "outputs": [
@@ -1348,6 +1493,10 @@
             "inputs": [
                 {
                     "description": "runtime parameter for tool bcftools annotate",
+                    "name": "input_file"
+                },
+                {
+                    "description": "runtime parameter for tool bcftools annotate",
                     "name": "sec_annotate"
                 },
                 {
@@ -1394,7 +1543,7 @@
         },
         "30": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.3+galaxy0",
             "errors": null,
             "id": 30,
             "input_connections": {
@@ -1403,7 +1552,12 @@
                     "output_name": "output_file"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Replace Text",
+                    "name": "infile"
+                }
+            ],
             "label": null,
             "name": "Replace Text",
             "outputs": [
@@ -1417,15 +1571,15 @@
                 "top": 745.546875
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/1.1.2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.3+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "d698c222f354",
+                "changeset_revision": "12615d397df7",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"infile\": {\"__class__\": \"ConnectedValue\"}, \"replacements\": [{\"__index__\": 0, \"find_pattern\": \"^##INFO=<ID=AmpliconBias,.+$\", \"replace_pattern\": \"##INFO=<ID=AmpliconBias,Number=0,Type=Flag,Description=\\\"Indicates that the AF value of the variant could not be corrected for potential amplicon bias.\\\">\"}, {\"__index__\": 1, \"find_pattern\": \"^##INFO=<ID=AF,.+$\", \"replace_pattern\": \"##INFO=<ID=AF,Number=1,Type=Float,Description=\\\"Lofreq Allele Frequency; Fraction of variant-supporting bases with q > --min-bq among all bases at the site\\\">\"}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.1.2",
+            "tool_version": "9.3+galaxy0",
             "type": "tool",
             "uuid": "490dbabb-04ee-426d-a8e5-e2ec9e59de3a",
             "when": null,
@@ -1449,6 +1603,10 @@
                 }
             },
             "inputs": [
+                {
+                    "description": "runtime parameter for tool SnpEff eff:",
+                    "name": "input"
+                },
                 {
                     "description": "runtime parameter for tool SnpEff eff:",
                     "name": "intervals"
@@ -1519,7 +1677,12 @@
                     "output_name": "snpeff_output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Lofreq filter",
+                    "name": "invcf"
+                }
+            ],
             "label": null,
             "name": "Lofreq filter",
             "outputs": [


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.9+galaxy2` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.15.1+galaxy0`
* `toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.2+galaxy2` should be updated to `toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.4`
* `toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy1`
* `toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy2` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy4`
* `toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy1` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy2`
* `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3.0`
* `toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.1+galaxy2` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/ivar_removereads/ivar_removereads/1.3.1+galaxy3`
* `toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.10` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/bcftools_annotate/bcftools_annotate/1.15.1+galaxy2`

The workflow release number has been updated from 0.5 to 0.6.
