### PR TITLE
Updating workflows/VGP-assembly-v2/VGP-meryldb-creation from 0.1 to 0.2

### DIFF
--- a/workflows/VGP-assembly-v2/VGP-meryldb-creation/CHANGELOG.md
+++ b/workflows/VGP-assembly-v2/VGP-meryldb-creation/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+
+## [0.2] 2022-11-02
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy5` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy6`
+- `toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0`
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/workflows/VGP-assembly-v2/VGP-meryldb-creation/meryldb-creation.ga
+++ b/workflows/VGP-assembly-v2/VGP-meryldb-creation/meryldb-creation.ga
@@ -12,7 +12,7 @@
             "name": "Galaxy"
         }
     ],
-    "release": "0.1",
+    "release": "0.2",
     "format-version": "0.1",
     "license": "CC-BY-4.0",
     "name": "Quality Evaluation",
@@ -33,14 +33,8 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "bottom": 274.671875,
-                "height": 82.171875,
-                "left": 158.5,
-                "right": 358.5,
-                "top": 192.5,
-                "width": 200,
-                "x": 158.5,
-                "y": 192.5
+                "left": 0.0,
+                "top": 11.0
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\"}",
@@ -65,14 +59,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 470.28125,
-                "height": 61.78125,
-                "left": 158.5,
-                "right": 358.5,
-                "top": 408.5,
-                "width": 200,
-                "x": 158.5,
-                "y": 408.5
+                "left": 0.0,
+                "top": 227.0
             },
             "tool_id": null,
             "tool_state": "{\"default\": 21, \"parameter_type\": \"integer\", \"optional\": true}",
@@ -97,14 +85,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 430.28125,
-                "height": 61.78125,
-                "left": 991.828125,
-                "right": 1191.828125,
-                "top": 368.5,
-                "width": 200,
-                "x": 991.828125,
-                "y": 368.5
+                "left": 833.328125,
+                "top": 187.0
             },
             "tool_id": null,
             "tool_state": "{\"default\": 2, \"parameter_type\": \"integer\", \"optional\": true}",
@@ -115,7 +97,7 @@
         },
         "3": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy5",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy6",
             "errors": null,
             "id": 3,
             "input_connections": {
@@ -138,14 +120,8 @@
                 }
             ],
             "position": {
-                "bottom": 325.453125,
-                "height": 143.953125,
-                "left": 436.28125,
-                "right": 636.28125,
-                "top": 181.5,
-                "width": 200,
-                "x": 436.28125,
-                "y": 181.5
+                "left": 277.78125,
+                "top": 0.0
             },
             "post_job_actions": {
                 "HideDatasetActionread_db": {
@@ -154,22 +130,22 @@
                     "output_name": "read_db"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy5",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy6",
             "tool_shed_repository": {
-                "changeset_revision": "9cd178127b19",
+                "changeset_revision": "29dabd8db6f2",
                 "name": "meryl",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"operation_type\": {\"command_type\": \"count-kmers\", \"__current_case__\": 0, \"count_operations\": \"count\", \"input_reads\": {\"__class__\": \"ConnectedValue\"}, \"options_kmer_size\": {\"kmer_size\": \"provide\", \"__current_case__\": 0, \"input_kmer_size\": {\"__class__\": \"ConnectedValue\"}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.3+galaxy5",
+            "tool_version": "1.3+galaxy6",
             "type": "tool",
             "uuid": "46f024d1-f0ee-4fdd-aea8-061e434c8326",
             "workflow_outputs": []
         },
         "4": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy5",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy6",
             "errors": null,
             "id": 4,
             "input_connections": {
@@ -188,14 +164,8 @@
                 }
             ],
             "position": {
-                "bottom": 320.0625,
-                "height": 113.5625,
-                "left": 714.0625,
-                "right": 914.0625,
-                "top": 206.5,
-                "width": 200,
-                "x": 714.0625,
-                "y": 206.5
+                "left": 555.5625,
+                "top": 25.0
             },
             "post_job_actions": {
                 "TagDatasetActionread_db": {
@@ -206,15 +176,15 @@
                     "output_name": "read_db"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy5",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy6",
             "tool_shed_repository": {
-                "changeset_revision": "9cd178127b19",
+                "changeset_revision": "29dabd8db6f2",
                 "name": "meryl",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"operation_type\": {\"command_type\": \"groups-kmers\", \"__current_case__\": 3, \"groups_operations\": \"union-sum\", \"input_meryldb_02\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.3+galaxy5",
+            "tool_version": "1.3+galaxy6",
             "type": "tool",
             "uuid": "d5bcfdeb-0c22-4a42-a98d-f201cddbbf0e",
             "workflow_outputs": [
@@ -227,7 +197,7 @@
         },
         "5": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy5",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy6",
             "errors": null,
             "id": 5,
             "input_connections": {
@@ -246,14 +216,8 @@
                 }
             ],
             "position": {
-                "bottom": 310.0625,
-                "height": 113.5625,
-                "left": 991.828125,
-                "right": 1191.828125,
-                "top": 196.5,
-                "width": 200,
-                "x": 991.828125,
-                "y": 196.5
+                "left": 833.328125,
+                "top": 15.0
             },
             "post_job_actions": {
                 "HideDatasetActionread_db_hist": {
@@ -262,22 +226,22 @@
                     "output_name": "read_db_hist"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy5",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy6",
             "tool_shed_repository": {
-                "changeset_revision": "9cd178127b19",
+                "changeset_revision": "29dabd8db6f2",
                 "name": "meryl",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"operation_type\": {\"command_type\": \"histogram-kmers\", \"__current_case__\": 4, \"input_meryldb_02\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.3+galaxy5",
+            "tool_version": "1.3+galaxy6",
             "type": "tool",
             "uuid": "73e1c147-700d-4707-9a93-fd2ba8b2a32f",
             "workflow_outputs": []
         },
         "6": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy2",
             "errors": null,
             "id": 6,
             "input_connections": {
@@ -294,12 +258,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool GenomeScope",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "GenomeScope",
             "outputs": [
@@ -333,14 +292,8 @@
                 }
             ],
             "position": {
-                "bottom": 756.703125,
-                "height": 540.203125,
-                "left": 1279.609375,
-                "right": 1479.609375,
-                "top": 216.5,
-                "width": 200,
-                "x": 1279.609375,
-                "y": 216.5
+                "left": 1121.109375,
+                "top": 35.0
             },
             "post_job_actions": {
                 "TagDatasetActionlinear_plot": {
@@ -393,15 +346,15 @@
                     "output_name": "transformed_log_plot"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy2",
             "tool_shed_repository": {
-                "changeset_revision": "3169a38c2656",
+                "changeset_revision": "01210c4e9144",
                 "name": "genomescope",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"advanced_options\": {\"topology\": null, \"initial_repetitiveness\": null, \"initial_heterozygosities\": \"\", \"transform_exp\": null, \"testing\": \"true\", \"true_params\": \"\", \"trace_flag\": \"false\", \"num_rounds\": null}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"kmer_length\": {\"__class__\": \"ConnectedValue\"}, \"lambda\": null, \"max_kmercov\": null, \"output_options\": {\"output_files\": [\"model_output\", \"summary_output\"], \"no_unique_sequence\": \"false\"}, \"ploidy\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.0+galaxy1",
+            "tool_state": "{\"advanced_options\": {\"topology\": null, \"initial_repetitiveness\": null, \"initial_heterozygosities\": \"\", \"transform_exp\": null, \"testing\": \"true\", \"true_params\": \"\", \"trace_flag\": \"false\", \"num_rounds\": null}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"kmer_length\": {\"__class__\": \"ConnectedValue\"}, \"lambda\": null, \"max_kmercov\": null, \"output_options\": {\"output_files\": [\"model_output\", \"summary_output\"], \"no_unique_sequence\": \"false\"}, \"ploidy\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.0+galaxy2",
             "type": "tool",
             "uuid": "460b05b9-297a-465b-aed8-6fa593cc1a3d",
             "workflow_outputs": [


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/VGP-assembly-v2/VGP-meryldb-creation**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy5` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/meryl/meryl/1.3+galaxy6`
* `toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy1` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0`

The workflow release number has been updated from 0.1 to 0.2.
