### PR TITLE
add missing CHANGELOG

### DIFF
--- a/workflows/VGP-assembly-v2/VGP-meryldb-creation-trio/CHANGELOG.md
+++ b/workflows/VGP-assembly-v2/VGP-meryldb-creation-trio/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+
+## [0.1] - 2021-08-26
+### Added
+- First version of the workflow. 


### PR DESCRIPTION
autoupdate failed because one workflow does not have changelog.
We should have in the CI something like:
```
for f in $(find . -name "*.ga"); do
  dir=$(dirname $f)
  if [ ! -e "$dir/README.md" ]; then
    echo "$dir has no README"
  fi
  if [ ! -e "$dir/CHANGELOG.md" ]; then
    echo "$dir has no CHANGELOG"
  fi
  if [ ! -e "$dir/.dockstore.yml" ]; then
    echo "$dir has no dockstore"
  fi
  if [ ! -e "$dir/.workflowhub.yml" ]; then
    echo "$dir has no workflowhub"
  fi
done
```