### PR TITLE
Updating workflows/VGP-assembly-v2/VGP-meryldb-creation-trio from 0.1 to 0.2

### DIFF
--- a/workflows/VGP-assembly-v2/VGP-meryldb-creation-trio/CHANGELOG.md
+++ b/workflows/VGP-assembly-v2/VGP-meryldb-creation-trio/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+
+## [0.2] 2022-11-02
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_interlacer/fastq_paired_end_interlacer/1.2.0.1+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_interlacer/fastq_paired_end_interlacer/1.2.0.1`
+- `toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0`
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/workflows/VGP-assembly-v2/VGP-meryldb-creation-trio/meryldb-creation-trio.ga
+++ b/workflows/VGP-assembly-v2/VGP-meryldb-creation-trio/meryldb-creation-trio.ga
@@ -12,48 +12,16 @@
             "name": "Galaxy"
         }
     ],
-    "release": "0.1",
+    "release": "0.2",
     "format-version": "0.1",
     "license": "CC-BY-4.0",
     "name": "Quality Evaluation For Trio Assembly",
     "steps": {
         "0": {
-            "annotation": "K-mer length used to calculate k-mer spectra. For a human genome, the best k-mer size is k=21 for both haploid (3.1G) or diploid (6.2G).",
-            "content_id": null,
-            "errors": null,
-            "id": 0,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "K-mer length used to calculate k-mer spectra. For a human genome, the best k-mer size is k=21 for both haploid (3.1G) or diploid (6.2G).",
-                    "name": "K-mer length "
-                }
-            ],
-            "label": "K-mer length ",
-            "name": "Input parameter",
-            "outputs": [],
-            "position": {
-                "bottom": 633.90625,
-                "height": 61.78125,
-                "left": 7.34375,
-                "right": 207.34375,
-                "top": 572.125,
-                "width": 200,
-                "x": 7.34375,
-                "y": 572.125
-            },
-            "tool_id": null,
-            "tool_state": "{\"default\": 21, \"parameter_type\": \"integer\", \"optional\": true}",
-            "tool_version": null,
-            "type": "parameter_input",
-            "uuid": "4e2b5596-56fa-44f1-be09-5618a74ec7bd",
-            "workflow_outputs": []
-        },
-        "1": {
             "annotation": "",
             "content_id": null,
             "errors": null,
-            "id": 1,
+            "id": 0,
             "input_connections": {},
             "inputs": [
                 {
@@ -65,14 +33,8 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "bottom": 200,
-                "height": 61.78125,
-                "left": -687.5,
-                "right": -487.5,
-                "top": 138.21875,
-                "width": 200,
-                "x": -687.5,
-                "y": 138.21875
+                "left": 0.0,
+                "top": 213.71875
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"format\": [\"fastq\"], \"tag\": null, \"collection_type\": \"list\"}",
@@ -81,11 +43,11 @@
             "uuid": "c80ca98e-a5c6-4be0-934e-32e6d3351ba6",
             "workflow_outputs": []
         },
-        "2": {
+        "1": {
             "annotation": "Collection of Paired Illumina Data in fastq format for Parent 1.",
             "content_id": null,
             "errors": null,
-            "id": 2,
+            "id": 1,
             "input_connections": {},
             "inputs": [
                 {
@@ -97,20 +59,40 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "bottom": 637.28125,
-                "height": 82.171875,
-                "left": -471.78125,
-                "right": -271.78125,
-                "top": 555.109375,
-                "width": 200,
-                "x": -471.78125,
-                "y": 555.109375
+                "left": 215.71875,
+                "top": 630.609375
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"format\": [\"fastqsanger\"], \"tag\": null, \"collection_type\": \"list:paired\"}",
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "f66a7cb2-8798-4e94-81ec-a1229398543e",
+            "workflow_outputs": []
+        },
+        "2": {
+            "annotation": "K-mer length used to calculate k-mer spectra. For a human genome, the best k-mer size is k=21 for both haploid (3.1G) or diploid (6.2G).",
+            "content_id": null,
+            "errors": null,
+            "id": 2,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "K-mer length used to calculate k-mer spectra. For a human genome, the best k-mer size is k=21 for both haploid (3.1G) or diploid (6.2G).",
+                    "name": "K-mer length "
+                }
+            ],
+            "label": "K-mer length ",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 694.84375,
+                "top": 647.625
+            },
+            "tool_id": null,
+            "tool_state": "{\"default\": 21, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "4e2b5596-56fa-44f1-be09-5618a74ec7bd",
             "workflow_outputs": []
         },
         "3": {
@@ -129,14 +111,8 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "bottom": 915.625,
-                "height": 82.171875,
-                "left": -402.046875,
-                "right": -202.046875,
-                "top": 833.453125,
-                "width": 200,
-                "x": -402.046875,
-                "y": 833.453125
+                "left": 285.453125,
+                "top": 908.953125
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"format\": [\"fastqsanger\"], \"tag\": null, \"collection_type\": \"list:paired\"}",
@@ -161,14 +137,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 1337.25,
-                "height": 61.78125,
-                "left": 744.359375,
-                "right": 944.359375,
-                "top": 1275.46875,
-                "width": 200,
-                "x": 744.359375,
-                "y": 1275.46875
+                "left": 1431.859375,
+                "top": 1350.96875
             },
             "tool_id": null,
             "tool_state": "{\"default\": 2, \"parameter_type\": \"integer\", \"optional\": true}",
@@ -184,7 +154,7 @@
             "id": 5,
             "input_connections": {
                 "reads|reads_coll": {
-                    "id": 2,
+                    "id": 1,
                     "output_name": "output"
                 }
             },
@@ -202,14 +172,8 @@
                 }
             ],
             "position": {
-                "bottom": 443.34375,
-                "height": 164.34375,
-                "left": -69.671875,
-                "right": 130.328125,
-                "top": 279,
-                "width": 200,
-                "x": -69.671875,
-                "y": 279
+                "left": 617.828125,
+                "top": 354.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile_singles_from_coll": {
@@ -269,14 +233,8 @@
                 }
             ],
             "position": {
-                "bottom": 1052.328125,
-                "height": 164.34375,
-                "left": -97.03125,
-                "right": 102.96875,
-                "top": 887.984375,
-                "width": 200,
-                "x": -97.03125,
-                "y": 887.984375
+                "left": 590.46875,
+                "top": 963.484375
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile_singles_from_coll": {
@@ -329,7 +287,7 @@
                     "output_name": "outfile_pairs_from_coll"
                 },
                 "operation_type|options_kmer_size|input_kmer_size": {
-                    "id": 0,
+                    "id": 2,
                     "output_name": "output"
                 }
             },
@@ -343,14 +301,8 @@
                 }
             ],
             "position": {
-                "bottom": 321.453125,
-                "height": 143.953125,
-                "left": 288.5,
-                "right": 488.5,
-                "top": 177.5,
-                "width": 200,
-                "x": 288.5,
-                "y": 177.5
+                "left": 976.0,
+                "top": 253.0
             },
             "post_job_actions": {
                 "HideDatasetActionread_db": {
@@ -379,7 +331,7 @@
             "id": 8,
             "input_connections": {
                 "operation_type|child_reads": {
-                    "id": 1,
+                    "id": 0,
                     "output_name": "output"
                 },
                 "operation_type|maternal_reads": {
@@ -387,7 +339,7 @@
                     "output_name": "outfile_pairs_from_coll"
                 },
                 "operation_type|options_kmer_size|input_kmer_size": {
-                    "id": 0,
+                    "id": 2,
                     "output_name": "output"
                 },
                 "operation_type|paternal_reads": {
@@ -395,20 +347,7 @@
                     "output_name": "outfile_pairs_from_coll"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Meryl",
-                    "name": "operation_type"
-                },
-                {
-                    "description": "runtime parameter for tool Meryl",
-                    "name": "operation_type"
-                },
-                {
-                    "description": "runtime parameter for tool Meryl",
-                    "name": "operation_type"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Meryl",
             "outputs": [
@@ -438,14 +377,8 @@
                 }
             ],
             "position": {
-                "bottom": 842.96875,
-                "height": 499.421875,
-                "left": 604.515625,
-                "right": 804.515625,
-                "top": 343.546875,
-                "width": 200,
-                "x": 604.515625,
-                "y": 343.546875
+                "left": 1292.015625,
+                "top": 419.046875
             },
             "post_job_actions": {
                 "HideDatasetActionmat_db_hist": {
@@ -513,7 +446,7 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"operation_type\": {\"command_type\": \"trio-mode\", \"__current_case__\": 6, \"child_reads\": {\"__class__\": \"RuntimeValue\"}, \"paternal_reads\": {\"__class__\": \"RuntimeValue\"}, \"maternal_reads\": {\"__class__\": \"RuntimeValue\"}, \"options_kmer_size\": {\"kmer_size\": \"provide\", \"__current_case__\": 0, \"input_kmer_size\": {\"__class__\": \"ConnectedValue\"}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"operation_type\": {\"command_type\": \"trio-mode\", \"__current_case__\": 6, \"child_reads\": {\"__class__\": \"ConnectedValue\"}, \"paternal_reads\": {\"__class__\": \"ConnectedValue\"}, \"maternal_reads\": {\"__class__\": \"ConnectedValue\"}, \"options_kmer_size\": {\"kmer_size\": \"provide\", \"__current_case__\": 0, \"input_kmer_size\": {\"__class__\": \"ConnectedValue\"}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.3+galaxy6",
             "type": "tool",
             "uuid": "e2d000c3-b08d-4871-bdac-49430ba6685c",
@@ -546,7 +479,7 @@
                     "output_name": "outfile_pairs_from_coll"
                 },
                 "operation_type|options_kmer_size|input_kmer_size": {
-                    "id": 0,
+                    "id": 2,
                     "output_name": "output"
                 }
             },
@@ -560,14 +493,8 @@
                 }
             ],
             "position": {
-                "bottom": 1068.453125,
-                "height": 143.953125,
-                "left": 318.5,
-                "right": 518.5,
-                "top": 924.5,
-                "width": 200,
-                "x": 318.5,
-                "y": 924.5
+                "left": 1006.0,
+                "top": 1000.0
             },
             "post_job_actions": {
                 "HideDatasetActionread_db": {
@@ -610,14 +537,8 @@
                 }
             ],
             "position": {
-                "bottom": 307.0625,
-                "height": 113.5625,
-                "left": 620.5,
-                "right": 820.5,
-                "top": 193.5,
-                "width": 200,
-                "x": 620.5,
-                "y": 193.5
+                "left": 1308.0,
+                "top": 269.0
             },
             "post_job_actions": {
                 "HideDatasetActionread_db": {
@@ -641,7 +562,7 @@
         },
         "11": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy2",
             "errors": null,
             "id": 11,
             "input_connections": {
@@ -650,7 +571,7 @@
                     "output_name": "read_db_hist"
                 },
                 "kmer_length": {
-                    "id": 0,
+                    "id": 2,
                     "output_name": "output"
                 },
                 "ploidy": {
@@ -658,12 +579,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool GenomeScope",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "GenomeScope",
             "outputs": [
@@ -693,14 +609,8 @@
                 }
             ],
             "position": {
-                "bottom": 495.484375,
-                "height": 570.984375,
-                "left": 1151.4375,
-                "right": 1351.4375,
-                "top": -75.5,
-                "width": 200,
-                "x": 1151.4375,
-                "y": -75.5
+                "left": 1838.9375,
+                "top": 0.0
             },
             "post_job_actions": {
                 "TagDatasetActionlinear_plot": {
@@ -746,15 +656,15 @@
                     "output_name": "transformed_log_plot"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy2",
             "tool_shed_repository": {
-                "changeset_revision": "3169a38c2656",
+                "changeset_revision": "01210c4e9144",
                 "name": "genomescope",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"advanced_options\": {\"topology\": null, \"initial_repetitiveness\": null, \"initial_heterozygosities\": \"\", \"transform_exp\": null, \"testing\": \"false\", \"true_params\": \"\", \"trace_flag\": \"false\", \"num_rounds\": null}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"kmer_length\": {\"__class__\": \"ConnectedValue\"}, \"lambda\": null, \"max_kmercov\": null, \"output_options\": {\"output_files\": [\"model_output\", \"summary_output\"], \"no_unique_sequence\": \"false\"}, \"ploidy\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.0+galaxy1",
+            "tool_state": "{\"advanced_options\": {\"topology\": null, \"initial_repetitiveness\": null, \"initial_heterozygosities\": \"\", \"transform_exp\": null, \"testing\": \"false\", \"true_params\": \"\", \"trace_flag\": \"false\", \"num_rounds\": null}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"kmer_length\": {\"__class__\": \"ConnectedValue\"}, \"lambda\": null, \"max_kmercov\": null, \"output_options\": {\"output_files\": [\"model_output\", \"summary_output\"], \"no_unique_sequence\": \"false\"}, \"ploidy\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.0+galaxy2",
             "type": "tool",
             "uuid": "dbe5f067-039b-4970-8fed-4956c71fdcd4",
             "workflow_outputs": [
@@ -811,14 +721,8 @@
                 }
             ],
             "position": {
-                "bottom": 1097.0625,
-                "height": 113.5625,
-                "left": 614.5,
-                "right": 814.5,
-                "top": 983.5,
-                "width": 200,
-                "x": 614.5,
-                "y": 983.5
+                "left": 1302.0,
+                "top": 1059.0
             },
             "post_job_actions": {
                 "HideDatasetActionread_db": {
@@ -861,14 +765,8 @@
                 }
             ],
             "position": {
-                "bottom": 346.0625,
-                "height": 113.5625,
-                "left": 876.5,
-                "right": 1076.5,
-                "top": 232.5,
-                "width": 200,
-                "x": 876.5,
-                "y": 232.5
+                "left": 1564.0,
+                "top": 308.0
             },
             "post_job_actions": {
                 "HideDatasetActionread_db_hist": {
@@ -911,14 +809,8 @@
                 }
             ],
             "position": {
-                "bottom": 1091.0625,
-                "height": 113.5625,
-                "left": 869.5,
-                "right": 1069.5,
-                "top": 977.5,
-                "width": 200,
-                "x": 869.5,
-                "y": 977.5
+                "left": 1557.0,
+                "top": 1053.0
             },
             "post_job_actions": {
                 "HideDatasetActionread_db_hist": {
@@ -942,7 +834,7 @@
         },
         "15": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy2",
             "errors": null,
             "id": 15,
             "input_connections": {
@@ -951,7 +843,7 @@
                     "output_name": "read_db_hist"
                 },
                 "kmer_length": {
-                    "id": 0,
+                    "id": 2,
                     "output_name": "output"
                 },
                 "ploidy": {
@@ -959,12 +851,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool GenomeScope",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": "Genomescope on paternal haplotype",
             "name": "GenomeScope",
             "outputs": [
@@ -994,14 +881,8 @@
                 }
             ],
             "position": {
-                "bottom": 1045.046875,
-                "height": 550.59375,
-                "left": 1155.109375,
-                "right": 1355.109375,
-                "top": 494.453125,
-                "width": 200,
-                "x": 1155.109375,
-                "y": 494.453125
+                "left": 1842.609375,
+                "top": 569.953125
             },
             "post_job_actions": {
                 "HideDatasetActionmodel": {
@@ -1057,15 +938,15 @@
                     "output_name": "transformed_log_plot"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy2",
             "tool_shed_repository": {
-                "changeset_revision": "3169a38c2656",
+                "changeset_revision": "01210c4e9144",
                 "name": "genomescope",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"advanced_options\": {\"topology\": null, \"initial_repetitiveness\": null, \"initial_heterozygosities\": \"\", \"transform_exp\": null, \"testing\": \"false\", \"true_params\": \"\", \"trace_flag\": \"false\", \"num_rounds\": null}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"kmer_length\": {\"__class__\": \"ConnectedValue\"}, \"lambda\": null, \"max_kmercov\": null, \"output_options\": {\"output_files\": [\"model_output\", \"summary_output\"], \"no_unique_sequence\": \"false\"}, \"ploidy\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.0+galaxy1",
+            "tool_state": "{\"advanced_options\": {\"topology\": null, \"initial_repetitiveness\": null, \"initial_heterozygosities\": \"\", \"transform_exp\": null, \"testing\": \"false\", \"true_params\": \"\", \"trace_flag\": \"false\", \"num_rounds\": null}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"kmer_length\": {\"__class__\": \"ConnectedValue\"}, \"lambda\": null, \"max_kmercov\": null, \"output_options\": {\"output_files\": [\"model_output\", \"summary_output\"], \"no_unique_sequence\": \"false\"}, \"ploidy\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.0+galaxy2",
             "type": "tool",
             "uuid": "0d7b78be-2a60-4a3b-8033-fcfafe0944c3",
             "workflow_outputs": [
@@ -1093,7 +974,7 @@
         },
         "16": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy2",
             "errors": null,
             "id": 16,
             "input_connections": {
@@ -1102,7 +983,7 @@
                     "output_name": "read_db_hist"
                 },
                 "kmer_length": {
-                    "id": 0,
+                    "id": 2,
                     "output_name": "output"
                 },
                 "ploidy": {
@@ -1110,12 +991,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool GenomeScope",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": "Genomescope on maternal haplotype",
             "name": "GenomeScope",
             "outputs": [
@@ -1145,14 +1021,8 @@
                 }
             ],
             "position": {
-                "bottom": 1624.0625,
-                "height": 550.59375,
-                "left": 1153.484375,
-                "right": 1353.484375,
-                "top": 1073.46875,
-                "width": 200,
-                "x": 1153.484375,
-                "y": 1073.46875
+                "left": 1840.984375,
+                "top": 1148.96875
             },
             "post_job_actions": {
                 "HideDatasetActionmodel": {
@@ -1208,15 +1078,15 @@
                     "output_name": "transformed_log_plot"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy2",
             "tool_shed_repository": {
-                "changeset_revision": "3169a38c2656",
+                "changeset_revision": "01210c4e9144",
                 "name": "genomescope",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"advanced_options\": {\"topology\": null, \"initial_repetitiveness\": null, \"initial_heterozygosities\": \"\", \"transform_exp\": null, \"testing\": \"false\", \"true_params\": \"\", \"trace_flag\": \"false\", \"num_rounds\": null}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"kmer_length\": {\"__class__\": \"ConnectedValue\"}, \"lambda\": null, \"max_kmercov\": null, \"output_options\": {\"output_files\": [\"model_output\", \"summary_output\"], \"no_unique_sequence\": \"false\"}, \"ploidy\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.0+galaxy1",
+            "tool_state": "{\"advanced_options\": {\"topology\": null, \"initial_repetitiveness\": null, \"initial_heterozygosities\": \"\", \"transform_exp\": null, \"testing\": \"false\", \"true_params\": \"\", \"trace_flag\": \"false\", \"num_rounds\": null}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"kmer_length\": {\"__class__\": \"ConnectedValue\"}, \"lambda\": null, \"max_kmercov\": null, \"output_options\": {\"output_files\": [\"model_output\", \"summary_output\"], \"no_unique_sequence\": \"false\"}, \"ploidy\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.0+galaxy2",
             "type": "tool",
             "uuid": "8ae9060f-ec62-4968-998e-50f44f2b3ab9",
             "workflow_outputs": [


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/VGP-assembly-v2/VGP-meryldb-creation-trio**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_interlacer/fastq_paired_end_interlacer/1.2.0.1+galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/devteam/fastq_paired_end_interlacer/fastq_paired_end_interlacer/1.2.0.1`
* `toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0+galaxy1` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/genomescope/genomescope/2.0`

The workflow release number has been updated from 0.1 to 0.2.
