### PR TITLE
Updating workflows/variant-calling/generic-variant-calling-wgs-pe from 0.1 to 0.2

### DIFF
--- a/workflows/variant-calling/generic-variant-calling-wgs-pe/CHANGELOG.md
+++ b/workflows/variant-calling/generic-variant-calling-wgs-pe/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.2] 2022-11-02
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_build_gb/4.3+T.galaxy4` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_build_gb/4.3.1t.1`
+- `toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.13+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.15.1+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.2` was updated to `toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.3`
+- `toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.2+galaxy2` was updated to `toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.4`
+- `toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy1`
+- `toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy2`
+- `toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/4.3+T.galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/4.3.1t.1`
+
 ## [0.1]
 
 - Initial version of Generic variation analysis on WGS PE data workflow

--- a/workflows/variant-calling/generic-variant-calling-wgs-pe/Generic-variation-analysis-on-WGS-PE-data.ga
+++ b/workflows/variant-calling/generic-variant-calling-wgs-pe/Generic-variation-analysis-on-WGS-PE-data.ga
@@ -1,801 +1,756 @@
 {
-  "a_galaxy_workflow": "true",
-  "annotation": "Workflow for variant analysis against  a reference genome in GenBank format",
-  "creator": [
-    {
-      "class": "Person",
-      "identifier": "https://orcid.org/0000-0002-5987-8032",
-      "name": "Anton Nekrutenko"
-    }
-  ],
-  "format-version": "0.1",
-  "release": "0.1",
-  "license": "MIT",
-  "name": "Generic variation analysis on WGS PE data",
-  "steps": {
-    "0": {
-      "annotation": "Illumina reads with fastqsanger encoding",
-      "content_id": null,
-      "errors": null,
-      "id": 0,
-      "input_connections": {},
-      "inputs": [
+    "a_galaxy_workflow": "true",
+    "annotation": "Workflow for variant analysis against  a reference genome in GenBank format",
+    "creator": [
         {
-          "description": "Illumina reads with fastqsanger encoding",
-          "name": "Paired Collection"
+            "class": "Person",
+            "identifier": "https://orcid.org/0000-0002-5987-8032",
+            "name": "Anton Nekrutenko"
         }
-      ],
-      "label": "Paired Collection",
-      "name": "Input dataset collection",
-      "outputs": [],
-      "position": {
-        "left": 58.531223149503546,
-        "top": 300.6406189710691
-      },
-      "tool_id": null,
-      "tool_state": "{\"optional\": false, \"format\": [\"fastqsanger\", \"fastqsanger.gz\"], \"tag\": \"\", \"collection_type\": \"list:paired\"}",
-      "tool_version": null,
-      "type": "data_collection_input",
-      "uuid": "2352cd98-29f2-456b-a807-ede1227f6089",
-      "workflow_outputs": []
+    ],
+    "format-version": "0.1",
+    "release": "0.2",
+    "license": "MIT",
+    "name": "Generic variation analysis on WGS PE data",
+    "steps": {
+        "0": {
+            "annotation": "Illumina reads with fastqsanger encoding",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Illumina reads with fastqsanger encoding",
+                    "name": "Paired Collection"
+                }
+            ],
+            "label": "Paired Collection",
+            "name": "Input dataset collection",
+            "outputs": [],
+            "position": {
+                "left": 58.531223149503546,
+                "top": 300.6406189710691
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"format\": [\"fastqsanger\", \"fastqsanger.gz\"], \"tag\": \"\", \"collection_type\": \"list:paired\"}",
+            "tool_version": null,
+            "type": "data_collection_input",
+            "uuid": "2352cd98-29f2-456b-a807-ede1227f6089",
+            "workflow_outputs": []
+        },
+        "1": {
+            "annotation": "GenBank with annotations for the genome of interest",
+            "content_id": null,
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "GenBank with annotations for the genome of interest",
+                    "name": "GenBank genome"
+                }
+            ],
+            "label": "GenBank genome",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 0,
+                "top": 631.656273804954
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"format\": [\"genbank\"], \"tag\": \"\"}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "5e6e8cac-8a75-42e8-9932-6c63bcebb861",
+            "workflow_outputs": []
+        },
+        "2": {
+            "annotation": "Should describe your reference genome, e.g. mpxv for Monkeypox virus.",
+            "content_id": null,
+            "errors": null,
+            "id": 2,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Should describe your reference genome, e.g. mpxv for Monkeypox virus.",
+                    "name": "Name for genome database"
+                }
+            ],
+            "label": "Name for genome database",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 20.98434665780934,
+                "top": 745.593744965532
+            },
+            "tool_id": null,
+            "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "7e5e0a5f-4386-44cb-8941-f04ec7d8b725",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "a543d03c-6cc6-4d50-8dee-ec7a839b16b9"
+                }
+            ]
+        },
+        "3": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.2+galaxy0",
+            "errors": null,
+            "id": 3,
+            "input_connections": {
+                "single_paired|paired_input": {
+                    "id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "fastp",
+            "outputs": [
+                {
+                    "name": "output_paired_coll",
+                    "type": "input"
+                },
+                {
+                    "name": "report_html",
+                    "type": "html"
+                },
+                {
+                    "name": "report_json",
+                    "type": "json"
+                }
+            ],
+            "position": {
+                "left": 325.0155944202679,
+                "top": 95.51562991016024
+            },
+            "post_job_actions": {
+                "HideDatasetActionreport_json": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "report_json"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.2+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "65b93b623c77",
+                "name": "fastp",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": \"false\", \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": \"false\", \"length_required\": null, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": \"false\", \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": \"true\", \"report_json\": \"true\"}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": \"false\", \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": \"false\", \"umi_loc\": \"\", \"umi_len\": null, \"umi_prefix\": \"\"}, \"cutting_by_quality_options\": {\"cut_by_quality5\": \"false\", \"cut_by_quality3\": \"false\", \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": \"false\"}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 2, \"paired_input\": {\"__class__\": \"ConnectedValue\"}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": \"false\", \"adapter_sequence1\": \"\", \"adapter_sequence2\": \"\"}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.23.2+galaxy0",
+            "type": "tool",
+            "uuid": "6410c94d-827d-4d1b-b15d-be13df2db0ac",
+            "workflow_outputs": [
+                {
+                    "label": "fastp_pe",
+                    "output_name": "output_paired_coll",
+                    "uuid": "c49d5f48-ab0e-4f59-8b2f-27b3a8f65609"
+                },
+                {
+                    "label": "fastp_html_report",
+                    "output_name": "report_html",
+                    "uuid": "c77d6708-0d13-4f9f-aed8-b3e30de5bafa"
+                }
+            ]
+        },
+        "4": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_build_gb/4.3+T.galaxy5",
+            "errors": null,
+            "id": 4,
+            "input_connections": {
+                "genome_version": {
+                    "id": 2,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool SnpEff build:",
+                    "name": "input_type"
+                }
+            ],
+            "label": null,
+            "name": "SnpEff build:",
+            "outputs": [
+                {
+                    "name": "snpeff_output",
+                    "type": "snpeffdb"
+                },
+                {
+                    "name": "output_fasta",
+                    "type": "fasta"
+                }
+            ],
+            "position": {
+                "left": 289.04683721041243,
+                "top": 692.6562509323089
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_build_gb/4.3+T.galaxy5",
+            "tool_shed_repository": {
+                "changeset_revision": "5c7b70713fb5",
+                "name": "snpeff",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"codon_table\": \"Standard\", \"genome_version\": {\"__class__\": \"ConnectedValue\"}, \"input_type\": {\"input_type_selector\": \"gb\", \"__current_case__\": 0, \"input\": {\"__class__\": \"RuntimeValue\"}, \"fasta\": \"yes\", \"remove_version\": \"true\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "4.3+T.galaxy5",
+            "type": "tool",
+            "uuid": "1406c6b2-51c9-47f7-9f9d-190c0e9ad515",
+            "workflow_outputs": [
+                {
+                    "label": "SnpEff4.3 database",
+                    "output_name": "snpeff_output",
+                    "uuid": "c43258f1-ae40-45d9-a559-a7e20f2ac107"
+                },
+                {
+                    "label": "Fasta sequences for genbank file",
+                    "output_name": "output_fasta",
+                    "uuid": "6a81041a-b077-4211-8d48-aafbe78c0713"
+                }
+            ]
+        },
+        "5": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2",
+            "errors": null,
+            "id": 5,
+            "input_connections": {
+                "fastq_input|fastq_input1": {
+                    "id": 3,
+                    "output_name": "output_paired_coll"
+                },
+                "reference_source|ref_file": {
+                    "id": 4,
+                    "output_name": "output_fasta"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Map with BWA-MEM",
+            "outputs": [
+                {
+                    "name": "bam_output",
+                    "type": "bam"
+                }
+            ],
+            "position": {
+                "left": 590.5546666162805,
+                "top": 327.0468702141476
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2",
+            "tool_shed_repository": {
+                "changeset_revision": "e188dc7a68e6",
+                "name": "bwa",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"analysis_type\": {\"analysis_type_selector\": \"full\", \"__current_case__\": 4, \"algorithmic_options\": {\"algorithmic_options_selector\": \"do_not_set\", \"__current_case__\": 1}, \"scoring_options\": {\"scoring_options_selector\": \"do_not_set\", \"__current_case__\": 1}, \"io_options\": {\"io_options_selector\": \"set\", \"__current_case__\": 0, \"five\": \"false\", \"q\": \"true\", \"T\": \"30\", \"h\": \"5\", \"a\": \"false\", \"C\": \"false\", \"V\": \"false\", \"Y\": \"true\", \"M\": \"false\"}}, \"fastq_input\": {\"fastq_input_selector\": \"paired_collection\", \"__current_case__\": 2, \"fastq_input1\": {\"__class__\": \"ConnectedValue\"}, \"iset_stats\": \"\"}, \"output_sort\": \"coordinate\", \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"ConnectedValue\"}, \"index_a\": \"auto\"}, \"rg\": {\"rg_selector\": \"do_not_set\", \"__current_case__\": 3}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.7.17.2",
+            "type": "tool",
+            "uuid": "a6bd6dbf-d3e7-439f-b826-16ec60bfb33f",
+            "workflow_outputs": [
+                {
+                    "label": "bwa_mem_alignments",
+                    "output_name": "bam_output",
+                    "uuid": "4fa2a1d1-3df1-43a0-9df8-687f55df83a4"
+                }
+            ]
+        },
+        "6": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.15.1+galaxy0",
+            "errors": null,
+            "id": 6,
+            "input_connections": {
+                "input": {
+                    "id": 5,
+                    "output_name": "bam_output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Samtools view",
+            "outputs": [
+                {
+                    "name": "outputsam",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 823.9531041162805,
+                "top": 207.86718147106907
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutputsam": {
+                    "action_arguments": {
+                        "newname": "Mapped read pairs (filtered bwa-mem result)"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "outputsam"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.15.1+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "5826298f6a73",
+                "name": "samtools_view",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"mode\": {\"outtype\": \"selected_reads\", \"__current_case__\": 1, \"filter_config\": {\"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cond_rg\": {\"select_rg\": \"no\", \"__current_case__\": 0}, \"quality\": \"0\", \"library\": \"\", \"cigarcons\": null, \"inclusive_filter\": [\"1\", \"2\"], \"exclusive_filter\": null, \"exclusive_filter_all\": null, \"tag\": \"\", \"qname_file\": {\"__class__\": \"RuntimeValue\"}}, \"subsample_config\": {\"subsampling_mode\": {\"select_subsample\": \"fraction\", \"__current_case__\": 0, \"factor\": \"1.0\", \"seed\": null}}, \"output_options\": {\"reads_report_type\": \"retained\", \"__current_case__\": 0, \"complementary_output\": \"false\", \"adv_output\": {\"readtags\": [], \"collapsecigar\": \"false\"}, \"output_format\": {\"oformat\": \"bam\", \"__current_case__\": 2}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.15.1+galaxy0",
+            "type": "tool",
+            "uuid": "6186b9e0-5841-4572-bec3-3f5c11a1c1cf",
+            "workflow_outputs": [
+                {
+                    "label": "filtered_alignment",
+                    "output_name": "outputsam",
+                    "uuid": "68a53be7-7332-4c7f-9615-32770064ffb0"
+                }
+            ]
+        },
+        "7": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.3",
+            "errors": null,
+            "id": 7,
+            "input_connections": {
+                "inputFile": {
+                    "id": 6,
+                    "output_name": "outputsam"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "MarkDuplicates",
+            "outputs": [
+                {
+                    "name": "metrics_file",
+                    "type": "txt"
+                },
+                {
+                    "name": "outFile",
+                    "type": "bam"
+                }
+            ],
+            "position": {
+                "left": 1043.617201919711,
+                "top": 322.0156341366272
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.3",
+            "tool_shed_repository": {
+                "changeset_revision": "b502c227b5e6",
+                "name": "picard",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"assume_sorted\": \"true\", \"barcode_tag\": \"\", \"comments\": [], \"duplicate_scoring_strategy\": \"SUM_OF_BASE_QUALITIES\", \"inputFile\": {\"__class__\": \"ConnectedValue\"}, \"optical_duplicate_pixel_distance\": \"100\", \"read_name_regex\": \"\", \"remove_duplicates\": \"true\", \"validation_stringency\": \"LENIENT\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.18.2.3",
+            "type": "tool",
+            "uuid": "cd152e82-b33b-4cca-9126-a4bd63138593",
+            "workflow_outputs": [
+                {
+                    "label": "markduplicates_stats",
+                    "output_name": "metrics_file",
+                    "uuid": "2a24ab1a-6f0f-4896-b436-d6eeeb7ca22c"
+                },
+                {
+                    "label": "markduplicates_reads",
+                    "output_name": "outFile",
+                    "uuid": "9fa98a79-4a12-41df-82c7-6fc4c5a8a1fa"
+                }
+            ]
+        },
+        "8": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.4",
+            "errors": null,
+            "id": 8,
+            "input_connections": {
+                "input": {
+                    "id": 6,
+                    "output_name": "outputsam"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Samtools stats",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 1099.2499388405358,
+                "top": 137.63280895722616
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.4",
+            "tool_shed_repository": {
+                "changeset_revision": "3a0efe14891f",
+                "name": "samtools_stats",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cov_threshold\": null, \"coverage_cond\": {\"coverage_select\": \"no\", \"__current_case__\": 0}, \"filter_by_flags\": {\"filter_flags\": \"nofilter\", \"__current_case__\": 1}, \"gc_depth\": null, \"input\": {\"__class__\": \"ConnectedValue\"}, \"insert_size\": null, \"most_inserts\": null, \"read_group\": null, \"read_length\": null, \"remove_dups\": \"false\", \"remove_overlaps\": \"false\", \"sparse\": \"false\", \"split_output_cond\": {\"split_output_selector\": \"no\", \"__current_case__\": 0}, \"trim_quality\": null, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.0.4",
+            "type": "tool",
+            "uuid": "0ba8c049-f7f1-487f-aa23-3bc6cb2d23aa",
+            "workflow_outputs": [
+                {
+                    "label": "mapped_reads_stats",
+                    "output_name": "output",
+                    "uuid": "acc7e52b-636c-4f28-a49a-0052f23c8737"
+                }
+            ]
+        },
+        "9": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_viterbi/lofreq_viterbi/2.1.5+galaxy0",
+            "errors": null,
+            "id": 9,
+            "input_connections": {
+                "reads": {
+                    "id": 7,
+                    "output_name": "outFile"
+                },
+                "reference_source|ref": {
+                    "id": 4,
+                    "output_name": "output_fasta"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Realign reads",
+            "outputs": [
+                {
+                    "name": "realigned",
+                    "type": "bam"
+                }
+            ],
+            "position": {
+                "left": 1181.2499875692147,
+                "top": 531.7812529212346
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_viterbi/lofreq_viterbi/2.1.5+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "aa35ee7f3ab2",
+                "name": "lofreq_viterbi",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"adv_options\": {\"keepflags\": \"false\", \"bq2_handling\": {\"replace_bq2\": \"keep\", \"__current_case__\": 0, \"defqual\": \"2\"}}, \"reads\": {\"__class__\": \"ConnectedValue\"}, \"reference_source\": {\"ref_selector\": \"history\", \"__current_case__\": 1, \"ref\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.1.5+galaxy0",
+            "type": "tool",
+            "uuid": "f22634d5-0472-4b37-9f1f-55693be5109d",
+            "workflow_outputs": [
+                {
+                    "label": "realigned_deduplicated_filtered_mapped_reads",
+                    "output_name": "realigned",
+                    "uuid": "436348c9-ad6f-46aa-9cd4-7744563ca643"
+                }
+            ]
+        },
+        "10": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy0",
+            "errors": null,
+            "id": 10,
+            "input_connections": {
+                "results_0|software_cond|input": {
+                    "id": 3,
+                    "output_name": "report_json"
+                },
+                "results_1|software_cond|output_0|type|input": {
+                    "id": 8,
+                    "output_name": "output"
+                },
+                "results_2|software_cond|output_0|input": {
+                    "id": 7,
+                    "output_name": "metrics_file"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "MultiQC",
+            "outputs": [
+                {
+                    "name": "stats",
+                    "type": "input"
+                },
+                {
+                    "name": "html_report",
+                    "type": "html"
+                }
+            ],
+            "position": {
+                "left": 1536.7109061744209,
+                "top": 0
+            },
+            "post_job_actions": {
+                "HideDatasetActionstats": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "stats"
+                },
+                "RenameDatasetActionhtml_report": {
+                    "action_arguments": {
+                        "newname": "Preprocessing and mapping reports"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "html_report"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "9a913cdee30e",
+                "name": "multiqc",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"comment\": \"\", \"export\": \"false\", \"flat\": \"false\", \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastp\", \"__current_case__\": 7, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"samtools\", \"__current_case__\": 24, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"stats\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}}]}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"picard\", \"__current_case__\": 17, \"output\": [{\"__index__\": 0, \"type\": \"markdups\", \"input\": {\"__class__\": \"ConnectedValue\"}}]}}], \"saveLog\": \"false\", \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.11+galaxy0",
+            "type": "tool",
+            "uuid": "1eab5364-f845-4668-9bb0-c820b2c61ab1",
+            "workflow_outputs": [
+                {
+                    "label": "preprocessing_and_mapping_reports",
+                    "output_name": "html_report",
+                    "uuid": "710f4e3f-c7a5-465a-96ec-7eb558a44b35"
+                }
+            ]
+        },
+        "11": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy1",
+            "errors": null,
+            "id": 11,
+            "input_connections": {
+                "reads": {
+                    "id": 9,
+                    "output_name": "realigned"
+                },
+                "strategy|reference_source|ref": {
+                    "id": 4,
+                    "output_name": "output_fasta"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Insert indel qualities",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "bam"
+                }
+            ],
+            "position": {
+                "left": 1296.3124448073129,
+                "top": 712.8437220928869
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "Fully processed reads for variant calling (deduplicated, realigned reads with added indelquals)"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "971e07ca4456",
+                "name": "lofreq_indelqual",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"reads\": {\"__class__\": \"ConnectedValue\"}, \"strategy\": {\"selector\": \"dindel\", \"__current_case__\": 1, \"reference_source\": {\"ref_selector\": \"history\", \"__current_case__\": 1, \"ref\": {\"__class__\": \"ConnectedValue\"}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.1.5+galaxy1",
+            "type": "tool",
+            "uuid": "8568254e-a9a6-4d67-a4a9-97947d7bc10e",
+            "workflow_outputs": [
+                {
+                    "label": "realigned_deduplicated_filtered_mapped_reads_with_indel_quals",
+                    "output_name": "output",
+                    "uuid": "71283f3d-16ce-43a6-af6a-89e0d6d0aa4f"
+                }
+            ]
+        },
+        "12": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy2",
+            "errors": null,
+            "id": 12,
+            "input_connections": {
+                "reads": {
+                    "id": 11,
+                    "output_name": "output"
+                },
+                "reference_source|ref": {
+                    "id": 4,
+                    "output_name": "output_fasta"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Call variants",
+            "outputs": [
+                {
+                    "name": "variants",
+                    "type": "vcf"
+                }
+            ],
+            "position": {
+                "left": 1423.3749607187183,
+                "top": 908.2577816094984
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "4805fe3d8fda",
+                "name": "lofreq_call",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"call_control\": {\"set_call_options\": \"yes\", \"__current_case__\": 1, \"coverage\": {\"min_cov\": \"5\", \"max_depth\": \"1000000\"}, \"pe\": {\"use_orphan\": \"false\"}, \"bc_quals\": {\"min_bq\": \"30\", \"min_alt_bq\": \"30\", \"alt_bq\": {\"modify\": \"\", \"__current_case__\": 0}}, \"align_quals\": {\"alnqual\": {\"use_alnqual\": \"\", \"__current_case__\": 0, \"alnqual_choice\": {\"alnquals_to_use\": \"\", \"__current_case__\": 1, \"extended_baq\": \"true\"}}}, \"map_quals\": {\"min_mq\": \"0\", \"use_mq\": {\"no_mq\": \"\", \"__current_case__\": 0, \"max_mq\": \"255\"}}, \"source_qual\": {\"use_src_qual\": {\"src_qual\": \"\", \"__current_case__\": 0}}, \"joint_qual\": {\"min_jq\": \"0\", \"min_alt_jq\": \"0\", \"def_alt_jq\": \"0\"}}, \"filter_control\": {\"filter_type\": \"set_custom\", \"__current_case__\": 3, \"sig\": \"0.0005\", \"bonf\": \"0\", \"others\": \"false\"}, \"reads\": {\"__class__\": \"ConnectedValue\"}, \"reference_source\": {\"ref_selector\": \"history\", \"__current_case__\": 1, \"ref\": {\"__class__\": \"ConnectedValue\"}}, \"regions\": {\"restrict_to_region\": \"genome\", \"__current_case__\": 0}, \"variant_types\": \"--call-indels\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.1.5+galaxy2",
+            "type": "tool",
+            "uuid": "b8c2b602-396e-4727-8774-cd87edbe3a07",
+            "workflow_outputs": [
+                {
+                    "label": "called_variants",
+                    "output_name": "variants",
+                    "uuid": "f0daf1f1-9200-45de-8c6e-776879096b3e"
+                }
+            ]
+        },
+        "13": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_filter/lofreq_filter/2.1.5+galaxy0",
+            "errors": null,
+            "id": 13,
+            "input_connections": {
+                "invcf": {
+                    "id": 12,
+                    "output_name": "variants"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Lofreq filter",
+            "outputs": [
+                {
+                    "name": "outvcf",
+                    "type": "vcf"
+                }
+            ],
+            "position": {
+                "left": 1623.8827831633464,
+                "top": 733.9296904212346
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_filter/lofreq_filter/2.1.5+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "7dfca164d2e3",
+                "name": "lofreq_filter",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"af\": {\"af_min\": \"0.0\", \"af_max\": \"0.0\"}, \"coverage\": {\"cov_min\": \"0\", \"cov_max\": \"0\"}, \"filter_by_type\": {\"keep_only\": \"\", \"__current_case__\": 0, \"qual\": {\"snvqual_filter\": {\"snvqual\": \"no\", \"__current_case__\": 0}, \"indelqual_filter\": {\"indelqual\": \"no\", \"__current_case__\": 0}}}, \"flag_or_drop\": \"--print-all\", \"invcf\": {\"__class__\": \"ConnectedValue\"}, \"sb\": {\"sb_filter\": {\"strand_bias\": \"mtc\", \"__current_case__\": 2, \"sb_alpha\": \"0.001\", \"sb_mtc\": \"fdr\", \"sb_compound\": \"true\", \"sb_indels\": \"false\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.1.5+galaxy0",
+            "type": "tool",
+            "uuid": "72fc0a88-0fff-4434-9c7b-cff1694f8fbf",
+            "workflow_outputs": [
+                {
+                    "label": "soft_filtered_variants",
+                    "output_name": "outvcf",
+                    "uuid": "58a73993-57b0-4590-b462-65f0a0f7978a"
+                }
+            ]
+        },
+        "14": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/4.3+T.galaxy1",
+            "errors": null,
+            "id": 14,
+            "input_connections": {
+                "input": {
+                    "id": 13,
+                    "output_name": "outvcf"
+                },
+                "snpDb|snpeff_db": {
+                    "id": 4,
+                    "output_name": "snpeff_output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool SnpEff eff:",
+                    "name": "intervals"
+                },
+                {
+                    "description": "runtime parameter for tool SnpEff eff:",
+                    "name": "transcripts"
+                }
+            ],
+            "label": null,
+            "name": "SnpEff eff:",
+            "outputs": [
+                {
+                    "name": "snpeff_output",
+                    "type": "vcf"
+                },
+                {
+                    "name": "statsFile",
+                    "type": "html"
+                }
+            ],
+            "position": {
+                "left": 1973.0859200969005,
+                "top": 761.6406458215656
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/4.3+T.galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "5c7b70713fb5",
+                "name": "snpeff",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"annotations\": [\"-formatEff\", \"-classic\"], \"chr\": \"\", \"csvStats\": \"false\", \"filter\": {\"specificEffects\": \"no\", \"__current_case__\": 0}, \"filterOut\": [\"-no-downstream\", \"-no-intergenic\", \"-no-intron\", \"-no-upstream\", \"-no-utr\"], \"generate_stats\": \"true\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"inputFormat\": \"vcf\", \"intervals\": {\"__class__\": \"RuntimeValue\"}, \"noLog\": \"true\", \"offset\": \"default\", \"outputConditional\": {\"outputFormat\": \"vcf\", \"__current_case__\": 0}, \"snpDb\": {\"genomeSrc\": \"custom\", \"__current_case__\": 3, \"snpeff_db\": {\"__class__\": \"ConnectedValue\"}, \"codon_table\": \"Standard\"}, \"spliceRegion\": {\"setSpliceRegions\": \"no\", \"__current_case__\": 0}, \"spliceSiteSize\": null, \"transcripts\": {\"__class__\": \"RuntimeValue\"}, \"udLength\": \"0\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "4.3+T.galaxy1",
+            "type": "tool",
+            "uuid": "2fa5e8fd-9282-4156-ba29-93d6ad2b65e1",
+            "workflow_outputs": [
+                {
+                    "label": "SnpEff eff: stats",
+                    "output_name": "statsFile",
+                    "uuid": "5587a236-9d63-4d3b-b368-0643fa07529e"
+                },
+                {
+                    "label": "SnpEff variants",
+                    "output_name": "snpeff_output",
+                    "uuid": "4a062f86-0ab4-4ba1-b8fc-70e35d1f1df7"
+                }
+            ]
+        }
     },
-    "1": {
-      "annotation": "GenBank with annotations for the genome of interest",
-      "content_id": null,
-      "errors": null,
-      "id": 1,
-      "input_connections": {},
-      "inputs": [
-        {
-          "description": "GenBank with annotations for the genome of interest",
-          "name": "GenBank genome"
-        }
-      ],
-      "label": "GenBank genome",
-      "name": "Input dataset",
-      "outputs": [],
-      "position": {
-        "left": 0,
-        "top": 631.656273804954
-      },
-      "tool_id": null,
-      "tool_state": "{\"optional\": false, \"format\": [\"genbank\"], \"tag\": \"\"}",
-      "tool_version": null,
-      "type": "data_input",
-      "uuid": "5e6e8cac-8a75-42e8-9932-6c63bcebb861",
-      "workflow_outputs": []
-    },
-    "2": {
-      "annotation": "Should describe your reference genome, e.g. mpxv for Monkeypox virus.",
-      "content_id": null,
-      "errors": null,
-      "id": 2,
-      "input_connections": {},
-      "inputs": [
-        {
-          "description": "Should describe your reference genome, e.g. mpxv for Monkeypox virus.",
-          "name": "Name for genome database"
-        }
-      ],
-      "label": "Name for genome database",
-      "name": "Input parameter",
-      "outputs": [],
-      "position": {
-        "left": 20.98434665780934,
-        "top": 745.593744965532
-      },
-      "tool_id": null,
-      "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
-      "tool_version": null,
-      "type": "parameter_input",
-      "uuid": "7e5e0a5f-4386-44cb-8941-f04ec7d8b725",
-      "workflow_outputs": [
-        {
-          "label": null,
-          "output_name": "output",
-          "uuid": "a543d03c-6cc6-4d50-8dee-ec7a839b16b9"
-        }
-      ]
-    },
-    "3": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.2+galaxy0",
-      "errors": null,
-      "id": 3,
-      "input_connections": {
-        "single_paired|paired_input": {
-          "id": 0,
-          "output_name": "output"
-        }
-      },
-      "inputs": [
-        {
-          "description": "runtime parameter for tool fastp",
-          "name": "single_paired"
-        }
-      ],
-      "label": null,
-      "name": "fastp",
-      "outputs": [
-        {
-          "name": "output_paired_coll",
-          "type": "input"
-        },
-        {
-          "name": "report_html",
-          "type": "html"
-        },
-        {
-          "name": "report_json",
-          "type": "json"
-        }
-      ],
-      "position": {
-        "left": 325.0155944202679,
-        "top": 95.51562991016024
-      },
-      "post_job_actions": {
-        "HideDatasetActionreport_json": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "report_json"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.2+galaxy0",
-      "tool_shed_repository": {
-        "changeset_revision": "65b93b623c77",
-        "name": "fastp",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": \"false\", \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": \"false\", \"length_required\": null, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": \"false\", \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": \"true\", \"report_json\": \"true\"}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": \"false\", \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": \"false\", \"umi_loc\": \"\", \"umi_len\": null, \"umi_prefix\": \"\"}, \"cutting_by_quality_options\": {\"cut_by_quality5\": \"false\", \"cut_by_quality3\": \"false\", \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": \"false\"}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 2, \"paired_input\": {\"__class__\": \"RuntimeValue\"}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": \"false\", \"adapter_sequence1\": \"\", \"adapter_sequence2\": \"\"}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "0.23.2+galaxy0",
-      "type": "tool",
-      "uuid": "6410c94d-827d-4d1b-b15d-be13df2db0ac",
-      "workflow_outputs": [
-        {
-          "label": "fastp_pe",
-          "output_name": "output_paired_coll",
-          "uuid": "c49d5f48-ab0e-4f59-8b2f-27b3a8f65609"
-        },
-        {
-          "label": "fastp_html_report",
-          "output_name": "report_html",
-          "uuid": "c77d6708-0d13-4f9f-aed8-b3e30de5bafa"
-        }
-      ]
-    },
-    "4": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_build_gb/4.3+T.galaxy4",
-      "errors": null,
-      "id": 4,
-      "input_connections": {
-        "genome_version": {
-          "id": 2,
-          "output_name": "output"
-        },
-        "input_type|input_gbk": {
-          "id": 1,
-          "output_name": "output"
-        }
-      },
-      "inputs": [
-        {
-          "description": "runtime parameter for tool SnpEff build:",
-          "name": "input_type"
-        }
-      ],
-      "label": null,
-      "name": "SnpEff build:",
-      "outputs": [
-        {
-          "name": "snpeff_output",
-          "type": "snpeffdb"
-        },
-        {
-          "name": "output_fasta",
-          "type": "fasta"
-        }
-      ],
-      "position": {
-        "left": 289.04683721041243,
-        "top": 692.6562509323089
-      },
-      "post_job_actions": {},
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_build_gb/4.3+T.galaxy4",
-      "tool_shed_repository": {
-        "changeset_revision": "74aebe30fb52",
-        "name": "snpeff",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"codon_table\": \"Standard\", \"genome_version\": {\"__class__\": \"ConnectedValue\"}, \"input_type\": {\"input_type_selector\": \"gb\", \"__current_case__\": 0, \"input_gbk\": {\"__class__\": \"RuntimeValue\"}, \"fasta\": \"yes\", \"remove_version\": \"true\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "4.3+T.galaxy4",
-      "type": "tool",
-      "uuid": "1406c6b2-51c9-47f7-9f9d-190c0e9ad515",
-      "workflow_outputs": [
-        {
-          "label": "SnpEff4.3 database",
-          "output_name": "snpeff_output",
-          "uuid": "c43258f1-ae40-45d9-a559-a7e20f2ac107"
-        },
-        {
-          "label": "Fasta sequences for genbank file",
-          "output_name": "output_fasta",
-          "uuid": "6a81041a-b077-4211-8d48-aafbe78c0713"
-        }
-      ]
-    },
-    "5": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2",
-      "errors": null,
-      "id": 5,
-      "input_connections": {
-        "fastq_input|fastq_input1": {
-          "id": 3,
-          "output_name": "output_paired_coll"
-        },
-        "reference_source|ref_file": {
-          "id": 4,
-          "output_name": "output_fasta"
-        }
-      },
-      "inputs": [
-        {
-          "description": "runtime parameter for tool Map with BWA-MEM",
-          "name": "fastq_input"
-        },
-        {
-          "description": "runtime parameter for tool Map with BWA-MEM",
-          "name": "reference_source"
-        }
-      ],
-      "label": null,
-      "name": "Map with BWA-MEM",
-      "outputs": [
-        {
-          "name": "bam_output",
-          "type": "bam"
-        }
-      ],
-      "position": {
-        "left": 590.5546666162805,
-        "top": 327.0468702141476
-      },
-      "post_job_actions": {},
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.17.2",
-      "tool_shed_repository": {
-        "changeset_revision": "64f11cf59c6e",
-        "name": "bwa",
-        "owner": "devteam",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"analysis_type\": {\"analysis_type_selector\": \"full\", \"__current_case__\": 4, \"algorithmic_options\": {\"algorithmic_options_selector\": \"do_not_set\", \"__current_case__\": 1}, \"scoring_options\": {\"scoring_options_selector\": \"do_not_set\", \"__current_case__\": 1}, \"io_options\": {\"io_options_selector\": \"set\", \"__current_case__\": 0, \"five\": \"false\", \"q\": \"true\", \"T\": \"30\", \"h\": \"5\", \"a\": \"false\", \"C\": \"false\", \"V\": \"false\", \"Y\": \"true\", \"M\": \"false\"}}, \"fastq_input\": {\"fastq_input_selector\": \"paired_collection\", \"__current_case__\": 2, \"fastq_input1\": {\"__class__\": \"RuntimeValue\"}, \"iset_stats\": \"\"}, \"output_sort\": \"coordinate\", \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"RuntimeValue\"}, \"index_a\": \"auto\"}, \"rg\": {\"rg_selector\": \"do_not_set\", \"__current_case__\": 3}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "0.7.17.2",
-      "type": "tool",
-      "uuid": "a6bd6dbf-d3e7-439f-b826-16ec60bfb33f",
-      "workflow_outputs": [
-        {
-          "label": "bwa_mem_alignments",
-          "output_name": "bam_output",
-          "uuid": "4fa2a1d1-3df1-43a0-9df8-687f55df83a4"
-        }
-      ]
-    },
-    "6": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.13+galaxy1",
-      "errors": null,
-      "id": 6,
-      "input_connections": {
-        "input": {
-          "id": 5,
-          "output_name": "bam_output"
-        }
-      },
-      "inputs": [
-        {
-          "description": "runtime parameter for tool Samtools view",
-          "name": "input"
-        }
-      ],
-      "label": null,
-      "name": "Samtools view",
-      "outputs": [
-        {
-          "name": "outputsam",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 823.9531041162805,
-        "top": 207.86718147106907
-      },
-      "post_job_actions": {
-        "RenameDatasetActionoutputsam": {
-          "action_arguments": {
-            "newname": "Mapped read pairs (filtered bwa-mem result)"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "outputsam"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.13+galaxy1",
-      "tool_shed_repository": {
-        "changeset_revision": "c370440f901e",
-        "name": "samtools_view",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"mode\": {\"outtype\": \"selected_reads\", \"__current_case__\": 1, \"filter_config\": {\"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cond_rg\": {\"select_rg\": \"no\", \"__current_case__\": 0}, \"quality\": \"0\", \"library\": \"\", \"cigarcons\": null, \"inclusive_filter\": [\"1\", \"2\"], \"exclusive_filter\": null, \"exclusive_filter_all\": null, \"tag\": \"\", \"qname_file\": {\"__class__\": \"RuntimeValue\"}}, \"subsample_config\": {\"subsampling_mode\": {\"select_subsample\": \"fraction\", \"__current_case__\": 0, \"factor\": \"1.0\", \"seed\": null}}, \"output_options\": {\"reads_report_type\": \"retained\", \"__current_case__\": 0, \"complementary_output\": \"false\", \"adv_output\": {\"readtags\": [], \"collapsecigar\": \"false\"}, \"output_format\": {\"oformat\": \"bam\", \"__current_case__\": 2}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.13+galaxy1",
-      "type": "tool",
-      "uuid": "6186b9e0-5841-4572-bec3-3f5c11a1c1cf",
-      "workflow_outputs": [
-        {
-          "label": "filtered_alignment",
-          "output_name": "outputsam",
-          "uuid": "68a53be7-7332-4c7f-9615-32770064ffb0"
-        }
-      ]
-    },
-    "7": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.2",
-      "errors": null,
-      "id": 7,
-      "input_connections": {
-        "inputFile": {
-          "id": 6,
-          "output_name": "outputsam"
-        }
-      },
-      "inputs": [
-        {
-          "description": "runtime parameter for tool MarkDuplicates",
-          "name": "inputFile"
-        }
-      ],
-      "label": null,
-      "name": "MarkDuplicates",
-      "outputs": [
-        {
-          "name": "metrics_file",
-          "type": "txt"
-        },
-        {
-          "name": "outFile",
-          "type": "bam"
-        }
-      ],
-      "position": {
-        "left": 1043.617201919711,
-        "top": 322.0156341366272
-      },
-      "post_job_actions": {},
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.2",
-      "tool_shed_repository": {
-        "changeset_revision": "a1f0b3f4b781",
-        "name": "picard",
-        "owner": "devteam",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"assume_sorted\": \"true\", \"barcode_tag\": \"\", \"comments\": [], \"duplicate_scoring_strategy\": \"SUM_OF_BASE_QUALITIES\", \"inputFile\": {\"__class__\": \"RuntimeValue\"}, \"optical_duplicate_pixel_distance\": \"100\", \"read_name_regex\": \"\", \"remove_duplicates\": \"true\", \"validation_stringency\": \"LENIENT\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "2.18.2.2",
-      "type": "tool",
-      "uuid": "cd152e82-b33b-4cca-9126-a4bd63138593",
-      "workflow_outputs": [
-        {
-          "label": "markduplicates_stats",
-          "output_name": "metrics_file",
-          "uuid": "2a24ab1a-6f0f-4896-b436-d6eeeb7ca22c"
-        },
-        {
-          "label": "markduplicates_reads",
-          "output_name": "outFile",
-          "uuid": "9fa98a79-4a12-41df-82c7-6fc4c5a8a1fa"
-        }
-      ]
-    },
-    "8": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.2+galaxy2",
-      "errors": null,
-      "id": 8,
-      "input_connections": {
-        "input": {
-          "id": 6,
-          "output_name": "outputsam"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Samtools stats",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 1099.2499388405358,
-        "top": 137.63280895722616
-      },
-      "post_job_actions": {},
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.2+galaxy2",
-      "tool_shed_repository": {
-        "changeset_revision": "145f6d74ff5e",
-        "name": "samtools_stats",
-        "owner": "devteam",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cov_threshold\": null, \"coverage_cond\": {\"coverage_select\": \"no\", \"__current_case__\": 0}, \"filter_by_flags\": {\"filter_flags\": \"nofilter\", \"__current_case__\": 1}, \"gc_depth\": null, \"input\": {\"__class__\": \"ConnectedValue\"}, \"insert_size\": null, \"most_inserts\": null, \"read_length\": null, \"remove_dups\": \"false\", \"remove_overlaps\": \"false\", \"sparse\": \"false\", \"split_output_cond\": {\"split_output_selector\": \"no\", \"__current_case__\": 0}, \"trim_quality\": null, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "2.0.2+galaxy2",
-      "type": "tool",
-      "uuid": "0ba8c049-f7f1-487f-aa23-3bc6cb2d23aa",
-      "workflow_outputs": [
-        {
-          "label": "mapped_reads_stats",
-          "output_name": "output",
-          "uuid": "acc7e52b-636c-4f28-a49a-0052f23c8737"
-        }
-      ]
-    },
-    "9": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_viterbi/lofreq_viterbi/2.1.5+galaxy0",
-      "errors": null,
-      "id": 9,
-      "input_connections": {
-        "reads": {
-          "id": 7,
-          "output_name": "outFile"
-        },
-        "reference_source|ref": {
-          "id": 4,
-          "output_name": "output_fasta"
-        }
-      },
-      "inputs": [
-        {
-          "description": "runtime parameter for tool Realign reads",
-          "name": "reads"
-        },
-        {
-          "description": "runtime parameter for tool Realign reads",
-          "name": "reference_source"
-        }
-      ],
-      "label": null,
-      "name": "Realign reads",
-      "outputs": [
-        {
-          "name": "realigned",
-          "type": "bam"
-        }
-      ],
-      "position": {
-        "left": 1181.2499875692147,
-        "top": 531.7812529212346
-      },
-      "post_job_actions": {},
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_viterbi/lofreq_viterbi/2.1.5+galaxy0",
-      "tool_shed_repository": {
-        "changeset_revision": "af7e416d8176",
-        "name": "lofreq_viterbi",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"adv_options\": {\"keepflags\": \"false\", \"bq2_handling\": {\"replace_bq2\": \"keep\", \"__current_case__\": 0, \"defqual\": \"2\"}}, \"reads\": {\"__class__\": \"RuntimeValue\"}, \"reference_source\": {\"ref_selector\": \"history\", \"__current_case__\": 1, \"ref\": {\"__class__\": \"RuntimeValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "2.1.5+galaxy0",
-      "type": "tool",
-      "uuid": "f22634d5-0472-4b37-9f1f-55693be5109d",
-      "workflow_outputs": [
-        {
-          "label": "realigned_deduplicated_filtered_mapped_reads",
-          "output_name": "realigned",
-          "uuid": "436348c9-ad6f-46aa-9cd4-7744563ca643"
-        }
-      ]
-    },
-    "10": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy0",
-      "errors": null,
-      "id": 10,
-      "input_connections": {
-        "results_0|software_cond|input": {
-          "id": 3,
-          "output_name": "report_json"
-        },
-        "results_1|software_cond|output_0|type|input": {
-          "id": 8,
-          "output_name": "output"
-        },
-        "results_2|software_cond|output_0|input": {
-          "id": 7,
-          "output_name": "metrics_file"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "MultiQC",
-      "outputs": [
-        {
-          "name": "stats",
-          "type": "input"
-        },
-        {
-          "name": "html_report",
-          "type": "html"
-        }
-      ],
-      "position": {
-        "left": 1536.7109061744209,
-        "top": 0
-      },
-      "post_job_actions": {
-        "HideDatasetActionstats": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "stats"
-        },
-        "RenameDatasetActionhtml_report": {
-          "action_arguments": {
-            "newname": "Preprocessing and mapping reports"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "html_report"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy0",
-      "tool_shed_repository": {
-        "changeset_revision": "9a913cdee30e",
-        "name": "multiqc",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"comment\": \"\", \"export\": \"false\", \"flat\": \"false\", \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastp\", \"__current_case__\": 7, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"samtools\", \"__current_case__\": 24, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"stats\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}}]}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"picard\", \"__current_case__\": 17, \"output\": [{\"__index__\": 0, \"type\": \"markdups\", \"input\": {\"__class__\": \"ConnectedValue\"}}]}}], \"saveLog\": \"false\", \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.11+galaxy0",
-      "type": "tool",
-      "uuid": "1eab5364-f845-4668-9bb0-c820b2c61ab1",
-      "workflow_outputs": [
-        {
-          "label": "preprocessing_and_mapping_reports",
-          "output_name": "html_report",
-          "uuid": "710f4e3f-c7a5-465a-96ec-7eb558a44b35"
-        }
-      ]
-    },
-    "11": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy0",
-      "errors": null,
-      "id": 11,
-      "input_connections": {
-        "reads": {
-          "id": 9,
-          "output_name": "realigned"
-        },
-        "strategy|reference_source|ref": {
-          "id": 4,
-          "output_name": "output_fasta"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Insert indel qualities",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "bam"
-        }
-      ],
-      "position": {
-        "left": 1296.3124448073129,
-        "top": 712.8437220928869
-      },
-      "post_job_actions": {
-        "RenameDatasetActionoutput": {
-          "action_arguments": {
-            "newname": "Fully processed reads for variant calling (deduplicated, realigned reads with added indelquals)"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy0",
-      "tool_shed_repository": {
-        "changeset_revision": "354b534eeab7",
-        "name": "lofreq_indelqual",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"reads\": {\"__class__\": \"ConnectedValue\"}, \"strategy\": {\"selector\": \"dindel\", \"__current_case__\": 1, \"reference_source\": {\"ref_selector\": \"history\", \"__current_case__\": 1, \"ref\": {\"__class__\": \"ConnectedValue\"}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "2.1.5+galaxy0",
-      "type": "tool",
-      "uuid": "8568254e-a9a6-4d67-a4a9-97947d7bc10e",
-      "workflow_outputs": [
-        {
-          "label": "realigned_deduplicated_filtered_mapped_reads_with_indel_quals",
-          "output_name": "output",
-          "uuid": "71283f3d-16ce-43a6-af6a-89e0d6d0aa4f"
-        }
-      ]
-    },
-    "12": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy1",
-      "errors": null,
-      "id": 12,
-      "input_connections": {
-        "reads": {
-          "id": 11,
-          "output_name": "output"
-        },
-        "reference_source|ref": {
-          "id": 4,
-          "output_name": "output_fasta"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Call variants",
-      "outputs": [
-        {
-          "name": "variants",
-          "type": "vcf"
-        }
-      ],
-      "position": {
-        "left": 1423.3749607187183,
-        "top": 908.2577816094984
-      },
-      "post_job_actions": {},
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy1",
-      "tool_shed_repository": {
-        "changeset_revision": "e1461b5c52a0",
-        "name": "lofreq_call",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"call_control\": {\"set_call_options\": \"yes\", \"__current_case__\": 1, \"coverage\": {\"min_cov\": \"5\", \"max_depth\": \"1000000\"}, \"pe\": {\"use_orphan\": \"false\"}, \"bc_quals\": {\"min_bq\": \"30\", \"min_alt_bq\": \"30\", \"alt_bq\": {\"modify\": \"\", \"__current_case__\": 0}}, \"align_quals\": {\"alnqual\": {\"use_alnqual\": \"\", \"__current_case__\": 0, \"alnqual_choice\": {\"alnquals_to_use\": \"\", \"__current_case__\": 1, \"extended_baq\": \"true\"}}}, \"map_quals\": {\"min_mq\": \"0\", \"use_mq\": {\"no_mq\": \"\", \"__current_case__\": 0, \"max_mq\": \"255\"}}, \"source_qual\": {\"use_src_qual\": {\"src_qual\": \"\", \"__current_case__\": 0}}, \"joint_qual\": {\"min_jq\": \"0\", \"min_alt_jq\": \"0\", \"def_alt_jq\": \"0\"}}, \"filter_control\": {\"filter_type\": \"set_custom\", \"__current_case__\": 3, \"sig\": \"0.0005\", \"bonf\": \"0\", \"others\": \"false\"}, \"reads\": {\"__class__\": \"ConnectedValue\"}, \"reference_source\": {\"ref_selector\": \"history\", \"__current_case__\": 1, \"ref\": {\"__class__\": \"ConnectedValue\"}}, \"regions\": {\"restrict_to_region\": \"genome\", \"__current_case__\": 0}, \"variant_types\": \"--call-indels\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "2.1.5+galaxy1",
-      "type": "tool",
-      "uuid": "b8c2b602-396e-4727-8774-cd87edbe3a07",
-      "workflow_outputs": [
-        {
-          "label": "called_variants",
-          "output_name": "variants",
-          "uuid": "f0daf1f1-9200-45de-8c6e-776879096b3e"
-        }
-      ]
-    },
-    "13": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_filter/lofreq_filter/2.1.5+galaxy0",
-      "errors": null,
-      "id": 13,
-      "input_connections": {
-        "invcf": {
-          "id": 12,
-          "output_name": "variants"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Lofreq filter",
-      "outputs": [
-        {
-          "name": "outvcf",
-          "type": "vcf"
-        }
-      ],
-      "position": {
-        "left": 1623.8827831633464,
-        "top": 733.9296904212346
-      },
-      "post_job_actions": {},
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/lofreq_filter/lofreq_filter/2.1.5+galaxy0",
-      "tool_shed_repository": {
-        "changeset_revision": "950d1d49d678",
-        "name": "lofreq_filter",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"af\": {\"af_min\": \"0.0\", \"af_max\": \"0.0\"}, \"coverage\": {\"cov_min\": \"0\", \"cov_max\": \"0\"}, \"filter_by_type\": {\"keep_only\": \"\", \"__current_case__\": 0, \"qual\": {\"snvqual_filter\": {\"snvqual\": \"no\", \"__current_case__\": 0}, \"indelqual_filter\": {\"indelqual\": \"no\", \"__current_case__\": 0}}}, \"flag_or_drop\": \"--print-all\", \"invcf\": {\"__class__\": \"ConnectedValue\"}, \"sb\": {\"sb_filter\": {\"strand_bias\": \"mtc\", \"__current_case__\": 2, \"sb_alpha\": \"0.001\", \"sb_mtc\": \"fdr\", \"sb_compound\": \"true\", \"sb_indels\": \"false\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "2.1.5+galaxy0",
-      "type": "tool",
-      "uuid": "72fc0a88-0fff-4434-9c7b-cff1694f8fbf",
-      "workflow_outputs": [
-        {
-          "label": "soft_filtered_variants",
-          "output_name": "outvcf",
-          "uuid": "58a73993-57b0-4590-b462-65f0a0f7978a"
-        }
-      ]
-    },
-    "14": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/4.3+T.galaxy1",
-      "errors": null,
-      "id": 14,
-      "input_connections": {
-        "input": {
-          "id": 13,
-          "output_name": "outvcf"
-        },
-        "snpDb|snpeff_db": {
-          "id": 4,
-          "output_name": "snpeff_output"
-        }
-      },
-      "inputs": [
-        {
-          "description": "runtime parameter for tool SnpEff eff:",
-          "name": "input"
-        },
-        {
-          "description": "runtime parameter for tool SnpEff eff:",
-          "name": "intervals"
-        },
-        {
-          "description": "runtime parameter for tool SnpEff eff:",
-          "name": "snpDb"
-        },
-        {
-          "description": "runtime parameter for tool SnpEff eff:",
-          "name": "transcripts"
-        }
-      ],
-      "label": null,
-      "name": "SnpEff eff:",
-      "outputs": [
-        {
-          "name": "snpeff_output",
-          "type": "vcf"
-        },
-        {
-          "name": "statsFile",
-          "type": "html"
-        }
-      ],
-      "position": {
-        "left": 1973.0859200969005,
-        "top": 761.6406458215656
-      },
-      "post_job_actions": {},
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/4.3+T.galaxy1",
-      "tool_shed_repository": {
-        "changeset_revision": "74aebe30fb52",
-        "name": "snpeff",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"annotations\": [\"-formatEff\", \"-classic\"], \"chr\": \"\", \"csvStats\": \"false\", \"filter\": {\"specificEffects\": \"no\", \"__current_case__\": 0}, \"filterOut\": [\"-no-downstream\", \"-no-intergenic\", \"-no-intron\", \"-no-upstream\", \"-no-utr\"], \"generate_stats\": \"true\", \"input\": {\"__class__\": \"RuntimeValue\"}, \"inputFormat\": \"vcf\", \"intervals\": {\"__class__\": \"RuntimeValue\"}, \"noLog\": \"true\", \"offset\": \"default\", \"outputConditional\": {\"outputFormat\": \"vcf\", \"__current_case__\": 0}, \"snpDb\": {\"genomeSrc\": \"custom\", \"__current_case__\": 3, \"snpeff_db\": {\"__class__\": \"RuntimeValue\"}, \"codon_table\": \"Standard\"}, \"spliceRegion\": {\"setSpliceRegions\": \"no\", \"__current_case__\": 0}, \"spliceSiteSize\": null, \"transcripts\": {\"__class__\": \"RuntimeValue\"}, \"udLength\": \"0\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "4.3+T.galaxy1",
-      "type": "tool",
-      "uuid": "2fa5e8fd-9282-4156-ba29-93d6ad2b65e1",
-      "workflow_outputs": [
-        {
-          "label": "SnpEff eff: stats",
-          "output_name": "statsFile",
-          "uuid": "5587a236-9d63-4d3b-b368-0643fa07529e"
-        },
-        {
-          "label": "SnpEff variants",
-          "output_name": "snpeff_output",
-          "uuid": "4a062f86-0ab4-4ba1-b8fc-70e35d1f1df7"
-        }
-      ]
-    }
-  },
-  "tags": [
-    "mpxv",
-    "generic"
-  ],
-  "uuid": "be0d055d-25ac-422a-ae9c-b0efdfb5bf86",
-  "version": 5
+    "tags": [
+        "mpxv",
+        "generic"
+    ],
+    "uuid": "be0d055d-25ac-422a-ae9c-b0efdfb5bf86",
+    "version": 5
 }


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/variant-calling/generic-variant-calling-wgs-pe**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_build_gb/4.3+T.galaxy4` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff_build_gb/4.3.1t.1`
* `toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.13+galaxy1` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.15.1+galaxy0`
* `toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.2` should be updated to `toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.3`
* `toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.2+galaxy2` should be updated to `toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.4`
* `toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/lofreq_indelqual/lofreq_indelqual/2.1.5+galaxy1`
* `toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy1` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/lofreq_call/lofreq_call/2.1.5+galaxy2`
* `toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/4.3+T.galaxy1` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpeff/snpEff/4.3.1t.1`

The workflow release number has been updated from 0.1 to 0.2.
