### PR TITLE
Updating workflows/variant-calling/variation-reporting from 0.1 to 0.2

### DIFF
--- a/workflows/variant-calling/variation-reporting/CHANGELOG.md
+++ b/workflows/variant-calling/variation-reporting/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2] 2022-11-02
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3.0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3+t.galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3.0`
+- `toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.6` was updated to `toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.0`
+- `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.3` was updated to `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.4`
+
 ## [0.1]
 
 - Initial version generic variation analysis reporting workflow

--- a/workflows/variant-calling/variation-reporting/Generic-variation-analysis-reporting.ga
+++ b/workflows/variant-calling/variation-reporting/Generic-variation-analysis-reporting.ga
@@ -1,1641 +1,1641 @@
 {
-  "a_galaxy_workflow": "true",
-  "annotation": "This workflow takes a VCF dataset of variants produced by any of the variant calling workflows in https://github.com/galaxyproject/iwc/tree/main/workflows/sars-cov-2-variant-calling and generates tabular lists of variants by Samples and by Variant, and an overview plot of variants and their allele-frequencies.",
-  "creator": [
-    {
-      "class": "Person",
-      "identifier": "https://orcid.org/0000-0002-9464-6640",
-      "name": "Wolfgang Maier"
-    }
-  ],
-  "release": "0.1",
-  "format-version": "0.1",
-  "license": "MIT",
-  "name": "Generic variation analysis reporting",
-  "steps": {
-    "0": {
-      "annotation": "Variation data in VCF format. Can be the output of any of the workflows in https://github.com/galaxyproject/iwc/tree/main/workflows/sars-cov-2-variant-calling",
-      "content_id": null,
-      "errors": null,
-      "id": 0,
-      "input_connections": {},
-      "inputs": [
+    "a_galaxy_workflow": "true",
+    "annotation": "This workflow takes a VCF dataset of variants produced by any of the variant calling workflows in https://github.com/galaxyproject/iwc/tree/main/workflows/sars-cov-2-variant-calling and generates tabular lists of variants by Samples and by Variant, and an overview plot of variants and their allele-frequencies.",
+    "creator": [
         {
-          "description": "Variation data in VCF format. Can be the output of any of the workflows in https://github.com/galaxyproject/iwc/tree/main/workflows/sars-cov-2-variant-calling",
-          "name": "Variation data to report"
+            "class": "Person",
+            "identifier": "https://orcid.org/0000-0002-9464-6640",
+            "name": "Wolfgang Maier"
         }
-      ],
-      "label": "Variation data to report",
-      "name": "Input dataset collection",
-      "outputs": [],
-      "position": {
-        "left": 29.25,
-        "top": 0
-      },
-      "tool_id": null,
-      "tool_state": "{\"optional\": false, \"format\": [\"vcf\", \"vcf_bgzip\"], \"tag\": \"\", \"collection_type\": \"list\"}",
-      "tool_version": null,
-      "type": "data_collection_input",
-      "uuid": "900f58cd-3ac6-4371-9295-6596726b1ee9",
-      "workflow_outputs": []
-    },
-    "1": {
-      "annotation": "Allele Frequency Filter. This is the minimum allele frequency required for variants to be included in the reports.",
-      "content_id": null,
-      "errors": null,
-      "id": 1,
-      "input_connections": {},
-      "inputs": [
-        {
-          "description": "Allele Frequency Filter. This is the minimum allele frequency required for variants to be included in the reports.",
-          "name": "AF Filter"
-        }
-      ],
-      "label": "AF Filter",
-      "name": "Input parameter",
-      "outputs": [],
-      "position": {
-        "left": 28.3125,
-        "top": 208.8203125
-      },
-      "tool_id": null,
-      "tool_state": "{\"default\": 0.05, \"parameter_type\": \"float\", \"optional\": true}",
-      "tool_version": null,
-      "type": "parameter_input",
-      "uuid": "664a4fe1-a981-4e22-b6c4-628c87baf28a",
-      "workflow_outputs": [
-        {
-          "label": null,
-          "output_name": "output",
-          "uuid": "15fcff98-3e33-4deb-a083-a6c3c94b1b8d"
-        }
-      ]
-    },
-    "2": {
-      "annotation": "Depth Filter. This is the minimum depth of all alignments at a variant site. ",
-      "content_id": null,
-      "errors": null,
-      "id": 2,
-      "input_connections": {},
-      "inputs": [
-        {
-          "description": "Depth Filter. This is the minimum depth of all alignments at a variant site. ",
-          "name": "DP Filter"
-        }
-      ],
-      "label": "DP Filter",
-      "name": "Input parameter",
-      "outputs": [],
-      "position": {
-        "left": 26.75,
-        "top": 358.8359375
-      },
-      "tool_id": null,
-      "tool_state": "{\"default\": 1, \"parameter_type\": \"integer\", \"optional\": true}",
-      "tool_version": null,
-      "type": "parameter_input",
-      "uuid": "8d6df2cd-f16c-476e-bc00-e83a5e568cdd",
-      "workflow_outputs": [
-        {
-          "label": null,
-          "output_name": "output",
-          "uuid": "a01b2b83-81d7-4cd5-a307-797046910821"
-        }
-      ]
-    },
-    "3": {
-      "annotation": "Depth Filter for variant allele. This is the minimum depth of alignments supporting a variant.",
-      "content_id": null,
-      "errors": null,
-      "id": 3,
-      "input_connections": {},
-      "inputs": [
-        {
-          "description": "Depth Filter for variant allele. This is the minimum depth of alignments supporting a variant.",
-          "name": "DP_ALT Filter"
-        }
-      ],
-      "label": "DP_ALT Filter",
-      "name": "Input parameter",
-      "outputs": [],
-      "position": {
-        "left": 0,
-        "top": 572.3359375
-      },
-      "tool_id": null,
-      "tool_state": "{\"default\": 10, \"parameter_type\": \"integer\", \"optional\": true}",
-      "tool_version": null,
-      "type": "parameter_input",
-      "uuid": "842ca5f3-acfd-4243-88cd-625d1834ad89",
-      "workflow_outputs": [
-        {
-          "label": null,
-          "output_name": "output",
-          "uuid": "89133c97-8b6f-4c7b-abbd-799fd385ac6a"
-        }
-      ]
-    },
-    "4": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1",
-      "errors": null,
-      "id": 4,
-      "input_connections": {
-        "input": {
-          "id": 0,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "SnpSift Filter",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "vcf"
-        }
-      ],
-      "position": {
-        "left": 348.65625,
-        "top": 159
-      },
-      "post_job_actions": {},
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1",
-      "tool_shed_repository": {
-        "changeset_revision": "2e497a770bca",
-        "name": "snpsift",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"filter_expression\": {\"type\": \"simple\", \"__current_case__\": 0, \"expr\": \"DP >= 1\"}, \"filtering\": {\"mode\": \"entries\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"inverse\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "4.3+t.galaxy1",
-      "type": "tool",
-      "uuid": "8adcdaba-fea6-4cb1-9ec3-70972604145e",
-      "workflow_outputs": [
-        {
-          "label": "prefiltered_variants",
-          "output_name": "output",
-          "uuid": "7e953ef0-9e3a-485b-8201-290512552269"
-        }
-      ]
-    },
-    "5": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
-      "errors": null,
-      "id": 5,
-      "input_connections": {
-        "components_1|param_type|component_value": {
-          "id": 1,
-          "output_name": "output"
+    ],
+    "release": "0.2",
+    "format-version": "0.1",
+    "license": "MIT",
+    "name": "Generic variation analysis reporting",
+    "steps": {
+        "0": {
+            "annotation": "Variation data in VCF format. Can be the output of any of the workflows in https://github.com/galaxyproject/iwc/tree/main/workflows/sars-cov-2-variant-calling",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Variation data in VCF format. Can be the output of any of the workflows in https://github.com/galaxyproject/iwc/tree/main/workflows/sars-cov-2-variant-calling",
+                    "name": "Variation data to report"
+                }
+            ],
+            "label": "Variation data to report",
+            "name": "Input dataset collection",
+            "outputs": [],
+            "position": {
+                "left": 29.25,
+                "top": 0
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"format\": [\"vcf\", \"vcf_bgzip\"], \"tag\": \"\", \"collection_type\": \"list\"}",
+            "tool_version": null,
+            "type": "data_collection_input",
+            "uuid": "900f58cd-3ac6-4371-9295-6596726b1ee9",
+            "workflow_outputs": []
         },
-        "components_3|param_type|component_value": {
-          "id": 2,
-          "output_name": "output"
+        "1": {
+            "annotation": "Allele Frequency Filter. This is the minimum allele frequency required for variants to be included in the reports.",
+            "content_id": null,
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Allele Frequency Filter. This is the minimum allele frequency required for variants to be included in the reports.",
+                    "name": "AF Filter"
+                }
+            ],
+            "label": "AF Filter",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 28.3125,
+                "top": 208.8203125
+            },
+            "tool_id": null,
+            "tool_state": "{\"default\": 0.05, \"parameter_type\": \"float\", \"optional\": true}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "664a4fe1-a981-4e22-b6c4-628c87baf28a",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "15fcff98-3e33-4deb-a083-a6c3c94b1b8d"
+                }
+            ]
         },
-        "components_5|param_type|component_value": {
-          "id": 3,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Compose text parameter value",
-      "outputs": [
-        {
-          "name": "out1",
-          "type": "expression.json"
-        }
-      ],
-      "position": {
-        "left": 347,
-        "top": 283.2734375
-      },
-      "post_job_actions": {
-        "HideDatasetActionout1": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out1"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
-      "tool_shed_repository": {
-        "changeset_revision": "e188c9826e0f",
-        "name": "compose_text_param",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \"( ( DP4[2] + DP4[3] ) < ( \"}}, {\"__index__\": 1, \"param_type\": {\"select_param_type\": \"float\", \"__current_case__\": 2, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \" * DP ) ) | ( DP < \"}}, {\"__index__\": 3, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 1, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 4, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \" ) | ( ( AF * DP ) < ( \"}}, {\"__index__\": 5, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 1, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 6, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \" - 0.5 ) )\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "0.1.1",
-      "type": "tool",
-      "uuid": "7b42a044-ea48-4aae-82d0-7e134e47e6ee",
-      "workflow_outputs": []
-    },
-    "6": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
-      "errors": null,
-      "id": 6,
-      "input_connections": {
-        "components_1|param_type|component_value": {
-          "id": 1,
-          "output_name": "output"
+        "2": {
+            "annotation": "Depth Filter. This is the minimum depth of all alignments at a variant site. ",
+            "content_id": null,
+            "errors": null,
+            "id": 2,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Depth Filter. This is the minimum depth of all alignments at a variant site. ",
+                    "name": "DP Filter"
+                }
+            ],
+            "label": "DP Filter",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 26.75,
+                "top": 358.8359375
+            },
+            "tool_id": null,
+            "tool_state": "{\"default\": 1, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "8d6df2cd-f16c-476e-bc00-e83a5e568cdd",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "a01b2b83-81d7-4cd5-a307-797046910821"
+                }
+            ]
         },
-        "components_3|param_type|component_value": {
-          "id": 2,
-          "output_name": "output"
+        "3": {
+            "annotation": "Depth Filter for variant allele. This is the minimum depth of alignments supporting a variant.",
+            "content_id": null,
+            "errors": null,
+            "id": 3,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Depth Filter for variant allele. This is the minimum depth of alignments supporting a variant.",
+                    "name": "DP_ALT Filter"
+                }
+            ],
+            "label": "DP_ALT Filter",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 0,
+                "top": 572.3359375
+            },
+            "tool_id": null,
+            "tool_state": "{\"default\": 10, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "842ca5f3-acfd-4243-88cd-625d1834ad89",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "89133c97-8b6f-4c7b-abbd-799fd385ac6a"
+                }
+            ]
         },
-        "components_5|param_type|component_value": {
-          "id": 3,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Compose text parameter value",
-      "outputs": [
-        {
-          "name": "out1",
-          "type": "expression.json"
-        }
-      ],
-      "position": {
-        "left": 343.71875,
-        "top": 590.75
-      },
-      "post_job_actions": {
-        "HideDatasetActionout1": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out1"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
-      "tool_shed_repository": {
-        "changeset_revision": "e188c9826e0f",
-        "name": "compose_text_param",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \"min_af_\"}}, {\"__index__\": 1, \"param_type\": {\"select_param_type\": \"float\", \"__current_case__\": 2, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \"|min_dp_\"}}, {\"__index__\": 3, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 1, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 4, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \"|min_dp_alt_\"}}, {\"__index__\": 5, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 1, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "0.1.1",
-      "type": "tool",
-      "uuid": "dd9b21a6-e2e1-4637-aca7-dd485b52ddf9",
-      "workflow_outputs": []
-    },
-    "7": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1",
-      "errors": null,
-      "id": 7,
-      "input_connections": {
-        "filter_expression|expr": {
-          "id": 5,
-          "output_name": "out1"
+        "4": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1",
+            "errors": null,
+            "id": 4,
+            "input_connections": {
+                "input": {
+                    "id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "SnpSift Filter",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "vcf"
+                }
+            ],
+            "position": {
+                "left": 348.65625,
+                "top": 159
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "5fab4f81391d",
+                "name": "snpsift",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"filter_expression\": {\"type\": \"simple\", \"__current_case__\": 0, \"expr\": \"DP >= 1\"}, \"filtering\": {\"mode\": \"entries\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"inverse\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "4.3+t.galaxy1",
+            "type": "tool",
+            "uuid": "8adcdaba-fea6-4cb1-9ec3-70972604145e",
+            "workflow_outputs": [
+                {
+                    "label": "prefiltered_variants",
+                    "output_name": "output",
+                    "uuid": "7e953ef0-9e3a-485b-8201-290512552269"
+                }
+            ]
         },
-        "filtering|add_filter": {
-          "id": 6,
-          "output_name": "out1"
+        "5": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
+            "errors": null,
+            "id": 5,
+            "input_connections": {
+                "components_1|param_type|component_value": {
+                    "id": 1,
+                    "output_name": "output"
+                },
+                "components_3|param_type|component_value": {
+                    "id": 2,
+                    "output_name": "output"
+                },
+                "components_5|param_type|component_value": {
+                    "id": 3,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Compose text parameter value",
+            "outputs": [
+                {
+                    "name": "out1",
+                    "type": "expression.json"
+                }
+            ],
+            "position": {
+                "left": 347,
+                "top": 283.2734375
+            },
+            "post_job_actions": {
+                "HideDatasetActionout1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out1"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
+            "tool_shed_repository": {
+                "changeset_revision": "e188c9826e0f",
+                "name": "compose_text_param",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \"( ( DP4[2] + DP4[3] ) < ( \"}}, {\"__index__\": 1, \"param_type\": {\"select_param_type\": \"float\", \"__current_case__\": 2, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \" * DP ) ) | ( DP < \"}}, {\"__index__\": 3, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 1, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 4, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \" ) | ( ( AF * DP ) < ( \"}}, {\"__index__\": 5, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 1, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 6, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \" - 0.5 ) )\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.1.1",
+            "type": "tool",
+            "uuid": "7b42a044-ea48-4aae-82d0-7e134e47e6ee",
+            "workflow_outputs": []
         },
-        "input": {
-          "id": 4,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "SnpSift Filter",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "vcf"
-        }
-      ],
-      "position": {
-        "left": 579.40625,
-        "top": 448.984375
-      },
-      "post_job_actions": {
-        "RenameDatasetActionoutput": {
-          "action_arguments": {
-            "newname": "Filtered variants"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1",
-      "tool_shed_repository": {
-        "changeset_revision": "2e497a770bca",
-        "name": "snpsift",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"filter_expression\": {\"type\": \"simple\", \"__current_case__\": 0, \"expr\": {\"__class__\": \"ConnectedValue\"}}, \"filtering\": {\"mode\": \"add_filter\", \"__current_case__\": 3, \"add_filter\": {\"__class__\": \"ConnectedValue\"}}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"inverse\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "4.3+t.galaxy1",
-      "type": "tool",
-      "uuid": "8c1888cd-fceb-45fc-add4-2e7edc582ca1",
-      "workflow_outputs": [
-        {
-          "label": "filtered_variants",
-          "output_name": "output",
-          "uuid": "a923399c-9faa-40a7-be8d-caa2ca72c5be"
-        }
-      ]
-    },
-    "8": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3+t.galaxy0",
-      "errors": null,
-      "id": 8,
-      "input_connections": {
-        "input": {
-          "id": 7,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "SnpSift Extract Fields",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 815.4375,
-        "top": 345.9609375
-      },
-      "post_job_actions": {
-        "RenameDatasetActionoutput": {
-          "action_arguments": {
-            "newname": "Filtered extracted variants"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3+t.galaxy0",
-      "tool_shed_repository": {
-        "changeset_revision": "2e497a770bca",
-        "name": "snpsift",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"empty_text\": \".\", \"extract\": \"CHROM POS FILTER REF ALT DP AF DP4 SB EFF[*].IMPACT EFF[*].FUNCLASS EFF[*].EFFECT EFF[*].GENE EFF[*].CODON EFF[*].AA EFF[*].TRID DP4[2] DP4[3]\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"one_effect_per_line\": \"true\", \"separator\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "4.3+t.galaxy0",
-      "type": "tool",
-      "uuid": "dce57343-cb31-469a-b886-d62e7ce53bad",
-      "workflow_outputs": [
-        {
-          "label": "filtered_extracted_variants",
-          "output_name": "output",
-          "uuid": "fb09ef77-9522-452a-a0e9-73a4a580b8aa"
-        }
-      ]
-    },
-    "9": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.6",
-      "errors": null,
-      "id": 9,
-      "input_connections": {
-        "input": {
-          "id": 8,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Compute",
-      "outputs": [
-        {
-          "name": "out_file1",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 1266.7265625,
-        "top": 367.2578125
-      },
-      "post_job_actions": {
-        "RenameDatasetActionout_file1": {
-          "action_arguments": {
-            "newname": "Extracted variants with filtered and renamed effects and AF recalculated"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "out_file1"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.6",
-      "tool_shed_repository": {
-        "changeset_revision": "427903d47026",
-        "name": "column_maker",
-        "owner": "devteam",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"avoid_scientific_notation\": \"false\", \"cond\": \"round((c17 + c18) / c6, 6)\", \"header_lines_conditional\": {\"header_lines_select\": \"yes\", \"__current_case__\": 1, \"header_new_column_name\": \"AFrecalc\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"round\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.6",
-      "type": "tool",
-      "uuid": "726b7b08-31a8-4ec7-b5b9-027b1f104eeb",
-      "workflow_outputs": [
-        {
-          "label": "af_recalculated",
-          "output_name": "out_file1",
-          "uuid": "a47c05f5-0ea1-4649-a7c1-7b88cca0e6e5"
-        }
-      ]
-    },
-    "10": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0",
-      "errors": null,
-      "id": 10,
-      "input_connections": {
-        "in_file": {
-          "id": 9,
-          "output_name": "out_file1"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Datamash",
-      "outputs": [
-        {
-          "name": "out_file",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 1433.15625,
-        "top": 147.5
-      },
-      "post_job_actions": {
-        "RenameDatasetActionout_file": {
-          "action_arguments": {
-            "newname": "Collapsed effects (Datamash on all variants)"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "out_file"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0",
-      "tool_shed_repository": {
-        "changeset_revision": "562f3c677828",
-        "name": "datamash_ops",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"grouping\": \"1,2,3,4,5,6,19,7,8,9\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"need_sort\": \"false\", \"operations\": [{\"__index__\": 0, \"op_name\": \"collapse\", \"op_column\": \"10\"}, {\"__index__\": 1, \"op_name\": \"collapse\", \"op_column\": \"11\"}, {\"__index__\": 2, \"op_name\": \"collapse\", \"op_column\": \"12\"}, {\"__index__\": 3, \"op_name\": \"collapse\", \"op_column\": \"13\"}, {\"__index__\": 4, \"op_name\": \"collapse\", \"op_column\": \"14\"}, {\"__index__\": 5, \"op_name\": \"collapse\", \"op_column\": \"15\"}, {\"__index__\": 6, \"op_name\": \"collapse\", \"op_column\": \"16\"}], \"print_full_line\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.0",
-      "type": "tool",
-      "uuid": "a5100b84-498a-47fe-b408-fd159a8d729a",
-      "workflow_outputs": [
-        {
-          "label": "collapsed_effects",
-          "output_name": "out_file",
-          "uuid": "407d9cee-4b7d-4855-b62c-a166ecf8f50e"
-        }
-      ]
-    },
-    "11": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.3",
-      "errors": null,
-      "id": 11,
-      "input_connections": {
-        "infile": {
-          "id": 10,
-          "output_name": "out_file"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Replace",
-      "outputs": [
-        {
-          "name": "outfile",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 1556.34375,
-        "top": 323.5625
-      },
-      "post_job_actions": {
-        "RenameDatasetActionoutfile": {
-          "action_arguments": {
-            "newname": "Extracted variants with highest impact effects"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "outfile"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.3",
-      "tool_shed_repository": {
-        "changeset_revision": "f46f0e4f75c4",
-        "name": "text_processing",
-        "owner": "bgruening",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"caseinsensitive\": \"false\", \"find_pattern\": \"\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\s]+\", \"global\": \"true\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"is_regex\": \"true\", \"replace_pattern\": \"\\\\t$1\\\\t$2\\\\t$3\\\\t$4\\\\t$5\\\\t$6\\\\t$7\", \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}, \"skip_first_line\": \"true\", \"wholewords\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.3",
-      "type": "tool",
-      "uuid": "6e156bbc-a207-4941-bd6a-d654473fde37",
-      "workflow_outputs": [
-        {
-          "label": "highest_impact_effects",
-          "output_name": "outfile",
-          "uuid": "aacf2235-fd9c-43e9-a886-dde7ccc7c691"
-        }
-      ]
-    },
-    "12": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.3",
-      "errors": null,
-      "id": 12,
-      "input_connections": {
-        "infile": {
-          "id": 11,
-          "output_name": "outfile"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Replace",
-      "outputs": [
-        {
-          "name": "outfile",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 1707.1953125,
-        "top": 165.234375
-      },
-      "post_job_actions": {
-        "RenameDatasetActionoutfile": {
-          "action_arguments": {
-            "newname": "Variants with cleaned up header"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "outfile"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.3",
-      "tool_shed_repository": {
-        "changeset_revision": "f46f0e4f75c4",
-        "name": "text_processing",
-        "owner": "bgruening",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"caseinsensitive\": \"false\", \"find_pattern\": \"(GroupBy|collapse)\\\\(([^)]+)\\\\)\", \"global\": \"true\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"is_regex\": \"true\", \"replace_pattern\": \"$2\", \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}, \"skip_first_line\": \"false\", \"wholewords\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.3",
-      "type": "tool",
-      "uuid": "4d002a96-055c-4892-8ad4-d6266de51e4e",
-      "workflow_outputs": [
-        {
-          "label": "cleaned_header",
-          "output_name": "outfile",
-          "uuid": "0bade229-08f2-491c-8361-77ec91ceed98"
-        }
-      ]
-    },
-    "13": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.3",
-      "errors": null,
-      "id": 13,
-      "input_connections": {
-        "infile": {
-          "id": 12,
-          "output_name": "outfile"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Replace",
-      "outputs": [
-        {
-          "name": "outfile",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 1825.5,
-        "top": 329.8828125
-      },
-      "post_job_actions": {
-        "RenameDatasetActionoutfile": {
-          "action_arguments": {
-            "newname": "Fully processed variants collection for reporting"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "outfile"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.3",
-      "tool_shed_repository": {
-        "changeset_revision": "f46f0e4f75c4",
-        "name": "text_processing",
-        "owner": "bgruening",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"caseinsensitive\": \"false\", \"find_pattern\": \"AFrecalc\\\\tAF\", \"global\": \"false\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"is_regex\": \"true\", \"replace_pattern\": \"AF\\\\tAFcaller\", \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}, \"skip_first_line\": \"false\", \"wholewords\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.3",
-      "type": "tool",
-      "uuid": "9ee0a745-0f40-4579-91ed-39aaa9895302",
-      "workflow_outputs": [
-        {
-          "label": "processed_variants_collection",
-          "output_name": "outfile",
-          "uuid": "2707f4c6-dd54-44bb-adad-a3703d165823"
-        }
-      ]
-    },
-    "14": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
-      "errors": null,
-      "id": 14,
-      "input_connections": {
-        "input_list": {
-          "id": 13,
-          "output_name": "outfile"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Collapse Collection",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 1984.5078125,
-        "top": 154.984375
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
-      "tool_shed_repository": {
-        "changeset_revision": "90981f86000f",
-        "name": "collapse_collections",
-        "owner": "nml",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"filename\": {\"add_name\": \"true\", \"__current_case__\": 0, \"place_name\": \"same_multiple\"}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "5.1.0",
-      "type": "tool",
-      "uuid": "c8ad21ea-c72b-4063-9974-380869b87d58",
-      "workflow_outputs": []
-    },
-    "15": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.6",
-      "errors": null,
-      "id": 15,
-      "input_connections": {
-        "input": {
-          "id": 14,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Compute",
-      "outputs": [
-        {
-          "name": "out_file1",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 2106.3828125,
-        "top": 338.484375
-      },
-      "post_job_actions": {
-        "HideDatasetActionout_file1": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out_file1"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.6",
-      "tool_shed_repository": {
-        "changeset_revision": "427903d47026",
-        "name": "column_maker",
-        "owner": "devteam",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"avoid_scientific_notation\": \"false\", \"cond\": \"str(c5) + '>' + str(c6)\", \"header_lines_conditional\": {\"header_lines_select\": \"yes\", \"__current_case__\": 1, \"header_new_column_name\": \"change\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"round\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.6",
-      "type": "tool",
-      "uuid": "61cc455a-4330-4518-bf8a-b099780bdb30",
-      "workflow_outputs": []
-    },
-    "16": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.6",
-      "errors": null,
-      "id": 16,
-      "input_connections": {
-        "input": {
-          "id": 15,
-          "output_name": "out_file1"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Compute",
-      "outputs": [
-        {
-          "name": "out_file1",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 2329.8984375,
-        "top": 339.296875
-      },
-      "post_job_actions": {
-        "HideDatasetActionout_file1": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out_file1"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.6",
-      "tool_shed_repository": {
-        "changeset_revision": "427903d47026",
-        "name": "column_maker",
-        "owner": "devteam",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"avoid_scientific_notation\": \"false\", \"cond\": \"str(int(c3)) + ':' + str(c19)\", \"header_lines_conditional\": {\"header_lines_select\": \"yes\", \"__current_case__\": 1, \"header_new_column_name\": \"change_with_pos\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"round\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.6",
-      "type": "tool",
-      "uuid": "5a0297af-22c4-4550-8673-cbe044496410",
-      "workflow_outputs": []
-    },
-    "17": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.3",
-      "errors": null,
-      "id": 17,
-      "input_connections": {
-        "infile": {
-          "id": 16,
-          "output_name": "out_file1"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Replace",
-      "outputs": [
-        {
-          "name": "outfile",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 2536.0703125,
-        "top": 207.0859375
-      },
-      "post_job_actions": {
-        "RenameDatasetActionoutfile": {
-          "action_arguments": {
-            "newname": "All variants of all samples"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "outfile"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.3",
-      "tool_shed_repository": {
-        "changeset_revision": "f46f0e4f75c4",
-        "name": "text_processing",
-        "owner": "bgruening",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"caseinsensitive\": \"false\", \"find_pattern\": \"EFF[*].\", \"global\": \"true\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"is_regex\": \"false\", \"replace_pattern\": \"\", \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}, \"skip_first_line\": \"false\", \"wholewords\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.3",
-      "type": "tool",
-      "uuid": "23c73601-2fdb-4a1e-be60-ff0f1ec96be8",
-      "workflow_outputs": [
-        {
-          "label": "all_variants_all_samples",
-          "output_name": "outfile",
-          "uuid": "c3bf5f59-3363-4305-ab99-7c38fceab34c"
-        }
-      ]
-    },
-    "18": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0",
-      "errors": null,
-      "id": 18,
-      "input_connections": {
-        "in_file": {
-          "id": 17,
-          "output_name": "outfile"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Datamash",
-      "outputs": [
-        {
-          "name": "out_file",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 2787.3359375,
-        "top": 158.5234375
-      },
-      "post_job_actions": {
-        "HideDatasetActionout_file": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out_file"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0",
-      "tool_shed_repository": {
-        "changeset_revision": "562f3c677828",
-        "name": "datamash_ops",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"grouping\": \"20\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"need_sort\": \"true\", \"operations\": [{\"__index__\": 0, \"op_name\": \"countunique\", \"op_column\": \"1\"}, {\"__index__\": 1, \"op_name\": \"min\", \"op_column\": \"8\"}, {\"__index__\": 2, \"op_name\": \"max\", \"op_column\": \"8\"}, {\"__index__\": 3, \"op_name\": \"collapse\", \"op_column\": \"1\"}, {\"__index__\": 4, \"op_name\": \"collapse\", \"op_column\": \"8\"}], \"print_full_line\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.0",
-      "type": "tool",
-      "uuid": "61adea76-ce05-489d-af2b-1ad74bd141fa",
-      "workflow_outputs": []
-    },
-    "19": {
-      "annotation": "",
-      "content_id": "Filter1",
-      "errors": null,
-      "id": 19,
-      "input_connections": {
-        "input": {
-          "id": 17,
-          "output_name": "outfile"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Filter",
-      "outputs": [
-        {
-          "name": "out_file1",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 2780.1328125,
-        "top": 371.6484375
-      },
-      "post_job_actions": {
-        "HideDatasetActionout_file1": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out_file1"
-        }
-      },
-      "tool_id": "Filter1",
-      "tool_state": "{\"cond\": \"c4=='PASS' or c4=='.'\", \"header_lines\": \"1\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.1",
-      "type": "tool",
-      "uuid": "c5568630-a6f4-468c-b320-5f28547f7c14",
-      "workflow_outputs": []
-    },
-    "20": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0",
-      "errors": null,
-      "id": 20,
-      "input_connections": {
-        "in_file": {
-          "id": 17,
-          "output_name": "outfile"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Datamash",
-      "outputs": [
-        {
-          "name": "out_file",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 3071.03125,
-        "top": 568.5703125
-      },
-      "post_job_actions": {
-        "HideDatasetActionout_file": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out_file"
+        "6": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
+            "errors": null,
+            "id": 6,
+            "input_connections": {
+                "components_1|param_type|component_value": {
+                    "id": 1,
+                    "output_name": "output"
+                },
+                "components_3|param_type|component_value": {
+                    "id": 2,
+                    "output_name": "output"
+                },
+                "components_5|param_type|component_value": {
+                    "id": 3,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Compose text parameter value",
+            "outputs": [
+                {
+                    "name": "out1",
+                    "type": "expression.json"
+                }
+            ],
+            "position": {
+                "left": 343.71875,
+                "top": 590.75
+            },
+            "post_job_actions": {
+                "HideDatasetActionout1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out1"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
+            "tool_shed_repository": {
+                "changeset_revision": "e188c9826e0f",
+                "name": "compose_text_param",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \"min_af_\"}}, {\"__index__\": 1, \"param_type\": {\"select_param_type\": \"float\", \"__current_case__\": 2, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \"|min_dp_\"}}, {\"__index__\": 3, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 1, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 4, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \"|min_dp_alt_\"}}, {\"__index__\": 5, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 1, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.1.1",
+            "type": "tool",
+            "uuid": "dd9b21a6-e2e1-4637-aca7-dd485b52ddf9",
+            "workflow_outputs": []
         },
-        "RenameDatasetActionout_file": {
-          "action_arguments": {
-            "newname": "Cross-sample variant stats (Datamash)"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "out_file"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0",
-      "tool_shed_repository": {
-        "changeset_revision": "562f3c677828",
-        "name": "datamash_ops",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"grouping\": \"3\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"need_sort\": \"true\", \"operations\": [{\"__index__\": 0, \"op_name\": \"countunique\", \"op_column\": \"1\"}, {\"__index__\": 1, \"op_name\": \"min\", \"op_column\": \"8\"}, {\"__index__\": 2, \"op_name\": \"max\", \"op_column\": \"8\"}, {\"__index__\": 3, \"op_name\": \"countunique\", \"op_column\": \"19\"}, {\"__index__\": 4, \"op_name\": \"countunique\", \"op_column\": \"13\"}], \"print_full_line\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.0",
-      "type": "tool",
-      "uuid": "517d8ba6-1df6-417c-96e9-f297b3b8f51f",
-      "workflow_outputs": []
-    },
-    "21": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0",
-      "errors": null,
-      "id": 21,
-      "input_connections": {
-        "in_file": {
-          "id": 19,
-          "output_name": "out_file1"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Datamash",
-      "outputs": [
-        {
-          "name": "out_file",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 2895.6484375,
-        "top": 789.3203125
-      },
-      "post_job_actions": {
-        "HideDatasetActionout_file": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out_file"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0",
-      "tool_shed_repository": {
-        "changeset_revision": "562f3c677828",
-        "name": "datamash_ops",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"grouping\": \"20\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"need_sort\": \"true\", \"operations\": [{\"__index__\": 0, \"op_name\": \"countunique\", \"op_column\": \"1\"}], \"print_full_line\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.0",
-      "type": "tool",
-      "uuid": "6f97bd54-aeea-4615-b6f0-b9cc8e99b519",
-      "workflow_outputs": []
-    },
-    "22": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
-      "errors": null,
-      "id": 22,
-      "input_connections": {
-        "infile1": {
-          "id": 19,
-          "output_name": "out_file1"
+        "7": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1",
+            "errors": null,
+            "id": 7,
+            "input_connections": {
+                "filter_expression|expr": {
+                    "id": 5,
+                    "output_name": "out1"
+                },
+                "filtering|add_filter": {
+                    "id": 6,
+                    "output_name": "out1"
+                },
+                "input": {
+                    "id": 4,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "SnpSift Filter",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "vcf"
+                }
+            ],
+            "position": {
+                "left": 579.40625,
+                "top": 448.984375
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "Filtered variants"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "5fab4f81391d",
+                "name": "snpsift",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"filter_expression\": {\"type\": \"simple\", \"__current_case__\": 0, \"expr\": {\"__class__\": \"ConnectedValue\"}}, \"filtering\": {\"mode\": \"add_filter\", \"__current_case__\": 3, \"add_filter\": {\"__class__\": \"ConnectedValue\"}}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"inverse\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "4.3+t.galaxy1",
+            "type": "tool",
+            "uuid": "8c1888cd-fceb-45fc-add4-2e7edc582ca1",
+            "workflow_outputs": [
+                {
+                    "label": "filtered_variants",
+                    "output_name": "output",
+                    "uuid": "a923399c-9faa-40a7-be8d-caa2ca72c5be"
+                }
+            ]
         },
-        "infile2": {
-          "id": 18,
-          "output_name": "out_file"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Join",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 3028.71875,
-        "top": 178.8984375
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
+        "8": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3+t.galaxy0",
+            "errors": null,
+            "id": 8,
+            "input_connections": {
+                "input": {
+                    "id": 7,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "SnpSift Extract Fields",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 815.4375,
+                "top": 345.9609375
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "Filtered extracted variants"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3+t.galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "5fab4f81391d",
+                "name": "snpsift",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"empty_text\": \".\", \"extract\": \"CHROM POS FILTER REF ALT DP AF DP4 SB EFF[*].IMPACT EFF[*].FUNCLASS EFF[*].EFFECT EFF[*].GENE EFF[*].CODON EFF[*].AA EFF[*].TRID DP4[2] DP4[3]\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"one_effect_per_line\": \"true\", \"separator\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "4.3+t.galaxy0",
+            "type": "tool",
+            "uuid": "dce57343-cb31-469a-b886-d62e7ce53bad",
+            "workflow_outputs": [
+                {
+                    "label": "filtered_extracted_variants",
+                    "output_name": "output",
+                    "uuid": "fb09ef77-9522-452a-a0e9-73a4a580b8aa"
+                }
+            ]
         },
-        "RenameDatasetActionoutput": {
-          "action_arguments": {
-            "newname": "Filtered variants of all samples with stats"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
-      "tool_shed_repository": {
-        "changeset_revision": "f46f0e4f75c4",
-        "name": "text_processing",
-        "owner": "bgruening",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"column1\": \"20\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": \"true\", \"ignore_case\": \"false\", \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.2",
-      "type": "tool",
-      "uuid": "ce58eb8c-118f-467e-80e4-b0bf35c2919f",
-      "workflow_outputs": []
-    },
-    "23": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0",
-      "errors": null,
-      "id": 23,
-      "input_connections": {
-        "in_file": {
-          "id": 19,
-          "output_name": "out_file1"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Datamash",
-      "outputs": [
-        {
-          "name": "out_file",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 3037.1484375,
-        "top": 439.0625
-      },
-      "post_job_actions": {
-        "HideDatasetActionout_file": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out_file"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0",
-      "tool_shed_repository": {
-        "changeset_revision": "562f3c677828",
-        "name": "datamash_ops",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"grouping\": \"3\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"need_sort\": \"true\", \"operations\": [{\"__index__\": 0, \"op_name\": \"countunique\", \"op_column\": \"1\"}], \"print_full_line\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.0",
-      "type": "tool",
-      "uuid": "aee9b1d2-a707-4101-8b22-23ebaa3a32a1",
-      "workflow_outputs": []
-    },
-    "24": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
-      "errors": null,
-      "id": 24,
-      "input_connections": {
-        "infile1": {
-          "id": 16,
-          "output_name": "out_file1"
+        "9": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.0",
+            "errors": null,
+            "id": 9,
+            "input_connections": {
+                "input": {
+                    "id": 8,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Compute",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1266.7265625,
+                "top": 367.2578125
+            },
+            "post_job_actions": {
+                "RenameDatasetActionout_file1": {
+                    "action_arguments": {
+                        "newname": "Extracted variants with filtered and renamed effects and AF recalculated"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.0",
+            "tool_shed_repository": {
+                "changeset_revision": "6595517c2dd8",
+                "name": "column_maker",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"avoid_scientific_notation\": \"false\", \"cond\": \"round((c17 + c18) / c6, 6)\", \"error_handling\": {\"auto_col_types\": \"true\", \"fail_on_non_existent_columns\": \"true\", \"non_computable\": {\"action\": \"--fail-on-non-computable\", \"__current_case__\": 0}}, \"header_lines_conditional\": {\"__current_case__\": 1, \"header_lines_select\": \"yes\", \"header_new_column_name\": \"AFrecalc\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"ops\": {\"header_lines_select\": \"no\", \"__current_case__\": 0, \"expressions\": []}, \"round\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.0",
+            "type": "tool",
+            "uuid": "726b7b08-31a8-4ec7-b5b9-027b1f104eeb",
+            "workflow_outputs": [
+                {
+                    "label": "af_recalculated",
+                    "output_name": "out_file1",
+                    "uuid": "a47c05f5-0ea1-4649-a7c1-7b88cca0e6e5"
+                }
+            ]
         },
-        "infile2": {
-          "id": 21,
-          "output_name": "out_file"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Join",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 3232.8984375,
-        "top": 719.8359375
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
-      "tool_shed_repository": {
-        "changeset_revision": "f46f0e4f75c4",
-        "name": "text_processing",
-        "owner": "bgruening",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"column1\": \"20\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": \"true\", \"ignore_case\": \"false\", \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.2",
-      "type": "tool",
-      "uuid": "9aeb39d3-d040-43ee-a3fa-2a65eb1a7c34",
-      "workflow_outputs": []
-    },
-    "25": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0",
-      "errors": null,
-      "id": 25,
-      "input_connections": {
-        "in_file": {
-          "id": 22,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Datamash",
-      "outputs": [
-        {
-          "name": "out_file",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 3272.8359375,
-        "top": 142.0234375
-      },
-      "post_job_actions": {
-        "HideDatasetActionout_file": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out_file"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0",
-      "tool_shed_repository": {
-        "changeset_revision": "562f3c677828",
-        "name": "datamash_ops",
-        "owner": "iuc",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"grouping\": \"1\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"need_sort\": \"true\", \"operations\": [{\"__index__\": 0, \"op_name\": \"unique\", \"op_column\": \"2\"}], \"print_full_line\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.0",
-      "type": "tool",
-      "uuid": "74886968-16db-41a0-9d2a-98475d1d163e",
-      "workflow_outputs": []
-    },
-    "26": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
-      "errors": null,
-      "id": 26,
-      "input_connections": {
-        "infile1": {
-          "id": 17,
-          "output_name": "outfile"
+        "10": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "errors": null,
+            "id": 10,
+            "input_connections": {
+                "in_file": {
+                    "id": 9,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Datamash",
+            "outputs": [
+                {
+                    "name": "out_file",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1433.15625,
+                "top": 147.5
+            },
+            "post_job_actions": {
+                "RenameDatasetActionout_file": {
+                    "action_arguments": {
+                        "newname": "Collapsed effects (Datamash on all variants)"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out_file"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "746e8e4bf929",
+                "name": "datamash_ops",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"grouping\": \"1,2,3,4,5,6,19,7,8,9\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": \"false\", \"need_sort\": \"false\", \"operations\": [{\"__index__\": 0, \"op_name\": \"collapse\", \"op_column\": \"10\"}, {\"__index__\": 1, \"op_name\": \"collapse\", \"op_column\": \"11\"}, {\"__index__\": 2, \"op_name\": \"collapse\", \"op_column\": \"12\"}, {\"__index__\": 3, \"op_name\": \"collapse\", \"op_column\": \"13\"}, {\"__index__\": 4, \"op_name\": \"collapse\", \"op_column\": \"14\"}, {\"__index__\": 5, \"op_name\": \"collapse\", \"op_column\": \"15\"}, {\"__index__\": 6, \"op_name\": \"collapse\", \"op_column\": \"16\"}], \"print_full_line\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0+galaxy2",
+            "type": "tool",
+            "uuid": "a5100b84-498a-47fe-b408-fd159a8d729a",
+            "workflow_outputs": [
+                {
+                    "label": "collapsed_effects",
+                    "output_name": "out_file",
+                    "uuid": "407d9cee-4b7d-4855-b62c-a166ecf8f50e"
+                }
+            ]
         },
-        "infile2": {
-          "id": 23,
-          "output_name": "out_file"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Join",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 3274.8984375,
-        "top": 351.5703125
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
-      "tool_shed_repository": {
-        "changeset_revision": "f46f0e4f75c4",
-        "name": "text_processing",
-        "owner": "bgruening",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"column1\": \"3\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": \"true\", \"ignore_case\": \"false\", \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.2",
-      "type": "tool",
-      "uuid": "9c3e2d08-a103-497b-b22c-667f1ca23152",
-      "workflow_outputs": []
-    },
-    "27": {
-      "annotation": "",
-      "content_id": "Cut1",
-      "errors": null,
-      "id": 27,
-      "input_connections": {
-        "input": {
-          "id": 24,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Cut",
-      "outputs": [
-        {
-          "name": "out_file1",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 3458.375,
-        "top": 655.5859375
-      },
-      "post_job_actions": {
-        "HideDatasetActionout_file1": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out_file1"
-        }
-      },
-      "tool_id": "Cut1",
-      "tool_state": "{\"columnList\": \"c2,c3,c4,c5,c6,c7,c8,c9,c11,c12,c13,c14,c15,c16,c17,c18,c19\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.0.2",
-      "type": "tool",
-      "uuid": "c74fc520-a76c-4b7b-b846-8cd8310ead70",
-      "workflow_outputs": []
-    },
-    "28": {
-      "annotation": "",
-      "content_id": "Cut1",
-      "errors": null,
-      "id": 28,
-      "input_connections": {
-        "input": {
-          "id": 25,
-          "output_name": "out_file"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Cut",
-      "outputs": [
-        {
-          "name": "out_file1",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 3496.8984375,
-        "top": 246.8125
-      },
-      "post_job_actions": {
-        "HideDatasetActionout_file1": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out_file1"
-        }
-      },
-      "tool_id": "Cut1",
-      "tool_state": "{\"columnList\": \"c4,c6,c7,c13,c14,c15,c16,c17,c18,c19,c21,c22,c23,c26,c24,c25,c20\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.0.2",
-      "type": "tool",
-      "uuid": "102b3ed6-1c6c-4545-9985-dfd3ac735acf",
-      "workflow_outputs": []
-    },
-    "29": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
-      "errors": null,
-      "id": 29,
-      "input_connections": {
-        "infile1": {
-          "id": 26,
-          "output_name": "output"
+        "11": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.4",
+            "errors": null,
+            "id": 11,
+            "input_connections": {
+                "infile": {
+                    "id": 10,
+                    "output_name": "out_file"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Replace",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1556.34375,
+                "top": 323.5625
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutfile": {
+                    "action_arguments": {
+                        "newname": "Extracted variants with highest impact effects"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.4",
+            "tool_shed_repository": {
+                "changeset_revision": "d698c222f354",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"caseinsensitive\": \"false\", \"find_and_replace\": [], \"find_pattern\": \"\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\s]+\", \"global\": \"true\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"is_regex\": \"true\", \"replace_pattern\": \"\\\\t$1\\\\t$2\\\\t$3\\\\t$4\\\\t$5\\\\t$6\\\\t$7\", \"searchwhere\": {\"__current_case__\": 0, \"searchwhere_select\": \"line\"}, \"skip_first_line\": \"true\", \"wholewords\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.4",
+            "type": "tool",
+            "uuid": "6e156bbc-a207-4941-bd6a-d654473fde37",
+            "workflow_outputs": [
+                {
+                    "label": "highest_impact_effects",
+                    "output_name": "outfile",
+                    "uuid": "aacf2235-fd9c-43e9-a886-dde7ccc7c691"
+                }
+            ]
         },
-        "infile2": {
-          "id": 20,
-          "output_name": "out_file"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Join",
-      "outputs": [
-        {
-          "name": "output",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 3492.9375,
-        "top": 444.734375
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutput": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "output"
+        "12": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.4",
+            "errors": null,
+            "id": 12,
+            "input_connections": {
+                "infile": {
+                    "id": 11,
+                    "output_name": "outfile"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Replace",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1707.1953125,
+                "top": 165.234375
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutfile": {
+                    "action_arguments": {
+                        "newname": "Variants with cleaned up header"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.4",
+            "tool_shed_repository": {
+                "changeset_revision": "d698c222f354",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"caseinsensitive\": \"false\", \"find_and_replace\": [], \"find_pattern\": \"(GroupBy|collapse)\\\\(([^)]+)\\\\)\", \"global\": \"true\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"is_regex\": \"true\", \"replace_pattern\": \"$2\", \"searchwhere\": {\"__current_case__\": 0, \"searchwhere_select\": \"line\"}, \"skip_first_line\": \"false\", \"wholewords\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.4",
+            "type": "tool",
+            "uuid": "4d002a96-055c-4892-8ad4-d6266de51e4e",
+            "workflow_outputs": [
+                {
+                    "label": "cleaned_header",
+                    "output_name": "outfile",
+                    "uuid": "0bade229-08f2-491c-8361-77ec91ceed98"
+                }
+            ]
         },
-        "RenameDatasetActionoutput": {
-          "action_arguments": {
-            "newname": "Filtered variants of all samples with per-position stats"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "output"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
-      "tool_shed_repository": {
-        "changeset_revision": "f46f0e4f75c4",
-        "name": "text_processing",
-        "owner": "bgruening",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"column1\": \"1\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": \"true\", \"ignore_case\": \"false\", \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.2",
-      "type": "tool",
-      "uuid": "95dcccd0-0323-4448-b8ca-ad1fce8d2a45",
-      "workflow_outputs": []
-    },
-    "30": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/split_file_to_collection/0.5.0",
-      "errors": null,
-      "id": 30,
-      "input_connections": {
-        "split_parms|input": {
-          "id": 27,
-          "output_name": "out_file1"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Split file",
-      "outputs": [
-        {
-          "name": "list_output_tab",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 3681.6328125,
-        "top": 655.7578125
-      },
-      "post_job_actions": {
-        "RenameDatasetActionlist_output_tab": {
-          "action_arguments": {
-            "newname": "Per-sample variants for plotting"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "list_output_tab"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/split_file_to_collection/0.5.0",
-      "tool_shed_repository": {
-        "changeset_revision": "6cbe2f30c2d7",
-        "name": "split_file_to_collection",
-        "owner": "bgruening",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"split_parms\": {\"select_ftype\": \"tabular\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}, \"top\": \"1\", \"split_by\": {\"select_split_by\": \"col\", \"__current_case__\": 0, \"id_col\": \"1\", \"match_regex\": \"(.*)\", \"sub_regex\": \"\\\\1\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "0.5.0",
-      "type": "tool",
-      "uuid": "c0accd6f-76af-46f7-a5f0-647000d54444",
-      "workflow_outputs": [
-        {
-          "label": "variants_for_plotting",
-          "output_name": "list_output_tab",
-          "uuid": "e62f958f-e749-43b4-9c02-17fced624689"
-        }
-      ]
-    },
-    "31": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.3",
-      "errors": null,
-      "id": 31,
-      "input_connections": {
-        "infile": {
-          "id": 28,
-          "output_name": "out_file1"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Replace",
-      "outputs": [
-        {
-          "name": "outfile",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 3706.375,
-        "top": 146.25
-      },
-      "post_job_actions": {
-        "HideDatasetActionoutfile": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "outfile"
+        "13": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.4",
+            "errors": null,
+            "id": 13,
+            "input_connections": {
+                "infile": {
+                    "id": 12,
+                    "output_name": "outfile"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Replace",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1825.5,
+                "top": 329.8828125
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutfile": {
+                    "action_arguments": {
+                        "newname": "Fully processed variants collection for reporting"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.4",
+            "tool_shed_repository": {
+                "changeset_revision": "d698c222f354",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"caseinsensitive\": \"false\", \"find_and_replace\": [], \"find_pattern\": \"AFrecalc\\\\tAF\", \"global\": \"false\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"is_regex\": \"true\", \"replace_pattern\": \"AF\\\\tAFcaller\", \"searchwhere\": {\"__current_case__\": 0, \"searchwhere_select\": \"line\"}, \"skip_first_line\": \"false\", \"wholewords\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.4",
+            "type": "tool",
+            "uuid": "9ee0a745-0f40-4579-91ed-39aaa9895302",
+            "workflow_outputs": [
+                {
+                    "label": "processed_variants_collection",
+                    "output_name": "outfile",
+                    "uuid": "2707f4c6-dd54-44bb-adad-a3703d165823"
+                }
+            ]
         },
-        "RenameDatasetActionoutfile": {
-          "action_arguments": {
-            "newname": "All variants of all samples"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "outfile"
+        "14": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+            "errors": null,
+            "id": 14,
+            "input_connections": {
+                "input_list": {
+                    "id": 13,
+                    "output_name": "outfile"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Collapse Collection",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1984.5078125,
+                "top": 154.984375
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+            "tool_shed_repository": {
+                "changeset_revision": "90981f86000f",
+                "name": "collapse_collections",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"filename\": {\"add_name\": \"true\", \"__current_case__\": 0, \"place_name\": \"same_multiple\"}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "5.1.0",
+            "type": "tool",
+            "uuid": "c8ad21ea-c72b-4063-9974-380869b87d58",
+            "workflow_outputs": []
+        },
+        "15": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.0",
+            "errors": null,
+            "id": 15,
+            "input_connections": {
+                "input": {
+                    "id": 14,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Compute",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2106.3828125,
+                "top": 338.484375
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.0",
+            "tool_shed_repository": {
+                "changeset_revision": "6595517c2dd8",
+                "name": "column_maker",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"avoid_scientific_notation\": \"false\", \"cond\": \"str(c5) + '>' + str(c6)\", \"error_handling\": {\"auto_col_types\": \"true\", \"fail_on_non_existent_columns\": \"true\", \"non_computable\": {\"action\": \"--fail-on-non-computable\", \"__current_case__\": 0}}, \"header_lines_conditional\": {\"__current_case__\": 1, \"header_lines_select\": \"yes\", \"header_new_column_name\": \"change\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"ops\": {\"header_lines_select\": \"no\", \"__current_case__\": 0, \"expressions\": []}, \"round\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.0",
+            "type": "tool",
+            "uuid": "61cc455a-4330-4518-bf8a-b099780bdb30",
+            "workflow_outputs": []
+        },
+        "16": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.0",
+            "errors": null,
+            "id": 16,
+            "input_connections": {
+                "input": {
+                    "id": 15,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Compute",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2329.8984375,
+                "top": 339.296875
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.0",
+            "tool_shed_repository": {
+                "changeset_revision": "6595517c2dd8",
+                "name": "column_maker",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"avoid_scientific_notation\": \"false\", \"cond\": \"str(int(c3)) + ':' + str(c19)\", \"error_handling\": {\"auto_col_types\": \"true\", \"fail_on_non_existent_columns\": \"true\", \"non_computable\": {\"action\": \"--fail-on-non-computable\", \"__current_case__\": 0}}, \"header_lines_conditional\": {\"__current_case__\": 1, \"header_lines_select\": \"yes\", \"header_new_column_name\": \"change_with_pos\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"ops\": {\"header_lines_select\": \"no\", \"__current_case__\": 0, \"expressions\": []}, \"round\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.0",
+            "type": "tool",
+            "uuid": "5a0297af-22c4-4550-8673-cbe044496410",
+            "workflow_outputs": []
+        },
+        "17": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.4",
+            "errors": null,
+            "id": 17,
+            "input_connections": {
+                "infile": {
+                    "id": 16,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Replace",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2536.0703125,
+                "top": 207.0859375
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutfile": {
+                    "action_arguments": {
+                        "newname": "All variants of all samples"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.4",
+            "tool_shed_repository": {
+                "changeset_revision": "d698c222f354",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"caseinsensitive\": \"false\", \"find_and_replace\": [], \"find_pattern\": \"EFF[*].\", \"global\": \"true\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"is_regex\": \"false\", \"replace_pattern\": \"\", \"searchwhere\": {\"__current_case__\": 0, \"searchwhere_select\": \"line\"}, \"skip_first_line\": \"false\", \"wholewords\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.4",
+            "type": "tool",
+            "uuid": "23c73601-2fdb-4a1e-be60-ff0f1ec96be8",
+            "workflow_outputs": [
+                {
+                    "label": "all_variants_all_samples",
+                    "output_name": "outfile",
+                    "uuid": "c3bf5f59-3363-4305-ab99-7c38fceab34c"
+                }
+            ]
+        },
+        "18": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "errors": null,
+            "id": 18,
+            "input_connections": {
+                "in_file": {
+                    "id": 17,
+                    "output_name": "outfile"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Datamash",
+            "outputs": [
+                {
+                    "name": "out_file",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2787.3359375,
+                "top": 158.5234375
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "746e8e4bf929",
+                "name": "datamash_ops",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"grouping\": \"20\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": \"false\", \"need_sort\": \"true\", \"operations\": [{\"__index__\": 0, \"op_name\": \"countunique\", \"op_column\": \"1\"}, {\"__index__\": 1, \"op_name\": \"min\", \"op_column\": \"8\"}, {\"__index__\": 2, \"op_name\": \"max\", \"op_column\": \"8\"}, {\"__index__\": 3, \"op_name\": \"collapse\", \"op_column\": \"1\"}, {\"__index__\": 4, \"op_name\": \"collapse\", \"op_column\": \"8\"}], \"print_full_line\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0+galaxy2",
+            "type": "tool",
+            "uuid": "61adea76-ce05-489d-af2b-1ad74bd141fa",
+            "workflow_outputs": []
+        },
+        "19": {
+            "annotation": "",
+            "content_id": "Filter1",
+            "errors": null,
+            "id": 19,
+            "input_connections": {
+                "input": {
+                    "id": 17,
+                    "output_name": "outfile"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Filter",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2780.1328125,
+                "top": 371.6484375
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "Filter1",
+            "tool_state": "{\"cond\": \"c4=='PASS' or c4=='.'\", \"header_lines\": \"1\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.1",
+            "type": "tool",
+            "uuid": "c5568630-a6f4-468c-b320-5f28547f7c14",
+            "workflow_outputs": []
+        },
+        "20": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "errors": null,
+            "id": 20,
+            "input_connections": {
+                "in_file": {
+                    "id": 17,
+                    "output_name": "outfile"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Datamash",
+            "outputs": [
+                {
+                    "name": "out_file",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3071.03125,
+                "top": 568.5703125
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file"
+                },
+                "RenameDatasetActionout_file": {
+                    "action_arguments": {
+                        "newname": "Cross-sample variant stats (Datamash)"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out_file"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "746e8e4bf929",
+                "name": "datamash_ops",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"grouping\": \"3\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": \"false\", \"need_sort\": \"true\", \"operations\": [{\"__index__\": 0, \"op_name\": \"countunique\", \"op_column\": \"1\"}, {\"__index__\": 1, \"op_name\": \"min\", \"op_column\": \"8\"}, {\"__index__\": 2, \"op_name\": \"max\", \"op_column\": \"8\"}, {\"__index__\": 3, \"op_name\": \"countunique\", \"op_column\": \"19\"}, {\"__index__\": 4, \"op_name\": \"countunique\", \"op_column\": \"13\"}], \"print_full_line\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0+galaxy2",
+            "type": "tool",
+            "uuid": "517d8ba6-1df6-417c-96e9-f297b3b8f51f",
+            "workflow_outputs": []
+        },
+        "21": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "errors": null,
+            "id": 21,
+            "input_connections": {
+                "in_file": {
+                    "id": 19,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Datamash",
+            "outputs": [
+                {
+                    "name": "out_file",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2895.6484375,
+                "top": 789.3203125
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "746e8e4bf929",
+                "name": "datamash_ops",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"grouping\": \"20\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": \"false\", \"need_sort\": \"true\", \"operations\": [{\"__index__\": 0, \"op_name\": \"countunique\", \"op_column\": \"1\"}], \"print_full_line\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0+galaxy2",
+            "type": "tool",
+            "uuid": "6f97bd54-aeea-4615-b6f0-b9cc8e99b519",
+            "workflow_outputs": []
+        },
+        "22": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
+            "errors": null,
+            "id": 22,
+            "input_connections": {
+                "infile1": {
+                    "id": 19,
+                    "output_name": "out_file1"
+                },
+                "infile2": {
+                    "id": 18,
+                    "output_name": "out_file"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Join",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3028.71875,
+                "top": 178.8984375
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                },
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "Filtered variants of all samples with stats"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
+            "tool_shed_repository": {
+                "changeset_revision": "d698c222f354",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"column1\": \"20\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": \"true\", \"ignore_case\": \"false\", \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.2",
+            "type": "tool",
+            "uuid": "ce58eb8c-118f-467e-80e4-b0bf35c2919f",
+            "workflow_outputs": []
+        },
+        "23": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "errors": null,
+            "id": 23,
+            "input_connections": {
+                "in_file": {
+                    "id": 19,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Datamash",
+            "outputs": [
+                {
+                    "name": "out_file",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3037.1484375,
+                "top": 439.0625
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "746e8e4bf929",
+                "name": "datamash_ops",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"grouping\": \"3\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": \"false\", \"need_sort\": \"true\", \"operations\": [{\"__index__\": 0, \"op_name\": \"countunique\", \"op_column\": \"1\"}], \"print_full_line\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0+galaxy2",
+            "type": "tool",
+            "uuid": "aee9b1d2-a707-4101-8b22-23ebaa3a32a1",
+            "workflow_outputs": []
+        },
+        "24": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
+            "errors": null,
+            "id": 24,
+            "input_connections": {
+                "infile1": {
+                    "id": 16,
+                    "output_name": "out_file1"
+                },
+                "infile2": {
+                    "id": 21,
+                    "output_name": "out_file"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Join",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3232.8984375,
+                "top": 719.8359375
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
+            "tool_shed_repository": {
+                "changeset_revision": "d698c222f354",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"column1\": \"20\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": \"true\", \"ignore_case\": \"false\", \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.2",
+            "type": "tool",
+            "uuid": "9aeb39d3-d040-43ee-a3fa-2a65eb1a7c34",
+            "workflow_outputs": []
+        },
+        "25": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "errors": null,
+            "id": 25,
+            "input_connections": {
+                "in_file": {
+                    "id": 22,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Datamash",
+            "outputs": [
+                {
+                    "name": "out_file",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3272.8359375,
+                "top": 142.0234375
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "746e8e4bf929",
+                "name": "datamash_ops",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"grouping\": \"1\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": \"false\", \"need_sort\": \"true\", \"operations\": [{\"__index__\": 0, \"op_name\": \"unique\", \"op_column\": \"2\"}], \"print_full_line\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0+galaxy2",
+            "type": "tool",
+            "uuid": "74886968-16db-41a0-9d2a-98475d1d163e",
+            "workflow_outputs": []
+        },
+        "26": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
+            "errors": null,
+            "id": 26,
+            "input_connections": {
+                "infile1": {
+                    "id": 17,
+                    "output_name": "outfile"
+                },
+                "infile2": {
+                    "id": 23,
+                    "output_name": "out_file"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Join",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3274.8984375,
+                "top": 351.5703125
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
+            "tool_shed_repository": {
+                "changeset_revision": "d698c222f354",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"column1\": \"3\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": \"true\", \"ignore_case\": \"false\", \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.2",
+            "type": "tool",
+            "uuid": "9c3e2d08-a103-497b-b22c-667f1ca23152",
+            "workflow_outputs": []
+        },
+        "27": {
+            "annotation": "",
+            "content_id": "Cut1",
+            "errors": null,
+            "id": 27,
+            "input_connections": {
+                "input": {
+                    "id": 24,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Cut",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 3458.375,
+                "top": 655.5859375
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "Cut1",
+            "tool_state": "{\"columnList\": \"c2,c3,c4,c5,c6,c7,c8,c9,c11,c12,c13,c14,c15,c16,c17,c18,c19\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.2",
+            "type": "tool",
+            "uuid": "c74fc520-a76c-4b7b-b846-8cd8310ead70",
+            "workflow_outputs": []
+        },
+        "28": {
+            "annotation": "",
+            "content_id": "Cut1",
+            "errors": null,
+            "id": 28,
+            "input_connections": {
+                "input": {
+                    "id": 25,
+                    "output_name": "out_file"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Cut",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 3496.8984375,
+                "top": 246.8125
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "Cut1",
+            "tool_state": "{\"columnList\": \"c4,c6,c7,c13,c14,c15,c16,c17,c18,c19,c21,c22,c23,c26,c24,c25,c20\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.2",
+            "type": "tool",
+            "uuid": "102b3ed6-1c6c-4545-9985-dfd3ac735acf",
+            "workflow_outputs": []
+        },
+        "29": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
+            "errors": null,
+            "id": 29,
+            "input_connections": {
+                "infile1": {
+                    "id": 26,
+                    "output_name": "output"
+                },
+                "infile2": {
+                    "id": 20,
+                    "output_name": "out_file"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Join",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3492.9375,
+                "top": 444.734375
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                },
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "Filtered variants of all samples with per-position stats"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
+            "tool_shed_repository": {
+                "changeset_revision": "d698c222f354",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"column1\": \"1\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": \"true\", \"ignore_case\": \"false\", \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.2",
+            "type": "tool",
+            "uuid": "95dcccd0-0323-4448-b8ca-ad1fce8d2a45",
+            "workflow_outputs": []
+        },
+        "30": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/split_file_to_collection/0.5.0",
+            "errors": null,
+            "id": 30,
+            "input_connections": {
+                "split_parms|input": {
+                    "id": 27,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Split file",
+            "outputs": [
+                {
+                    "name": "list_output_tab",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3681.6328125,
+                "top": 655.7578125
+            },
+            "post_job_actions": {
+                "RenameDatasetActionlist_output_tab": {
+                    "action_arguments": {
+                        "newname": "Per-sample variants for plotting"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "list_output_tab"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/split_file_to_collection/0.5.0",
+            "tool_shed_repository": {
+                "changeset_revision": "6cbe2f30c2d7",
+                "name": "split_file_to_collection",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"split_parms\": {\"select_ftype\": \"tabular\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}, \"top\": \"1\", \"split_by\": {\"select_split_by\": \"col\", \"__current_case__\": 0, \"id_col\": \"1\", \"match_regex\": \"(.*)\", \"sub_regex\": \"\\\\1\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.5.0",
+            "type": "tool",
+            "uuid": "c0accd6f-76af-46f7-a5f0-647000d54444",
+            "workflow_outputs": [
+                {
+                    "label": "variants_for_plotting",
+                    "output_name": "list_output_tab",
+                    "uuid": "e62f958f-e749-43b4-9c02-17fced624689"
+                }
+            ]
+        },
+        "31": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.4",
+            "errors": null,
+            "id": 31,
+            "input_connections": {
+                "infile": {
+                    "id": 28,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Replace",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3706.375,
+                "top": 146.25
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutfile": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "outfile"
+                },
+                "RenameDatasetActionoutfile": {
+                    "action_arguments": {
+                        "newname": "All variants of all samples"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.4",
+            "tool_shed_repository": {
+                "changeset_revision": "d698c222f354",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"caseinsensitive\": \"false\", \"find_and_replace\": [], \"find_pattern\": \"unique\\\\(Sample\\\\)\\\\tcollapse\\\\(Sample\\\\)\\\\tcollapse\\\\(AF\\\\)\", \"global\": \"true\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"is_regex\": \"true\", \"replace_pattern\": \"SAMPLES(above-thresholds)\\\\tSAMPLES(all)\\\\tAFs(all)\", \"searchwhere\": {\"__current_case__\": 0, \"searchwhere_select\": \"line\"}, \"skip_first_line\": \"false\", \"wholewords\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.4",
+            "type": "tool",
+            "uuid": "cf84a2f6-689b-4bed-bc0d-324d40f46dd7",
+            "workflow_outputs": []
+        },
+        "32": {
+            "annotation": "",
+            "content_id": "Cut1",
+            "errors": null,
+            "id": 32,
+            "input_connections": {
+                "input": {
+                    "id": 29,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Cut",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 3710.1875,
+                "top": 471.234375
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "Cut1",
+            "tool_state": "{\"columnList\": \"c2,c1,c4,c5,c6,c7,c8,c9,c11,c10,c12,c13,c14,c15,c16,c17,c18,c23,c24,c25,c26,c19\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.2",
+            "type": "tool",
+            "uuid": "3d0237fc-33b6-4305-b6e8-2502175f624f",
+            "workflow_outputs": []
+        },
+        "33": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+            "errors": null,
+            "id": 33,
+            "input_connections": {
+                "infile": {
+                    "id": 31,
+                    "output_name": "outfile"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Sort",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3928.8984375,
+                "top": 247.8125
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutfile": {
+                    "action_arguments": {
+                        "newname": "Combined Variant Report by Variant"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+            "tool_shed_repository": {
+                "changeset_revision": "d698c222f354",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"header\": \"1\", \"ignore_case\": \"false\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"sortkeys\": [{\"__index__\": 0, \"column\": \"1\", \"order\": \"\", \"style\": \"g\"}], \"unique\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.1",
+            "type": "tool",
+            "uuid": "6edca54f-9af8-4305-bd11-4c74251af900",
+            "workflow_outputs": [
+                {
+                    "label": "by_variant_report",
+                    "output_name": "outfile",
+                    "uuid": "30808300-2789-48b0-9073-98ec1bddcb3f"
+                }
+            ]
+        },
+        "34": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+            "errors": null,
+            "id": 34,
+            "input_connections": {
+                "infile": {
+                    "id": 32,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Sort",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3932.6953125,
+                "top": 457.4609375
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutfile": {
+                    "action_arguments": {
+                        "newname": "Combined Variant Report by Sample"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+            "tool_shed_repository": {
+                "changeset_revision": "d698c222f354",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"header\": \"1\", \"ignore_case\": \"false\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"sortkeys\": [{\"__index__\": 0, \"column\": \"1\", \"order\": \"\", \"style\": \"\"}, {\"__index__\": 1, \"column\": \"2\", \"order\": \"\", \"style\": \"n\"}], \"unique\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.1",
+            "type": "tool",
+            "uuid": "eb754361-9ec5-46c8-80b5-6bb040345719",
+            "workflow_outputs": [
+                {
+                    "label": "combined_variant_report",
+                    "output_name": "outfile",
+                    "uuid": "2f0680a4-d809-4f85-8df9-4fcd6c4f3d80"
+                }
+            ]
         }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.3",
-      "tool_shed_repository": {
-        "changeset_revision": "f46f0e4f75c4",
-        "name": "text_processing",
-        "owner": "bgruening",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"caseinsensitive\": \"false\", \"find_pattern\": \"unique\\\\(Sample\\\\)\\\\tcollapse\\\\(Sample\\\\)\\\\tcollapse\\\\(AF\\\\)\", \"global\": \"true\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"is_regex\": \"true\", \"replace_pattern\": \"SAMPLES(above-thresholds)\\\\tSAMPLES(all)\\\\tAFs(all)\", \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}, \"skip_first_line\": \"false\", \"wholewords\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.3",
-      "type": "tool",
-      "uuid": "cf84a2f6-689b-4bed-bc0d-324d40f46dd7",
-      "workflow_outputs": []
     },
-    "32": {
-      "annotation": "",
-      "content_id": "Cut1",
-      "errors": null,
-      "id": 32,
-      "input_connections": {
-        "input": {
-          "id": 29,
-          "output_name": "output"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Cut",
-      "outputs": [
-        {
-          "name": "out_file1",
-          "type": "tabular"
-        }
-      ],
-      "position": {
-        "left": 3710.1875,
-        "top": 471.234375
-      },
-      "post_job_actions": {
-        "HideDatasetActionout_file1": {
-          "action_arguments": {},
-          "action_type": "HideDatasetAction",
-          "output_name": "out_file1"
-        }
-      },
-      "tool_id": "Cut1",
-      "tool_state": "{\"columnList\": \"c2,c1,c4,c5,c6,c7,c8,c9,c11,c10,c12,c13,c14,c15,c16,c17,c18,c23,c24,c25,c26,c19\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.0.2",
-      "type": "tool",
-      "uuid": "3d0237fc-33b6-4305-b6e8-2502175f624f",
-      "workflow_outputs": []
-    },
-    "33": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
-      "errors": null,
-      "id": 33,
-      "input_connections": {
-        "infile": {
-          "id": 31,
-          "output_name": "outfile"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Sort",
-      "outputs": [
-        {
-          "name": "outfile",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 3928.8984375,
-        "top": 247.8125
-      },
-      "post_job_actions": {
-        "RenameDatasetActionoutfile": {
-          "action_arguments": {
-            "newname": "Combined Variant Report by Variant"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "outfile"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
-      "tool_shed_repository": {
-        "changeset_revision": "f46f0e4f75c4",
-        "name": "text_processing",
-        "owner": "bgruening",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"header\": \"1\", \"ignore_case\": \"false\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"sortkeys\": [{\"__index__\": 0, \"column\": \"1\", \"order\": \"\", \"style\": \"g\"}], \"unique\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.1",
-      "type": "tool",
-      "uuid": "6edca54f-9af8-4305-bd11-4c74251af900",
-      "workflow_outputs": [
-        {
-          "label": "by_variant_report",
-          "output_name": "outfile",
-          "uuid": "30808300-2789-48b0-9073-98ec1bddcb3f"
-        }
-      ]
-    },
-    "34": {
-      "annotation": "",
-      "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
-      "errors": null,
-      "id": 34,
-      "input_connections": {
-        "infile": {
-          "id": 32,
-          "output_name": "out_file1"
-        }
-      },
-      "inputs": [],
-      "label": null,
-      "name": "Sort",
-      "outputs": [
-        {
-          "name": "outfile",
-          "type": "input"
-        }
-      ],
-      "position": {
-        "left": 3932.6953125,
-        "top": 457.4609375
-      },
-      "post_job_actions": {
-        "RenameDatasetActionoutfile": {
-          "action_arguments": {
-            "newname": "Combined Variant Report by Sample"
-          },
-          "action_type": "RenameDatasetAction",
-          "output_name": "outfile"
-        }
-      },
-      "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
-      "tool_shed_repository": {
-        "changeset_revision": "f46f0e4f75c4",
-        "name": "text_processing",
-        "owner": "bgruening",
-        "tool_shed": "toolshed.g2.bx.psu.edu"
-      },
-      "tool_state": "{\"header\": \"1\", \"ignore_case\": \"false\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"sortkeys\": [{\"__index__\": 0, \"column\": \"1\", \"order\": \"\", \"style\": \"\"}, {\"__index__\": 1, \"column\": \"2\", \"order\": \"\", \"style\": \"n\"}], \"unique\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-      "tool_version": "1.1.1",
-      "type": "tool",
-      "uuid": "eb754361-9ec5-46c8-80b5-6bb040345719",
-      "workflow_outputs": [
-        {
-          "label": "combined_variant_report",
-          "output_name": "outfile",
-          "uuid": "2f0680a4-d809-4f85-8df9-4fcd6c4f3d80"
-        }
-      ]
-    }
-  },
-  "tags": [
-    "mpvx",
-    "generic"
-  ],
-  "uuid": "9e94da53-d8ab-4713-8aac-7c6674fa1d39",
-  "version": 2
+    "tags": [
+        "mpvx",
+        "generic"
+    ],
+    "uuid": "9e94da53-d8ab-4713-8aac-7c6674fa1d39",
+    "version": 2
 }


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/variant-calling/variation-reporting**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3.0`
* `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3+t.galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_extractFields/4.3.0`
* `toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/1.6` should be updated to `toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.0`
* `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.3` should be updated to `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/1.1.4`

The workflow release number has been updated from 0.1 to 0.2.
