### PR TITLE
Updating workflows/epigenetics/chipseq-sr from 0.2 to 0.3

### DIFF
--- a/workflows/epigenetics/chipseq-sr/CHANGELOG.md
+++ b/workflows/epigenetics/chipseq-sr/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3] 2022-12-17
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy1`
+
 ## [0.2] 2022-11-28
 
 ### Automatic update

--- a/workflows/epigenetics/chipseq-sr/chipseq-sr.ga
+++ b/workflows/epigenetics/chipseq-sr/chipseq-sr.ga
@@ -10,7 +10,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.2",
+    "release": "0.3",
     "name": "ChIPseq_SR",
     "steps": {
         "0": {
@@ -546,7 +546,7 @@
         },
         "10": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy1",
             "errors": null,
             "id": 10,
             "input_connections": {
@@ -591,15 +591,15 @@
                     "output_name": "plots"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "9a913cdee30e",
+                "changeset_revision": "abfd8a6544d7",
                 "name": "multiqc",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"comment\": \"\", \"export\": \"true\", \"flat\": \"false\", \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"cutadapt\", \"__current_case__\": 5, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"bowtie2\", \"__current_case__\": 3, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"macs2\", \"__current_case__\": 16, \"input\": {\"__class__\": \"ConnectedValue\"}}}], \"saveLog\": \"false\", \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.11+galaxy0",
+            "tool_version": "1.11+galaxy1",
             "type": "tool",
             "uuid": "fb066848-43df-412a-9767-9613bac7d961",
             "workflow_outputs": [


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/epigenetics/chipseq-sr**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy1`

The workflow release number has been updated from 0.2 to 0.3.
