### PR TITLE
Updating workflows/epigenetics/atacseq from 0.3 to 0.4

### DIFF
--- a/workflows/epigenetics/atacseq/CHANGELOG.md
+++ b/workflows/epigenetics/atacseq/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Automatic update
 - `toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.1+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy1`
-- `toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.3` was updated to `toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicatesWithMateCigar/2.18.2.2`
 
 ## [0.3] 2022-12-17
 

--- a/workflows/epigenetics/atacseq/CHANGELOG.md
+++ b/workflows/epigenetics/atacseq/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4] 2023-01-16
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.1+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy1`
+- `toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.3` was updated to `toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicatesWithMateCigar/2.18.2.2`
+
 ## [0.3] 2022-12-17
 
 ### Automatic update

--- a/workflows/epigenetics/atacseq/atacseq.ga
+++ b/workflows/epigenetics/atacseq/atacseq.ga
@@ -10,7 +10,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.3",
+    "release": "0.4",
     "name": "ATACseq",
     "steps": {
         "0": {
@@ -225,7 +225,7 @@
         },
         "5": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.1+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy1",
             "errors": null,
             "id": 5,
             "input_connections": {
@@ -236,7 +236,7 @@
             },
             "inputs": [],
             "label": "filter MAPQ30 concordant pairs and not mitochondrial pairs",
-            "name": "Filter",
+            "name": "Filter BAM",
             "outputs": [
                 {
                     "name": "out_file2",
@@ -270,15 +270,15 @@
                     "output_name": "out_file1"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.1+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "1dfd95ee241e",
+                "changeset_revision": "108db6635177",
                 "name": "bamtools_filter",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"conditions\": [{\"__index__\": 0, \"filters\": [{\"__index__\": 0, \"bam_property\": {\"bam_property_selector\": \"mapQuality\", \"__current_case__\": 14, \"bam_property_value\": \">=30\"}}, {\"__index__\": 1, \"bam_property\": {\"bam_property_selector\": \"isProperPair\", \"__current_case__\": 11, \"bam_property_value\": \"true\"}}, {\"__index__\": 2, \"bam_property\": {\"bam_property_selector\": \"reference\", \"__current_case__\": 20, \"bam_property_value\": \"!chrM\"}}, {\"__index__\": 3, \"bam_property\": {\"bam_property_selector\": \"mateReference\", \"__current_case__\": 16, \"bam_property_value\": \"!MT\"}}]}], \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"rule_configuration\": {\"rules_selector\": \"false\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.5.1+galaxy0",
+            "tool_version": "2.5.2+galaxy1",
             "type": "tool",
             "uuid": "eba4c413-30c9-4bab-a088-dc12d5956c91",
             "workflow_outputs": []


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/epigenetics/atacseq**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.1+galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy1`
* `toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/2.18.2.3` should be updated to `toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicatesWithMateCigar/2.18.2.2`

The workflow release number has been updated from 0.3 to 0.4.
