### PR TITLE
Updating workflows/transcriptomics/rnaseq-pe from 0.3 to 0.4

### DIFF
--- a/workflows/transcriptomics/rnaseq-pe/CHANGELOG.md
+++ b/workflows/transcriptomics/rnaseq-pe/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4] 2023-01-16
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.1+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy1`
+
 ## [0.3] 2022-12-17
 
 ### Automatic update

--- a/workflows/transcriptomics/rnaseq-pe/rnaseq-pe.ga
+++ b/workflows/transcriptomics/rnaseq-pe/rnaseq-pe.ga
@@ -10,7 +10,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.3",
+    "release": "0.4",
     "name": "RNAseq_PE",
     "steps": {
         "0": {
@@ -685,7 +685,7 @@
         },
         "16": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.1+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy1",
             "errors": null,
             "id": 16,
             "input_connections": {
@@ -696,7 +696,7 @@
             },
             "inputs": [],
             "label": "Keep only uniquely mapped reads",
-            "name": "Filter",
+            "name": "Filter BAM",
             "outputs": [
                 {
                     "name": "out_file2",
@@ -723,15 +723,15 @@
                     "output_name": "out_file2"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.1+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "1dfd95ee241e",
+                "changeset_revision": "108db6635177",
                 "name": "bamtools_filter",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"conditions\": [{\"__index__\": 0, \"filters\": [{\"__index__\": 0, \"bam_property\": {\"bam_property_selector\": \"tag\", \"__current_case__\": 21, \"bam_property_value\": \"NH=1\"}}]}], \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"rule_configuration\": {\"rules_selector\": \"false\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.5.1+galaxy0",
+            "tool_version": "2.5.2+galaxy1",
             "type": "tool",
             "uuid": "e39f8468-742e-4cc7-8b29-3955c4adb0d0",
             "workflow_outputs": []


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/transcriptomics/rnaseq-pe**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.1+galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy1`

The workflow release number has been updated from 0.3 to 0.4.
