### PR TITLE
Fix changeset revisions in fragment-based-docking-scoring workflow

### DIFF
--- a/workflows/computational-chemistry/fragment-based-docking-scoring/CHANGELOG.md
+++ b/workflows/computational-chemistry/fragment-based-docking-scoring/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.4] 2023-02-14
+
+### Fixed
+- Fix the changeset revisions for 2 tool shed repositories
+
 ## [0.1.3] 2022-05-25
 
 ### Changed

--- a/workflows/computational-chemistry/fragment-based-docking-scoring/CHANGELOG.md
+++ b/workflows/computational-chemistry/fragment-based-docking-scoring/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Fix the changeset revisions for 2 tool shed repositories
+- Sync version of ``openbabel_compund_convert`` step to newest version
 
 ## [0.1.3] 2022-05-25
 

--- a/workflows/computational-chemistry/fragment-based-docking-scoring/fragment-based-docking-scoring.ga
+++ b/workflows/computational-chemistry/fragment-based-docking-scoring/fragment-based-docking-scoring.ga
@@ -504,7 +504,7 @@
         },
         "12": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_compound_convert/openbabel_compound_convert/2.4.2.2.0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_compound_convert/openbabel_compound_convert/3.1.1+galaxy0",
             "errors": null,
             "id": 12,
             "input_connections": {
@@ -539,7 +539,7 @@
                     "output_name": "outfile"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_compound_convert/openbabel_compound_convert/2.4.2.2.0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/openbabel_compound_convert/openbabel_compound_convert/3.1.1+galaxy0",
             "tool_shed_repository": {
                 "changeset_revision": "e2c36f62e22f",
                 "name": "openbabel_compound_convert",
@@ -547,7 +547,7 @@
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"appendtotitle\": \"\", \"dative_bonds\": \"false\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"oformat\": {\"oformat_opts_selector\": \"sdf\", \"__current_case__\": 58, \"sdf_exp_h\": \"false\", \"sdf_no_prop\": \"false\", \"sdf_wedge_bonds\": \"false\", \"sdf_alias_out\": \"false\", \"gen2d\": \"false\", \"gen3d\": \"true\"}, \"ph\": \"7.4\", \"remove_h\": \"false\", \"split\": \"false\", \"unique\": {\"unique_opts_selector\": \"\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.4.2.2.0",
+            "tool_version": "3.1.1+galaxy0",
             "type": "tool",
             "uuid": "7f069b7b-a0c0-474a-9e33-052ab9318658",
             "workflow_outputs": []

--- a/workflows/computational-chemistry/fragment-based-docking-scoring/fragment-based-docking-scoring.ga
+++ b/workflows/computational-chemistry/fragment-based-docking-scoring/fragment-based-docking-scoring.ga
@@ -16,7 +16,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "Fragment-based virtual screening using rDock for docking and SuCOS for pose scoring",
-    "release": "0.1.3",
+    "release": "0.1.4",
     "steps": {
         "0": {
             "annotation": "Number of docking poses to generate per input compound",
@@ -491,7 +491,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/rxdock_rbcavity/rxdock_rbcavity/2013.1.1_148c5bd1+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "7e5c2e4bc227",
+                "changeset_revision": "0848d3b1a46f",
                 "name": "rxdock_rbcavity",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -651,7 +651,7 @@
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/rxdock_rbdock/rxdock_rbdock/2013.1.1_148c5bd1+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "c362398df83b",
+                "changeset_revision": "b34d068c2782",
                 "name": "rxdock_rbdock",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"


### PR DESCRIPTION
I'm not sure where those revision numbers are coming from, they are not to be found in the tool shed or test tool shed. This prevents repo installation with `planemo test`