### PR TITLE
Updating workflows/epigenetics/hic-hicup-cooler from 0.1 to 0.2

### DIFF
--- a/workflows/epigenetics/hic-hicup-cooler/.dockstore.yml
+++ b/workflows/epigenetics/hic-hicup-cooler/.dockstore.yml
@@ -1,6 +1,6 @@
 version: 1.2
 workflows:
-- name: hic-fastq-to-cool-hicup-cooler
+- name: hic_fastq_to_cool_hicup_cooler
   subclass: Galaxy
   publish: true
   primaryDescriptorPath: /hic_fastq_to_cool_hicup_cooler.ga
@@ -8,8 +8,8 @@ workflows:
   - /hic_fastq_to_cool_hicup_cooler-tests.yml
   authors:
   - name: Lucille Delisle
-    orcid: 0000-0002-1964-496
-- name: chic-fastq-to-cool-hicup-cooler
+    orcid: 0000-0002-1964-4960
+- name: chic_fastq_to_cool_hicup_cooler
   subclass: Galaxy
   publish: true
   primaryDescriptorPath: /chic_fastq_to_cool_hicup_cooler.ga
@@ -17,8 +17,8 @@ workflows:
   - /chic_fastq_to_cool_hicup_cooler-tests.yml
   authors:
   - name: Lucille Delisle
-    orcid: 0000-0002-1964-496
-- name: hic-juicermediumtabix-to-cool-cooler
+    orcid: 0000-0002-1964-4960
+- name: hic_juicermediumtabix_to_cool_cooler
   subclass: Galaxy
   publish: true
   primaryDescriptorPath: /hic_juicermediumtabix_to_cool_cooler.ga
@@ -26,8 +26,8 @@ workflows:
   - /hic_juicermediumtabix_to_cool_cooler-tests.yml
   authors:
   - name: Lucille Delisle
-    orcid: 0000-0002-1964-496
-- name: hic-fastq-to-pairs-hicup
+    orcid: 0000-0002-1964-4960
+- name: hic_fastq_to_pairs_hicup
   subclass: Galaxy
   publish: true
   primaryDescriptorPath: /hic_fastq_to_pairs_hicup.ga
@@ -35,4 +35,4 @@ workflows:
   - /hic_fastq_to_pairs_hicup-tests.yml
   authors:
   - name: Lucille Delisle
-    orcid: 0000-0002-1964-496
+    orcid: 0000-0002-1964-4960

--- a/workflows/epigenetics/hic-hicup-cooler/CHANGELOG.md
+++ b/workflows/epigenetics/hic-hicup-cooler/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2] 2023-02-17
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.7+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.7+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy0`
+
 ## [0.1] 2023-01-16
 
 First release.

--- a/workflows/epigenetics/hic-hicup-cooler/CHANGELOG.md
+++ b/workflows/epigenetics/hic-hicup-cooler/CHANGELOG.md
@@ -7,6 +7,9 @@
 - `toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.8.3+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.9.2+galaxy0`
 - `toolshed.g2.bx.psu.edu/repos/bgruening/hicup2juicer/hicup2juicer/0.8.3+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/bgruening/hicup2juicer/hicup2juicer/0.9.2+galaxy0`
 
+### Manual update
+- Get fragment id in valid pairs file.
+- Use the middle of the fragment instead of 5' of the read in the valid pairs file.
 
 ## [0.1] 2023-01-16
 

--- a/workflows/epigenetics/hic-hicup-cooler/CHANGELOG.md
+++ b/workflows/epigenetics/hic-hicup-cooler/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Automatic update
 - `toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.7+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy0`
-- `toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.7+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.8.3+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.9.2+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/bgruening/hicup2juicer/hicup2juicer/0.8.3+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/bgruening/hicup2juicer/hicup2juicer/0.9.2+galaxy0`
+
 
 ## [0.1] 2023-01-16
 

--- a/workflows/epigenetics/hic-hicup-cooler/README.md
+++ b/workflows/epigenetics/hic-hicup-cooler/README.md
@@ -31,7 +31,7 @@ For the Hi-C workflow:
   - Pairing the mates when both mates are uniquely mapped or MAPQ30
   - Filtering the pairs for undigested, self-ligated...
   - Removing duplicates
-- The output BAM file is converted to medium juicer format: `<readname> <str1> <chr1> <pos1> <frag1> <str2> <chr2> <pos2> <frag2> <mapq1> <mapq2>` where str = strand (0 for forward, anything else for reverse) and pos is the 5' end.
+- The output BAM file is converted to medium juicer format: `<readname> <str1> <chr1> <pos1> <frag1> <str2> <chr2> <pos2> <frag2> <mapq1> <mapq2>` where str = strand (0 for forward, anything else for reverse) and pos is the middle of the fragment.
 - The pairs are filtered for MAPQ if specified.
 - For the region capture Hi-C workflow the pairs are filtered for both mates in the captured region.
 - The filtered pairs are sorted and indexed with cooler_csort.

--- a/workflows/epigenetics/hic-hicup-cooler/chic_fastq_to_cool_hicup_cooler-tests.yml
+++ b/workflows/epigenetics/hic-hicup-cooler/chic_fastq_to_cool_hicup_cooler-tests.yml
@@ -44,28 +44,28 @@
         test_dataset:
           asserts:
             - that: "has_line"
-              line: "1	1	chr10	100016423	0	1	chr10	101499220	1	42	42"
+              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
             - that: "has_line"
-              line: "2	1	chr10	100088974	0	1	chr10	122241330	1	38	42"
+              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
             - that: "has_line"
-              line: "3	0	chr10	100130383	0	1	chr10	50863577	1	0	42"
+              line: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
     valid pairs in juicebox format MAPQ filtered:
       element_tests:
         test_dataset:
           asserts:
             - that: "has_line"
-              line: "1	1	chr10	100016423	0	1	chr10	101499220	1	42	42"
+              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
             - that: "has_line"
-              line: "2	1	chr10	100088974	0	1	chr10	122241330	1	38	42"
+              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
             - that: "not_has_text"
-              text: "3	0	chr10	100130383	0	1	chr10	50863577	1	0	42"
+              text: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
     valid pairs filtered and sorted:
       element_tests:
         test_dataset:
           asserts:
             has_size:
-              value: 599
-              delta: 60
+              value: 807
+              delta: 80
     matrix with raw values:
       element_tests:
         test_dataset:

--- a/workflows/epigenetics/hic-hicup-cooler/chic_fastq_to_cool_hicup_cooler.ga
+++ b/workflows/epigenetics/hic-hicup-cooler/chic_fastq_to_cool_hicup_cooler.ga
@@ -10,7 +10,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.1",
+    "release": "0.2",
     "name": "cHi-C_fastqToCool_hicup_cooler",
     "steps": {
         "0": {
@@ -30,13 +30,14 @@
             "outputs": [],
             "position": {
                 "left": 0,
-                "top": 0.5
+                "top": 39.12167999999406
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list:paired\"}",
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "30fe3d0f-541a-478a-b57d-a43c0c16ccad",
+            "when": null,
             "workflow_outputs": []
         },
         "1": {
@@ -56,13 +57,14 @@
             "outputs": [],
             "position": {
                 "left": 39,
-                "top": 70.5
+                "top": 109.12167999999406
             },
             "tool_id": null,
             "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "45194ed6-a1e9-4248-8d3a-f51febc36d61",
+            "when": null,
             "workflow_outputs": []
         },
         "2": {
@@ -82,13 +84,14 @@
             "outputs": [],
             "position": {
                 "left": 72,
-                "top": 145.5
+                "top": 184.12167999999406
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "ec011ceb-c601-464f-8661-ca9c0b335bb5",
+            "when": null,
             "workflow_outputs": []
         },
         "3": {
@@ -108,13 +111,14 @@
             "outputs": [],
             "position": {
                 "left": 98.5,
-                "top": 231
+                "top": 269.62167999999406
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"boolean\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "11e64d82-c022-48b2-b616-076bfcdb14ad",
+            "when": null,
             "workflow_outputs": []
         },
         "4": {
@@ -134,13 +138,14 @@
             "outputs": [],
             "position": {
                 "left": 144,
-                "top": 300.5
+                "top": 339.12167999999406
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "748c8800-5bef-41b7-b2cf-6d6a57c0eb70",
+            "when": null,
             "workflow_outputs": []
         },
         "5": {
@@ -160,13 +165,14 @@
             "outputs": [],
             "position": {
                 "left": 173,
-                "top": 371
+                "top": 409.62167999999406
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "1e019ddf-171c-4247-ab11-0d2cdbe10f6a",
+            "when": null,
             "workflow_outputs": []
         },
         "6": {
@@ -186,13 +192,14 @@
             "outputs": [],
             "position": {
                 "left": 236,
-                "top": 435.25
+                "top": 473.87167999999406
             },
             "tool_id": null,
             "tool_state": "{\"restrictions\": [\"\", \"--cis-only\", \"--trans-only\"], \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "2cf7902e-aa51-45a7-ae75-9107bbb41911",
+            "when": null,
             "workflow_outputs": []
         },
         "7": {
@@ -212,13 +219,14 @@
             "outputs": [],
             "position": {
                 "left": 279.5,
-                "top": 584
+                "top": 622.6216799999941
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "386a8e30-aab6-4168-877e-581b883928e5",
+            "when": null,
             "workflow_outputs": []
         },
         "8": {
@@ -238,13 +246,14 @@
             "outputs": [],
             "position": {
                 "left": 333.5,
-                "top": 685
+                "top": 723.6216799999941
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "47de292d-7499-407e-bf9a-b67a4dc47348",
+            "when": null,
             "workflow_outputs": []
         },
         "9": {
@@ -264,13 +273,14 @@
             "outputs": [],
             "position": {
                 "left": 397.5,
-                "top": 797
+                "top": 835.6216799999941
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "25480973-63be-4e64-9ba1-26088b4a65c4",
+            "when": null,
             "workflow_outputs": []
         },
         "10": {
@@ -308,8 +318,8 @@
             "name": "Hi-C_fastqToPairs_hicup",
             "outputs": [],
             "position": {
-                "left": 557.5,
-                "top": 0
+                "left": 520,
+                "top": 0.0
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -341,7 +351,7 @@
                         "name": "Input dataset collection",
                         "outputs": [],
                         "position": {
-                            "left": 0.0,
+                            "left": 0,
                             "top": 12.5
                         },
                         "tool_id": null,
@@ -349,17 +359,18 @@
                         "tool_version": null,
                         "type": "data_collection_input",
                         "uuid": "30fe3d0f-541a-478a-b57d-a43c0c16ccad",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "1": {
-                        "annotation": "use only genome ids which have bowtie2 indexes",
+                        "annotation": "use the bowtie2 indexes to display choices",
                         "content_id": null,
                         "errors": null,
                         "id": 1,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "use only genome ids which have bowtie2 indexes",
+                                "description": "use the bowtie2 indexes to display choices",
                                 "name": "genome name"
                             }
                         ],
@@ -367,7 +378,7 @@
                         "name": "Input parameter",
                         "outputs": [],
                         "position": {
-                            "left": 39.0,
+                            "left": 39,
                             "top": 82.5
                         },
                         "tool_id": null,
@@ -375,13 +386,8 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "45194ed6-a1e9-4248-8d3a-f51febc36d61",
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "bd9475a2-5158-4bd0-8b48-9476d7891ab4"
-                            }
-                        ]
+                        "when": null,
+                        "workflow_outputs": []
                     },
                     "2": {
                         "annotation": "Restriction enzyme used e.g. A^GATCT,BglII. Some Hi-C protocols may use several enzymes. To specify several enzymes, use the ':' to separate them e.g. A^GATCT,BglII:A^AGCTT,HindIII:^GATC,DpnII. HiCUP accomodates N in restriction enzyme: e.g. :A^ANCTT",
@@ -399,7 +405,7 @@
                         "name": "Input parameter",
                         "outputs": [],
                         "position": {
-                            "left": 58.0,
+                            "left": 58,
                             "top": 155.5
                         },
                         "tool_id": null,
@@ -407,13 +413,8 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "ec011ceb-c601-464f-8661-ca9c0b335bb5",
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "50c83eb6-b03a-435a-8688-1c683f4735f4"
-                            }
-                        ]
+                        "when": null,
+                        "workflow_outputs": []
                     },
                     "3": {
                         "annotation": "Hi-C protocol did NOT include a fill-in of sticky ends prior to re-ligation and therefore reads shall be truncated at the restriction site sequence",
@@ -439,13 +440,8 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "c807fdbf-1c1d-45b4-851e-47fb919b07d6",
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "6791ad54-3142-4c2e-b2ab-08fb618890dd"
-                            }
-                        ]
+                        "when": null,
+                        "workflow_outputs": []
                     },
                     "4": {
                         "annotation": "can be set to 0 for no filtering",
@@ -463,7 +459,7 @@
                         "name": "Input parameter",
                         "outputs": [],
                         "position": {
-                            "left": 131.0,
+                            "left": 131,
                             "top": 320.5
                         },
                         "tool_id": null,
@@ -471,17 +467,12 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "748c8800-5bef-41b7-b2cf-6d6a57c0eb70",
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "7040ff41-3e55-4771-a078-33c9d2f4c066"
-                            }
-                        ]
+                        "when": null,
+                        "workflow_outputs": []
                     },
                     "5": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.8.3+galaxy0",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.9.2+galaxy0",
                         "errors": null,
                         "id": 5,
                         "input_connections": {
@@ -506,12 +497,7 @@
                                 "output_name": "output"
                             }
                         },
-                        "inputs": [
-                            {
-                                "description": "runtime parameter for tool Hicup Pipeline",
-                                "name": "library"
-                            }
-                        ],
+                        "inputs": [],
                         "label": "HiCUP",
                         "name": "Hicup Pipeline",
                         "outputs": [
@@ -538,7 +524,7 @@
                         ],
                         "position": {
                             "left": 356.5,
-                            "top": 0.0
+                            "top": 0
                         },
                         "post_job_actions": {
                             "HideDatasetActiondataset_hicup": {
@@ -571,27 +557,28 @@
                                 "output_name": "hicup_results"
                             }
                         },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.8.3+galaxy0",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.9.2+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "852e1fac4802",
+                            "changeset_revision": "68fb19094f84",
                             "name": "hicup_hicup",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"advanced_options\": {\"re2\": \"\", \"longest\": \"\", \"shortest\": \"\", \"nofill\": {\"__class__\": \"ConnectedValue\"}}, \"genome\": {\"__class__\": \"ConnectedValue\"}, \"library\": {\"type\": \"paired_collection\", \"__current_case__\": 1, \"input_1\": {\"__class__\": \"RuntimeValue\"}}, \"re1\": {\"__class__\": \"ConnectedValue\"}, \"reference_genome\": {\"source\": \"indexed\", \"__current_case__\": 0, \"index\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "0.8.3+galaxy0",
+                        "tool_state": "{\"advanced_options\": {\"re2\": \"\", \"longest\": \"\", \"shortest\": \"\", \"nofill\": {\"__class__\": \"ConnectedValue\"}}, \"genome\": {\"__class__\": \"ConnectedValue\"}, \"library\": {\"type\": \"paired_collection\", \"__current_case__\": 1, \"input_1\": {\"__class__\": \"ConnectedValue\"}}, \"re1\": {\"__class__\": \"ConnectedValue\"}, \"reference_genome\": {\"source\": \"indexed\", \"__current_case__\": 0, \"index\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "0.9.2+galaxy0",
                         "type": "tool",
                         "uuid": "8aba6fbb-d940-4826-911b-8c148e82085c",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": "HiCUP report (HTML)",
                                 "output_name": "hicup_results",
-                                "uuid": "605b22a3-2408-42eb-b8ea-931b4ae43e4c"
+                                "uuid": "ba37bb7a-ad3a-487b-b7ba-0023f1c496fd"
                             },
                             {
                                 "label": "HiCUP report (tabular)",
                                 "output_name": "hicup_report",
-                                "uuid": "1d054a07-8ecb-470e-bb6a-5f33995526e3"
+                                "uuid": "fd8f1b17-c68e-4652-b139-acccf51baa30"
                             }
                         ]
                     },
@@ -640,15 +627,20 @@
                         "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \"(c10>=\"}}, {\"__index__\": 1, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 1, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \") and (c11>=\"}}, {\"__index__\": 3, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 1, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 4, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \")\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
                         "tool_version": "0.1.1",
                         "type": "tool",
-                        "uuid": "58932328-5dee-4473-8900-d213a25bc3e6",
+                        "uuid": "ee70cd21-6a36-4e21-97d2-ff0749236523",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "7": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup2juicer/hicup2juicer/0.8.3+galaxy0",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup2juicer/hicup2juicer/0.9.2+galaxy0",
                         "errors": null,
                         "id": 7,
                         "input_connections": {
+                            "digester|digester_file": {
+                                "id": 5,
+                                "output_name": "digester_file"
+                            },
                             "input_file": {
                                 "id": 5,
                                 "output_name": "dataset_hicup"
@@ -676,22 +668,23 @@
                                 "output_name": "output"
                             }
                         },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup2juicer/hicup2juicer/0.8.3+galaxy0",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup2juicer/hicup2juicer/0.9.2+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "f8cb84c49623",
+                            "changeset_revision": "b4e7244246e2",
                             "name": "hicup2juicer",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "0.8.3+galaxy0",
+                        "tool_state": "{\"digester\": {\"provide_digester\": \"yes\", \"__current_case__\": 0, \"digester_file\": {\"__class__\": \"ConnectedValue\"}, \"usemid\": true}, \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "0.9.2+galaxy0",
                         "type": "tool",
                         "uuid": "659811cd-a212-4949-9693-074f6161ed11",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": "valid pairs in juicebox format",
                                 "output_name": "output",
-                                "uuid": "bad396c6-90bb-468e-a29a-0f784259ce2c"
+                                "uuid": "dfc67c68-2569-4727-9ca6-a70f3b13edd9"
                             }
                         ]
                     },
@@ -720,7 +713,7 @@
                             }
                         ],
                         "position": {
-                            "left": 1041.0,
+                            "left": 1041,
                             "top": 304.5
                         },
                         "post_job_actions": {
@@ -737,41 +730,43 @@
                         "tool_version": "1.1.1",
                         "type": "tool",
                         "uuid": "fe9a084d-06ad-4671-a4d6-85dff2f96138",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": "valid pairs in juicebox format MAPQ filtered",
                                 "output_name": "out_file1",
-                                "uuid": "4a35d65b-eb98-47c0-8d95-bb7967dbe559"
+                                "uuid": "b08373c7-59b2-4ae3-90b7-7c9a05ca81b7"
                             }
                         ]
                     }
                 },
                 "tags": "",
-                "uuid": "39b0818f-2c1c-43fb-9f71-08ca7ef17362"
+                "uuid": "4a815412-cadd-4df9-9559-15b365715f05"
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "09faf294-f11a-4975-885a-1da5372e5f08",
+            "uuid": "3584d879-0b7a-4a89-a5f6-8439db6f003e",
+            "when": null,
             "workflow_outputs": [
                 {
-                    "label": "valid pairs in juicebox format MAPQ filtered",
-                    "output_name": "valid pairs in juicebox format MAPQ filtered",
-                    "uuid": "91663e23-231f-4047-9a49-662686190e58"
+                    "label": "HiCUP report (txt)",
+                    "output_name": "HiCUP report (tabular)",
+                    "uuid": "b479e588-6d59-4b60-9dd7-036e58358eae"
+                },
+                {
+                    "label": "HiCUP report (HTML)",
+                    "output_name": "HiCUP report (HTML)",
+                    "uuid": "902f20ef-d51d-4fad-86a0-206cda2ef361"
                 },
                 {
                     "label": "valid pairs in juicebox format",
                     "output_name": "valid pairs in juicebox format",
-                    "uuid": "3555ff5a-db0b-4298-8201-6b02dd1418ab"
+                    "uuid": "bc19676e-9619-43b9-9c21-bc3c31fad3b2"
                 },
                 {
-                    "label": "HiCUP report (html)",
-                    "output_name": "HiCUP report (HTML)",
-                    "uuid": "7983935c-11fb-434d-9ed9-21537b7234e3"
-                },
-                {
-                    "label": "HiCUP report (txt)",
-                    "output_name": "HiCUP report (tabular)",
-                    "uuid": "a461a15d-2001-4934-99fc-8bce9bb8e1b9"
+                    "label": "valid pairs in juicebox format MAPQ filtered",
+                    "output_name": "valid pairs in juicebox format MAPQ filtered",
+                    "uuid": "ec040a8e-883a-4cdb-b5bf-ea5a611a16a7"
                 }
             ]
         },
@@ -817,7 +812,7 @@
             ],
             "position": {
                 "left": 698.5,
-                "top": 808
+                "top": 846.6216799999941
             },
             "post_job_actions": {
                 "HideDatasetActionout1": {
@@ -837,6 +832,7 @@
             "tool_version": "0.1.1",
             "type": "tool",
             "uuid": "5736ad36-505d-45cd-aebc-6763055e9509",
+            "when": null,
             "workflow_outputs": []
         },
         "12": {
@@ -869,7 +865,7 @@
             ],
             "position": {
                 "left": 1398,
-                "top": 651
+                "top": 689.6216799999941
             },
             "post_job_actions": {
                 "HideDatasetActionout1": {
@@ -889,6 +885,7 @@
             "tool_version": "0.1.1",
             "type": "tool",
             "uuid": "eb2d5028-6f3f-4f6f-9338-ec979be3b4ab",
+            "when": null,
             "workflow_outputs": []
         },
         "13": {
@@ -917,7 +914,7 @@
             ],
             "position": {
                 "left": 891.5,
-                "top": 517
+                "top": 555.6216799999941
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -931,6 +928,7 @@
             "tool_version": "1.1.1",
             "type": "tool",
             "uuid": "f39490d2-503d-4c69-a682-c8472abc8e94",
+            "when": null,
             "workflow_outputs": []
         },
         "14": {
@@ -959,7 +957,7 @@
             ],
             "position": {
                 "left": 988,
-                "top": 189.5
+                "top": 228.12167999999406
             },
             "post_job_actions": {
                 "ChangeDatatypeActionoutput": {
@@ -988,6 +986,7 @@
             "tool_version": "0.8.11+galaxy1",
             "type": "tool",
             "uuid": "bbb479cd-c67c-4347-9c1d-ac8095d90aa9",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "valid pairs filtered and sorted",
@@ -1026,8 +1025,8 @@
             "name": "Hi-C_juicermediumtabixToCool_cooler",
             "outputs": [],
             "position": {
-                "left": 1283,
-                "top": 300.5
+                "left": 1290,
+                "top": 309.1166687011719
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -1067,6 +1066,7 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "d0a82863-82f8-426c-addb-06066e9d0a73",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": null,
@@ -1099,6 +1099,7 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "48506f80-b1b5-4d1d-98a6-c6882de026f1",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": null,
@@ -1131,6 +1132,7 @@
                         "tool_version": null,
                         "type": "data_collection_input",
                         "uuid": "588962a4-8ce4-4929-81fd-a9dfdd032598",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "3": {
@@ -1157,6 +1159,7 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "d6375500-a591-47a9-b126-950347e3e7a8",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": null,
@@ -1211,6 +1214,7 @@
                         "tool_version": "0.8.11+galaxy0",
                         "type": "tool",
                         "uuid": "34e0a213-93e8-466e-b07b-ede1443ee7d6",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "5": {
@@ -1265,6 +1269,7 @@
                         "tool_version": "0.8.11+galaxy1",
                         "type": "tool",
                         "uuid": "d411eea7-7996-44f2-af2a-feecb854a067",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": "matrix with raw values",
@@ -1326,6 +1331,7 @@
                         "tool_version": "0.8.11+galaxy0",
                         "type": "tool",
                         "uuid": "44270887-1c96-4ede-8bb9-3db2a07eeb6e",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": "matrix with iced values",
@@ -1341,6 +1347,7 @@
             "tool_id": null,
             "type": "subworkflow",
             "uuid": "63c60960-bd33-436a-ac47-fdaf69c4bdfa",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "matrix with raw values",
@@ -1380,7 +1387,7 @@
             ],
             "position": {
                 "left": 1673,
-                "top": 768
+                "top": 806.6216799999941
             },
             "post_job_actions": {
                 "RenameDatasetActionoutFileName": {
@@ -1398,10 +1405,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"global_args\": {\"title\": \"\", \"fontsize\": \"12\", \"dpi\": \"72\", \"width\": \"40.0\", \"plotWidth\": null, \"height\": null, \"trackLabelFraction\": \"0.05\", \"trackLabelHAlign\": \"left\", \"decreasingXAxis\": \"false\"}, \"image_file_format\": \"png\", \"region\": {\"__class__\": \"ConnectedValue\"}, \"tracks\": [{\"__index__\": 0, \"track_file_style_conditional\": {\"track_file_style_selector\": \"hic_matrix_option\", \"__current_case__\": 0, \"title\": \"\", \"matrix_h5_cooler_multiple\": {\"__class__\": \"RuntimeValue\"}, \"colormap\": \"RdYlBu_r\", \"min_value\": null, \"max_value\": null, \"depth\": \"8000000\", \"transform\": \"no\", \"height_matrix\": null, \"show_masked_bins\": \"false\", \"boundaries_file\": {\"__class__\": \"RuntimeValue\"}, \"scale_factor\": \"1.0\", \"rasterize\": \"true\", \"invert_orientation\": \"false\", \"spacer_height\": null}}, {\"__index__\": 1, \"track_file_style_conditional\": {\"track_file_style_selector\": \"xaxis_option\", \"__current_case__\": 13, \"title\": \"\", \"fontsize\": null, \"xaxis_where\": \"bottom\", \"spacer_height\": null}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"global_args\": {\"title\": \"\", \"fontsize\": \"12\", \"dpi\": \"72\", \"width\": \"40.0\", \"plotWidth\": null, \"height\": null, \"trackLabelFraction\": \"0.05\", \"trackLabelHAlign\": \"left\", \"decreasingXAxis\": false}, \"image_file_format\": \"png\", \"region\": {\"__class__\": \"ConnectedValue\"}, \"tracks\": [{\"__index__\": 0, \"track_file_style_conditional\": {\"track_file_style_selector\": \"hic_matrix_option\", \"__current_case__\": 0, \"title\": \"\", \"matrix_h5_cooler_multiple\": {\"__class__\": \"ConnectedValue\"}, \"colormap\": \"RdYlBu_r\", \"min_value\": null, \"max_value\": null, \"depth\": \"8000000\", \"transform\": \"no\", \"height_matrix\": null, \"show_masked_bins\": false, \"boundaries_file\": {\"__class__\": \"RuntimeValue\"}, \"scale_factor\": \"1.0\", \"rasterize\": true, \"invert_orientation\": false, \"spacer_height\": null}}, {\"__index__\": 1, \"track_file_style_conditional\": {\"track_file_style_selector\": \"xaxis_option\", \"__current_case__\": 13, \"title\": \"\", \"fontsize\": null, \"xaxis_where\": \"bottom\", \"spacer_height\": null}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "3.7+galaxy0",
             "type": "tool",
             "uuid": "dfbe45de-b2a7-479e-b717-29ec5b31379e",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "plot with pyGenomeTracks",
@@ -1414,6 +1422,6 @@
     "tags": [
         "Hi-C"
     ],
-    "uuid": "c699e1db-1c3b-4899-83d2-4892d75c3aea",
+    "uuid": "f310abac-4a50-41fa-a59a-84c51816a462",
     "version": 1
 }

--- a/workflows/epigenetics/hic-hicup-cooler/chic_fastq_to_cool_hicup_cooler.ga
+++ b/workflows/epigenetics/hic-hicup-cooler/chic_fastq_to_cool_hicup_cooler.ga
@@ -754,7 +754,7 @@
                     "uuid": "b479e588-6d59-4b60-9dd7-036e58358eae"
                 },
                 {
-                    "label": "HiCUP report (HTML)",
+                    "label": "HiCUP report (html)",
                     "output_name": "HiCUP report (HTML)",
                     "uuid": "902f20ef-d51d-4fad-86a0-206cda2ef361"
                 },

--- a/workflows/epigenetics/hic-hicup-cooler/hic_fastq_to_cool_hicup_cooler-tests.yml
+++ b/workflows/epigenetics/hic-hicup-cooler/hic_fastq_to_cool_hicup_cooler-tests.yml
@@ -42,28 +42,28 @@
         test_dataset:
           asserts:
             - that: "has_line"
-              line: "1	1	chr10	100016423	0	1	chr10	101499220	1	42	42"
+              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
             - that: "has_line"
-              line: "2	1	chr10	100088974	0	1	chr10	122241330	1	38	42"
+              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
             - that: "has_line"
-              line: "3	0	chr10	100130383	0	1	chr10	50863577	1	0	42"
+              line: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
     valid pairs in juicebox format MAPQ filtered:
       element_tests:
         test_dataset:
           asserts:
             - that: "has_line"
-              line: "1	1	chr10	100016423	0	1	chr10	101499220	1	42	42"
+              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
             - that: "has_line"
-              line: "2	1	chr10	100088974	0	1	chr10	122241330	1	38	42"
+              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
             - that: "not_has_text"
-              text: "3	0	chr10	100130383	0	1	chr10	50863577	1	0	42"
+              text: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
     valid pairs filtered and sorted:
       element_tests:
         test_dataset:
           asserts:
             has_size:
-              value: 523343
-              delta: 50000
+              value: 735227
+              delta: 70000
     matrix with raw values:
       element_tests:
         test_dataset:

--- a/workflows/epigenetics/hic-hicup-cooler/hic_fastq_to_cool_hicup_cooler.ga
+++ b/workflows/epigenetics/hic-hicup-cooler/hic_fastq_to_cool_hicup_cooler.ga
@@ -10,7 +10,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.3",
+    "release": "0.4",
     "name": "Hi-C_fastqToCool_hicup_cooler",
     "steps": {
         "0": {
@@ -37,6 +37,7 @@
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "30fe3d0f-541a-478a-b57d-a43c0c16ccad",
+            "when": null,
             "workflow_outputs": []
         },
         "1": {
@@ -63,6 +64,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "45194ed6-a1e9-4248-8d3a-f51febc36d61",
+            "when": null,
             "workflow_outputs": []
         },
         "2": {
@@ -89,6 +91,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "ec011ceb-c601-464f-8661-ca9c0b335bb5",
+            "when": null,
             "workflow_outputs": []
         },
         "3": {
@@ -115,6 +118,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "11e64d82-c022-48b2-b616-076bfcdb14ad",
+            "when": null,
             "workflow_outputs": []
         },
         "4": {
@@ -141,6 +145,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "748c8800-5bef-41b7-b2cf-6d6a57c0eb70",
+            "when": null,
             "workflow_outputs": []
         },
         "5": {
@@ -167,6 +172,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "1e019ddf-171c-4247-ab11-0d2cdbe10f6a",
+            "when": null,
             "workflow_outputs": []
         },
         "6": {
@@ -193,6 +199,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "51990231-540d-4fbc-bf77-bbbb4d1fc461",
+            "when": null,
             "workflow_outputs": []
         },
         "7": {
@@ -219,6 +226,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "ea792308-f30e-49c4-9fec-8de03f45f64c",
+            "when": null,
             "workflow_outputs": []
         },
         "8": {
@@ -297,6 +305,7 @@
                         "tool_version": null,
                         "type": "data_collection_input",
                         "uuid": "30fe3d0f-541a-478a-b57d-a43c0c16ccad",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "1": {
@@ -323,6 +332,7 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "45194ed6-a1e9-4248-8d3a-f51febc36d61",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": null,
@@ -355,6 +365,7 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "ec011ceb-c601-464f-8661-ca9c0b335bb5",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": null,
@@ -387,6 +398,7 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "c807fdbf-1c1d-45b4-851e-47fb919b07d6",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": null,
@@ -419,6 +431,7 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "748c8800-5bef-41b7-b2cf-6d6a57c0eb70",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": null,
@@ -525,6 +538,7 @@
                         "tool_version": "0.9.2+galaxy0",
                         "type": "tool",
                         "uuid": "8aba6fbb-d940-4826-911b-8c148e82085c",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": "HiCUP report (HTML)",
@@ -584,6 +598,7 @@
                         "tool_version": "0.1.1",
                         "type": "tool",
                         "uuid": "ee70cd21-6a36-4e21-97d2-ff0749236523",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "7": {
@@ -631,10 +646,11 @@
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"digester\": {\"provide_digester\": \"yes\", \"__current_case__\": 0, \"digester_file\": {\"__class__\": \"RuntimeValue\"}, \"usemid\": \"false\"}, \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_state": "{\"digester\": {\"provide_digester\": \"yes\", \"__current_case__\": 0, \"digester_file\": {\"__class__\": \"RuntimeValue\"}, \"usemid\": false}, \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
                         "tool_version": "0.9.2+galaxy0",
                         "type": "tool",
                         "uuid": "659811cd-a212-4949-9693-074f6161ed11",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": "valid pairs in juicebox format",
@@ -685,6 +701,7 @@
                         "tool_version": "1.1.1",
                         "type": "tool",
                         "uuid": "fe9a084d-06ad-4671-a4d6-85dff2f96138",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": "valid pairs in juicebox format MAPQ filtered",
@@ -695,11 +712,12 @@
                     }
                 },
                 "tags": "",
-                "uuid": "bd695c06-442d-49be-9f7c-2d94efe8cbca"
+                "uuid": "fb4ae0eb-3f8b-4a5c-9d50-3234dd9df3d2"
             },
             "tool_id": null,
             "type": "subworkflow",
             "uuid": "33846b88-4c1c-4c90-9ff9-63cdb29e9587",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "valid pairs in juicebox format",
@@ -778,6 +796,7 @@
             "tool_version": "0.8.11+galaxy1",
             "type": "tool",
             "uuid": "bbb479cd-c67c-4347-9c1d-ac8095d90aa9",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "valid pairs filtered and sorted",
@@ -857,6 +876,7 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "d0a82863-82f8-426c-addb-06066e9d0a73",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": null,
@@ -889,6 +909,7 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "48506f80-b1b5-4d1d-98a6-c6882de026f1",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": null,
@@ -921,6 +942,7 @@
                         "tool_version": null,
                         "type": "data_collection_input",
                         "uuid": "588962a4-8ce4-4929-81fd-a9dfdd032598",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "3": {
@@ -947,6 +969,7 @@
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "d6375500-a591-47a9-b126-950347e3e7a8",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": null,
@@ -1001,6 +1024,7 @@
                         "tool_version": "0.8.11+galaxy0",
                         "type": "tool",
                         "uuid": "34e0a213-93e8-466e-b07b-ede1443ee7d6",
+                        "when": null,
                         "workflow_outputs": []
                     },
                     "5": {
@@ -1055,6 +1079,7 @@
                         "tool_version": "0.8.11+galaxy1",
                         "type": "tool",
                         "uuid": "d411eea7-7996-44f2-af2a-feecb854a067",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": "matrix with raw values",
@@ -1116,6 +1141,7 @@
                         "tool_version": "0.8.11+galaxy0",
                         "type": "tool",
                         "uuid": "44270887-1c96-4ede-8bb9-3db2a07eeb6e",
+                        "when": null,
                         "workflow_outputs": [
                             {
                                 "label": "matrix with iced values",
@@ -1126,11 +1152,12 @@
                     }
                 },
                 "tags": "",
-                "uuid": "eb94eb55-03fc-4be8-b4c9-e26709bfeabe"
+                "uuid": "ea1a61d4-def1-4cdb-b29c-77e77ebacb7a"
             },
             "tool_id": null,
             "type": "subworkflow",
             "uuid": "c4d87b28-5da7-48cb-aa49-cab59a0cb19b",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "matrix with iced values",
@@ -1146,7 +1173,7 @@
         },
         "11": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy1",
             "errors": null,
             "id": 11,
             "input_connections": {
@@ -1181,17 +1208,18 @@
                     "output_name": "outFileName"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "14e7c35f3d00",
+                "changeset_revision": "360df4999907",
                 "name": "pygenometracks",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"global_args\": {\"title\": \"\", \"fontsize\": \"12\", \"dpi\": \"72\", \"width\": \"40.0\", \"plotWidth\": null, \"height\": null, \"trackLabelFraction\": \"0.05\", \"trackLabelHAlign\": \"left\", \"decreasingXAxis\": \"false\"}, \"image_file_format\": \"png\", \"region\": {\"__class__\": \"ConnectedValue\"}, \"tracks\": [{\"__index__\": 0, \"track_file_style_conditional\": {\"track_file_style_selector\": \"hic_matrix_option\", \"__current_case__\": 0, \"title\": \"\", \"matrix_h5_cooler_multiple\": {\"__class__\": \"ConnectedValue\"}, \"colormap\": \"RdYlBu_r\", \"min_value\": null, \"max_value\": null, \"depth\": \"8000000\", \"transform\": \"no\", \"height_matrix\": null, \"show_masked_bins\": \"false\", \"boundaries_file\": {\"__class__\": \"RuntimeValue\"}, \"scale_factor\": \"1.0\", \"rasterize\": \"true\", \"invert_orientation\": \"false\", \"spacer_height\": null}}, {\"__index__\": 1, \"track_file_style_conditional\": {\"track_file_style_selector\": \"xaxis_option\", \"__current_case__\": 13, \"title\": \"\", \"fontsize\": null, \"xaxis_where\": \"bottom\", \"spacer_height\": null}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "3.8+galaxy0",
+            "tool_state": "{\"global_args\": {\"title\": \"\", \"fontsize\": \"12\", \"dpi\": \"72\", \"width\": \"40.0\", \"plotWidth\": null, \"height\": null, \"trackLabelFraction\": \"0.05\", \"trackLabelHAlign\": \"left\", \"decreasingXAxis\": false}, \"image_file_format\": \"png\", \"region\": {\"__class__\": \"ConnectedValue\"}, \"tracks\": [{\"__index__\": 0, \"track_file_style_conditional\": {\"track_file_style_selector\": \"hic_matrix_option\", \"__current_case__\": 0, \"title\": \"\", \"matrix_h5_cooler_multiple\": {\"__class__\": \"ConnectedValue\"}, \"colormap\": \"RdYlBu_r\", \"min_value\": null, \"max_value\": null, \"depth\": \"8000000\", \"transform\": \"no\", \"height_matrix\": null, \"show_masked_bins\": false, \"boundaries_file\": {\"__class__\": \"RuntimeValue\"}, \"scale_factor\": \"1.0\", \"rasterize\": true, \"invert_orientation\": false, \"spacer_height\": null}}, {\"__index__\": 1, \"track_file_style_conditional\": {\"track_file_style_selector\": \"xaxis_option\", \"__current_case__\": 13, \"title\": \"\", \"fontsize\": null, \"xaxis_where\": \"bottom\", \"spacer_height\": null}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "3.8+galaxy1",
             "type": "tool",
             "uuid": "d8b80397-70dc-4522-8a12-948b1107ac8d",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "plot with pyGenomeTracks",

--- a/workflows/epigenetics/hic-hicup-cooler/hic_fastq_to_cool_hicup_cooler.ga
+++ b/workflows/epigenetics/hic-hicup-cooler/hic_fastq_to_cool_hicup_cooler.ga
@@ -10,7 +10,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.2",
+    "release": "0.3",
     "name": "Hi-C_fastqToCool_hicup_cooler",
     "steps": {
         "0": {
@@ -429,7 +429,7 @@
                     },
                     "5": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.8.3+galaxy0",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.9.2+galaxy0",
                         "errors": null,
                         "id": 5,
                         "input_connections": {
@@ -514,15 +514,15 @@
                                 "output_name": "hicup_results"
                             }
                         },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.8.3+galaxy0",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.9.2+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "852e1fac4802",
+                            "changeset_revision": "68fb19094f84",
                             "name": "hicup_hicup",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
                         "tool_state": "{\"advanced_options\": {\"re2\": \"\", \"longest\": \"\", \"shortest\": \"\", \"nofill\": {\"__class__\": \"ConnectedValue\"}}, \"genome\": {\"__class__\": \"ConnectedValue\"}, \"library\": {\"type\": \"paired_collection\", \"__current_case__\": 1, \"input_1\": {\"__class__\": \"ConnectedValue\"}}, \"re1\": {\"__class__\": \"ConnectedValue\"}, \"reference_genome\": {\"source\": \"indexed\", \"__current_case__\": 0, \"index\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "0.8.3+galaxy0",
+                        "tool_version": "0.9.2+galaxy0",
                         "type": "tool",
                         "uuid": "8aba6fbb-d940-4826-911b-8c148e82085c",
                         "workflow_outputs": [
@@ -588,7 +588,7 @@
                     },
                     "7": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup2juicer/hicup2juicer/0.8.3+galaxy0",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup2juicer/hicup2juicer/0.9.2+galaxy0",
                         "errors": null,
                         "id": 7,
                         "input_connections": {
@@ -597,7 +597,12 @@
                                 "output_name": "dataset_hicup"
                             }
                         },
-                        "inputs": [],
+                        "inputs": [
+                            {
+                                "description": "runtime parameter for tool Hicup to juicer converter",
+                                "name": "digester"
+                            }
+                        ],
                         "label": "valid pairs in juicebox format",
                         "name": "Hicup to juicer converter",
                         "outputs": [
@@ -619,15 +624,15 @@
                                 "output_name": "output"
                             }
                         },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup2juicer/hicup2juicer/0.8.3+galaxy0",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup2juicer/hicup2juicer/0.9.2+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "f8cb84c49623",
+                            "changeset_revision": "b4e7244246e2",
                             "name": "hicup2juicer",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "0.8.3+galaxy0",
+                        "tool_state": "{\"digester\": {\"provide_digester\": \"yes\", \"__current_case__\": 0, \"digester_file\": {\"__class__\": \"RuntimeValue\"}, \"usemid\": \"false\"}, \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "0.9.2+galaxy0",
                         "type": "tool",
                         "uuid": "659811cd-a212-4949-9693-074f6161ed11",
                         "workflow_outputs": [
@@ -690,9 +695,9 @@
                     }
                 },
                 "tags": "",
-                "uuid": "54e02e74-a6af-4848-ad37-cc4162a20547"
+                "uuid": "bd695c06-442d-49be-9f7c-2d94efe8cbca"
             },
-            "tool_id": 7,
+            "tool_id": null,
             "type": "subworkflow",
             "uuid": "33846b88-4c1c-4c90-9ff9-63cdb29e9587",
             "workflow_outputs": [
@@ -1121,9 +1126,9 @@
                     }
                 },
                 "tags": "",
-                "uuid": "3d450f15-858f-4cc6-a5d6-3a38bde7c8d2"
+                "uuid": "eb94eb55-03fc-4be8-b4c9-e26709bfeabe"
             },
-            "tool_id": 8,
+            "tool_id": null,
             "type": "subworkflow",
             "uuid": "c4d87b28-5da7-48cb-aa49-cab59a0cb19b",
             "workflow_outputs": [

--- a/workflows/epigenetics/hic-hicup-cooler/hic_fastq_to_cool_hicup_cooler.ga
+++ b/workflows/epigenetics/hic-hicup-cooler/hic_fastq_to_cool_hicup_cooler.ga
@@ -10,7 +10,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.1",
+    "release": "0.2",
     "name": "Hi-C_fastqToCool_hicup_cooler",
     "steps": {
         "0": {
@@ -690,9 +690,9 @@
                     }
                 },
                 "tags": "",
-                "uuid": "cc08c539-5d45-4137-95c2-07fb1b8b8a73"
+                "uuid": "54e02e74-a6af-4848-ad37-cc4162a20547"
             },
-            "tool_id": null,
+            "tool_id": 7,
             "type": "subworkflow",
             "uuid": "33846b88-4c1c-4c90-9ff9-63cdb29e9587",
             "workflow_outputs": [
@@ -1121,9 +1121,9 @@
                     }
                 },
                 "tags": "",
-                "uuid": "bb361160-3ee3-4f03-99a3-7870baee168e"
+                "uuid": "3d450f15-858f-4cc6-a5d6-3a38bde7c8d2"
             },
-            "tool_id": null,
+            "tool_id": 8,
             "type": "subworkflow",
             "uuid": "c4d87b28-5da7-48cb-aa49-cab59a0cb19b",
             "workflow_outputs": [
@@ -1141,7 +1141,7 @@
         },
         "11": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.7+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy0",
             "errors": null,
             "id": 11,
             "input_connections": {
@@ -1176,15 +1176,15 @@
                     "output_name": "outFileName"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.7+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "7dd841a32245",
+                "changeset_revision": "14e7c35f3d00",
                 "name": "pygenometracks",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"global_args\": {\"title\": \"\", \"fontsize\": \"12\", \"dpi\": \"72\", \"width\": \"40.0\", \"plotWidth\": null, \"height\": null, \"trackLabelFraction\": \"0.05\", \"trackLabelHAlign\": \"left\", \"decreasingXAxis\": \"false\"}, \"image_file_format\": \"png\", \"region\": {\"__class__\": \"ConnectedValue\"}, \"tracks\": [{\"__index__\": 0, \"track_file_style_conditional\": {\"track_file_style_selector\": \"hic_matrix_option\", \"__current_case__\": 0, \"title\": \"\", \"matrix_h5_cooler_multiple\": {\"__class__\": \"ConnectedValue\"}, \"colormap\": \"RdYlBu_r\", \"min_value\": null, \"max_value\": null, \"depth\": \"8000000\", \"transform\": \"no\", \"height_matrix\": null, \"show_masked_bins\": \"false\", \"boundaries_file\": {\"__class__\": \"RuntimeValue\"}, \"scale_factor\": \"1.0\", \"rasterize\": \"true\", \"invert_orientation\": \"false\", \"spacer_height\": null}}, {\"__index__\": 1, \"track_file_style_conditional\": {\"track_file_style_selector\": \"xaxis_option\", \"__current_case__\": 13, \"title\": \"\", \"fontsize\": null, \"xaxis_where\": \"bottom\", \"spacer_height\": null}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "3.7+galaxy0",
+            "tool_version": "3.8+galaxy0",
             "type": "tool",
             "uuid": "d8b80397-70dc-4522-8a12-948b1107ac8d",
             "workflow_outputs": [

--- a/workflows/epigenetics/hic-hicup-cooler/hic_fastq_to_cool_hicup_cooler.ga
+++ b/workflows/epigenetics/hic-hicup-cooler/hic_fastq_to_cool_hicup_cooler.ga
@@ -10,7 +10,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.4",
+    "release": "0.5",
     "name": "Hi-C_fastqToCool_hicup_cooler",
     "steps": {
         "0": {
@@ -712,7 +712,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "fb4ae0eb-3f8b-4a5c-9d50-3234dd9df3d2"
+                "uuid": "e1953d09-91ff-4afe-91fc-3f301acc26d5"
             },
             "tool_id": null,
             "type": "subworkflow",
@@ -1152,7 +1152,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "ea1a61d4-def1-4cdb-b29c-77e77ebacb7a"
+                "uuid": "3b4cd11c-7937-4679-bb3c-9b067ad8f567"
             },
             "tool_id": null,
             "type": "subworkflow",
@@ -1173,7 +1173,7 @@
         },
         "11": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy2",
             "errors": null,
             "id": 11,
             "input_connections": {
@@ -1208,15 +1208,15 @@
                     "output_name": "outFileName"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy2",
             "tool_shed_repository": {
-                "changeset_revision": "360df4999907",
+                "changeset_revision": "59fd173ac850",
                 "name": "pygenometracks",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"global_args\": {\"title\": \"\", \"fontsize\": \"12\", \"dpi\": \"72\", \"width\": \"40.0\", \"plotWidth\": null, \"height\": null, \"trackLabelFraction\": \"0.05\", \"trackLabelHAlign\": \"left\", \"decreasingXAxis\": false}, \"image_file_format\": \"png\", \"region\": {\"__class__\": \"ConnectedValue\"}, \"tracks\": [{\"__index__\": 0, \"track_file_style_conditional\": {\"track_file_style_selector\": \"hic_matrix_option\", \"__current_case__\": 0, \"title\": \"\", \"matrix_h5_cooler_multiple\": {\"__class__\": \"ConnectedValue\"}, \"colormap\": \"RdYlBu_r\", \"min_value\": null, \"max_value\": null, \"depth\": \"8000000\", \"transform\": \"no\", \"height_matrix\": null, \"show_masked_bins\": false, \"boundaries_file\": {\"__class__\": \"RuntimeValue\"}, \"scale_factor\": \"1.0\", \"rasterize\": true, \"invert_orientation\": false, \"spacer_height\": null}}, {\"__index__\": 1, \"track_file_style_conditional\": {\"track_file_style_selector\": \"xaxis_option\", \"__current_case__\": 13, \"title\": \"\", \"fontsize\": null, \"xaxis_where\": \"bottom\", \"spacer_height\": null}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "3.8+galaxy1",
+            "tool_version": "3.8+galaxy2",
             "type": "tool",
             "uuid": "d8b80397-70dc-4522-8a12-948b1107ac8d",
             "when": null,

--- a/workflows/epigenetics/hic-hicup-cooler/hic_fastq_to_cool_hicup_cooler.ga
+++ b/workflows/epigenetics/hic-hicup-cooler/hic_fastq_to_cool_hicup_cooler.ga
@@ -1,6 +1,6 @@
 {
     "a_galaxy_workflow": "true",
-    "annotation": "This workflow take as input a collection of paired fastq. It uses HiCUP to go from fastq to validPair file. The pairs are filtered for MAPQ and sorted by cooler to generate a tabix dataset. Cooler is used to generate a balanced cool file to the desired resolution.",
+    "annotation": "This workflow takes as input a collection of paired fastq. It uses HiCUP to go from fastq to validPair file using the middle of the fragment as coordinates. The pairs are filtered for MAPQ and sorted by cooler to generate a tabix dataset. Cooler is used to generate a balanced cool file to the desired resolution.",
     "creator": [
         {
             "class": "Person",
@@ -10,7 +10,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.5",
+    "release": "0.2",
     "name": "Hi-C_fastqToCool_hicup_cooler",
     "steps": {
         "0": {
@@ -333,13 +333,7 @@
                         "type": "parameter_input",
                         "uuid": "45194ed6-a1e9-4248-8d3a-f51febc36d61",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "fa980d4e-cee2-45ac-b96f-9cf6241a93ff"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "2": {
                         "annotation": "Restriction enzyme used e.g. A^GATCT,BglII. Some Hi-C protocols may use several enzymes. To specify several enzymes, use the ':' to separate them e.g. A^GATCT,BglII:A^AGCTT,HindIII:^GATC,DpnII. HiCUP accomodates N in restriction enzyme: e.g. :A^ANCTT",
@@ -366,13 +360,7 @@
                         "type": "parameter_input",
                         "uuid": "ec011ceb-c601-464f-8661-ca9c0b335bb5",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "911cf010-68c0-494e-b601-01e96790a19d"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "3": {
                         "annotation": "Hi-C protocol did NOT include a fill-in of sticky ends prior to re-ligation and therefore reads shall be truncated at the restriction site sequence",
@@ -399,13 +387,7 @@
                         "type": "parameter_input",
                         "uuid": "c807fdbf-1c1d-45b4-851e-47fb919b07d6",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "0455a6e0-b240-4ae6-9f57-08463ec33d7c"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "4": {
                         "annotation": "can be set to 0 for no filtering",
@@ -432,13 +414,7 @@
                         "type": "parameter_input",
                         "uuid": "748c8800-5bef-41b7-b2cf-6d6a57c0eb70",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "9d330032-0bb5-4378-841a-854c63ea492f"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "5": {
                         "annotation": "",
@@ -607,6 +583,10 @@
                         "errors": null,
                         "id": 7,
                         "input_connections": {
+                            "digester|digester_file": {
+                                "id": 5,
+                                "output_name": "digester_file"
+                            },
                             "input_file": {
                                 "id": 5,
                                 "output_name": "dataset_hicup"
@@ -616,6 +596,10 @@
                             {
                                 "description": "runtime parameter for tool Hicup to juicer converter",
                                 "name": "digester"
+                            },
+                            {
+                                "description": "runtime parameter for tool Hicup to juicer converter",
+                                "name": "input_file"
                             }
                         ],
                         "label": "valid pairs in juicebox format",
@@ -646,7 +630,7 @@
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"digester\": {\"provide_digester\": \"yes\", \"__current_case__\": 0, \"digester_file\": {\"__class__\": \"RuntimeValue\"}, \"usemid\": false}, \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_state": "{\"digester\": {\"provide_digester\": \"yes\", \"__current_case__\": 0, \"digester_file\": {\"__class__\": \"RuntimeValue\"}, \"usemid\": true}, \"input_file\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
                         "tool_version": "0.9.2+galaxy0",
                         "type": "tool",
                         "uuid": "659811cd-a212-4949-9693-074f6161ed11",
@@ -712,7 +696,7 @@
                     }
                 },
                 "tags": "",
-                "uuid": "e1953d09-91ff-4afe-91fc-3f301acc26d5"
+                "uuid": "48f579ea-eaac-49ee-b38f-93c82f8b7d76"
             },
             "tool_id": null,
             "type": "subworkflow",
@@ -725,11 +709,6 @@
                     "uuid": "4dffbfdd-cd23-435c-8fac-0cf7d202d8a1"
                 },
                 {
-                    "label": "HiCUP report (html)",
-                    "output_name": "HiCUP report (HTML)",
-                    "uuid": "ea4b99e0-c0f4-491a-8992-62d177b60c23"
-                },
-                {
                     "label": "HiCUP report (txt)",
                     "output_name": "HiCUP report (tabular)",
                     "uuid": "38b61150-fc80-43e3-86c2-027562e128da"
@@ -738,6 +717,11 @@
                     "label": "valid pairs in juicebox format MAPQ filtered",
                     "output_name": "valid pairs in juicebox format MAPQ filtered",
                     "uuid": "c82b20be-667c-4085-9619-dba3b551adf3"
+                },
+                {
+                    "label": "HiCUP report (html)",
+                    "output_name": "HiCUP report (HTML)",
+                    "uuid": "ea4b99e0-c0f4-491a-8992-62d177b60c23"
                 }
             ]
         },
@@ -1160,14 +1144,14 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "matrix with iced values",
-                    "output_name": "matrix with iced values",
-                    "uuid": "b7485ffe-ffcd-4e03-b8ad-7e0d02b05c17"
-                },
-                {
                     "label": "matrix with raw values",
                     "output_name": "matrix with raw values",
                     "uuid": "140f460e-a1b0-4868-ac7e-5605c78e18a9"
+                },
+                {
+                    "label": "matrix with iced values",
+                    "output_name": "matrix with iced values",
+                    "uuid": "b7485ffe-ffcd-4e03-b8ad-7e0d02b05c17"
                 }
             ]
         },
@@ -1232,6 +1216,6 @@
     "tags": [
         "Hi-C"
     ],
-    "uuid": "18e73437-7fc5-4dd3-90f6-7ab40261bebc",
-    "version": 2
+    "uuid": "2196fbff-317e-437d-a022-696a1f95a850",
+    "version": 4
 }

--- a/workflows/epigenetics/hic-hicup-cooler/hic_fastq_to_pairs_hicup-tests.yml
+++ b/workflows/epigenetics/hic-hicup-cooler/hic_fastq_to_pairs_hicup-tests.yml
@@ -39,18 +39,18 @@
         test_dataset:
           asserts:
             - that: "has_line"
-              line: "1	1	chr10	100016423	0	1	chr10	101499220	1	42	42"
+              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
             - that: "has_line"
-              line: "2	1	chr10	100088974	0	1	chr10	122241330	1	38	42"
+              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
             - that: "has_line"
-              line: "3	0	chr10	100130383	0	1	chr10	50863577	1	0	42"
+              line: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
     valid pairs in juicebox format MAPQ filtered:
       element_tests:
         test_dataset:
           asserts:
             - that: "has_line"
-              line: "1	1	chr10	100016423	0	1	chr10	101499220	1	42	42"
+              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
             - that: "has_line"
-              line: "2	1	chr10	100088974	0	1	chr10	122241330	1	38	42"
+              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
             - that: "not_has_text"
-              text: "3	0	chr10	100130383	0	1	chr10	50863577	1	0	42"
+              text: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"

--- a/workflows/epigenetics/hic-hicup-cooler/hic_fastq_to_pairs_hicup.ga
+++ b/workflows/epigenetics/hic-hicup-cooler/hic_fastq_to_pairs_hicup.ga
@@ -1,6 +1,6 @@
 {
     "a_galaxy_workflow": "true",
-    "annotation": "This workflow take as input a collection of paired fastq. It uses HiCUP to go from fastq to validPair file. First truncate the fastq using the cutting sequence to guess the fill-in. Then map the truncated fastq. Then asign to fragment and filter the self-ligated and dandling ends or internal (it can also filter for the size). Then it removes the duplicates. Convert the output to be compatible with juicebox or cooler. Finally filter for mapping quality",
+    "annotation": "This workflow takes as input a collection of paired fastq. It uses HiCUP to go from fastq to validPair file. First truncate the fastq using the cutting sequence to guess the fill-in. Then map the truncated fastq. Then asign to fragment and filter the self-ligated and dandling ends or internal (it can also filter for the size). Then it removes the duplicates. Convert the output to be compatible with juicebox or cooler using the middle of the fragment as coordinates. Finally filter for mapping quality",
     "creator": [
         {
             "class": "Person",
@@ -10,7 +10,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.1",
+    "release": "0.2",
     "name": "Hi-C_fastqToPairs_hicup",
     "steps": {
         "0": {
@@ -29,20 +29,15 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "bottom": 282.8000030517578,
-                "height": 61.80000305175781,
-                "left": 498.5,
-                "right": 698.5,
-                "top": 221,
-                "width": 200,
-                "x": 498.5,
-                "y": 221
+                "left": 0,
+                "top": 12.5
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"collection_type\": \"list:paired\"}",
+            "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list:paired\"}",
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "30fe3d0f-541a-478a-b57d-a43c0c16ccad",
+            "when": null,
             "workflow_outputs": []
         },
         "1": {
@@ -61,20 +56,15 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 352.8000030517578,
-                "height": 61.80000305175781,
-                "left": 537.5,
-                "right": 737.5,
-                "top": 291,
-                "width": 200,
-                "x": 537.5,
-                "y": 291
+                "left": 39,
+                "top": 82.5
             },
             "tool_id": null,
             "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "45194ed6-a1e9-4248-8d3a-f51febc36d61",
+            "when": null,
             "workflow_outputs": []
         },
         "2": {
@@ -93,20 +83,15 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 446.1999969482422,
-                "height": 82.19999694824219,
-                "left": 556.5,
-                "right": 756.5,
-                "top": 364,
-                "width": 200,
-                "x": 556.5,
-                "y": 364
+                "left": 58,
+                "top": 155.5
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "ec011ceb-c601-464f-8661-ca9c0b335bb5",
+            "when": null,
             "workflow_outputs": []
         },
         "3": {
@@ -125,20 +110,15 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 518.8000030517578,
-                "height": 61.80000305175781,
-                "left": 596,
-                "right": 796,
-                "top": 457,
-                "width": 200,
-                "x": 596,
-                "y": 457
+                "left": 97.5,
+                "top": 248.5
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"boolean\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "c807fdbf-1c1d-45b4-851e-47fb919b07d6",
+            "when": null,
             "workflow_outputs": []
         },
         "4": {
@@ -157,25 +137,20 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 590.8000030517578,
-                "height": 61.80000305175781,
-                "left": 629.5,
-                "right": 829.5,
-                "top": 529,
-                "width": 200,
-                "x": 629.5,
-                "y": 529
+                "left": 131,
+                "top": 320.5
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "748c8800-5bef-41b7-b2cf-6d6a57c0eb70",
+            "when": null,
             "workflow_outputs": []
         },
         "5": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.8.3+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.9.2+galaxy0",
             "errors": null,
             "id": 5,
             "input_connections": {
@@ -226,14 +201,8 @@
                 }
             ],
             "position": {
-                "bottom": 646.8999938964844,
-                "height": 438.3999938964844,
-                "left": 855,
-                "right": 1055,
-                "top": 208.5,
-                "width": 200,
-                "x": 855,
-                "y": 208.5
+                "left": 356.5,
+                "top": 0
             },
             "post_job_actions": {
                 "HideDatasetActiondataset_hicup": {
@@ -266,27 +235,28 @@
                     "output_name": "hicup_results"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.8.3+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup_hicup/hicup_hicup/0.9.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "852e1fac4802",
+                "changeset_revision": "68fb19094f84",
                 "name": "hicup_hicup",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"advanced_options\": {\"re2\": \"\", \"longest\": \"\", \"shortest\": \"\", \"nofill\": {\"__class__\": \"ConnectedValue\"}}, \"genome\": {\"__class__\": \"ConnectedValue\"}, \"library\": {\"type\": \"paired_collection\", \"__current_case__\": 1, \"input_1\": {\"__class__\": \"ConnectedValue\"}}, \"re1\": {\"__class__\": \"ConnectedValue\"}, \"reference_genome\": {\"source\": \"indexed\", \"__current_case__\": 0, \"index\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.8.3+galaxy0",
+            "tool_version": "0.9.2+galaxy0",
             "type": "tool",
             "uuid": "8aba6fbb-d940-4826-911b-8c148e82085c",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "HiCUP report (tabular)",
                     "output_name": "hicup_report",
-                    "uuid": "a9ecf264-a71a-42cb-bd6b-a7fb2d09bb77"
+                    "uuid": "fd8f1b17-c68e-4652-b139-acccf51baa30"
                 },
                 {
                     "label": "HiCUP report (HTML)",
                     "output_name": "hicup_results",
-                    "uuid": "8fdd1a80-66a1-491e-8ffe-e17adb61fd28"
+                    "uuid": "ba37bb7a-ad3a-487b-b7ba-0023f1c496fd"
                 }
             ]
         },
@@ -315,14 +285,8 @@
                 }
             ],
             "position": {
-                "bottom": 826.6000061035156,
-                "height": 225.60000610351562,
-                "left": 1245,
-                "right": 1445,
-                "top": 601,
-                "width": 200,
-                "x": 1245,
-                "y": 601
+                "left": 746.5,
+                "top": 392.5
             },
             "post_job_actions": {
                 "HideDatasetActionout1": {
@@ -342,20 +306,34 @@
             "tool_version": "0.1.1",
             "type": "tool",
             "uuid": "ee70cd21-6a36-4e21-97d2-ff0749236523",
+            "when": null,
             "workflow_outputs": []
         },
         "7": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup2juicer/hicup2juicer/0.8.3+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup2juicer/hicup2juicer/0.9.2+galaxy0",
             "errors": null,
             "id": 7,
             "input_connections": {
+                "digester|digester_file": {
+                    "id": 5,
+                    "output_name": "digester_file"
+                },
                 "input_file": {
                     "id": 5,
                     "output_name": "dataset_hicup"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Hicup to juicer converter",
+                    "name": "digester"
+                },
+                {
+                    "description": "runtime parameter for tool Hicup to juicer converter",
+                    "name": "input_file"
+                }
+            ],
             "label": "valid pairs in juicebox format",
             "name": "Hicup to juicer converter",
             "outputs": [
@@ -365,14 +343,8 @@
                 }
             ],
             "position": {
-                "bottom": 540,
-                "height": 134,
-                "left": 1136,
-                "right": 1336,
-                "top": 406,
-                "width": 200,
-                "x": 1136,
-                "y": 406
+                "left": 637.5,
+                "top": 197.5
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -383,22 +355,23 @@
                     "output_name": "output"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup2juicer/hicup2juicer/0.8.3+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/hicup2juicer/hicup2juicer/0.9.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "f8cb84c49623",
+                "changeset_revision": "b4e7244246e2",
                 "name": "hicup2juicer",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.8.3+galaxy0",
+            "tool_state": "{\"digester\": {\"provide_digester\": \"yes\", \"__current_case__\": 0, \"digester_file\": {\"__class__\": \"RuntimeValue\"}, \"usemid\": true}, \"input_file\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.9.2+galaxy0",
             "type": "tool",
             "uuid": "659811cd-a212-4949-9693-074f6161ed11",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "valid pairs in juicebox format",
                     "output_name": "output",
-                    "uuid": "0ad74732-4117-4620-8ae6-e6b25c323b88"
+                    "uuid": "dfc67c68-2569-4727-9ca6-a70f3b13edd9"
                 }
             ]
         },
@@ -427,14 +400,8 @@
                 }
             ],
             "position": {
-                "bottom": 677.3999938964844,
-                "height": 164.39999389648438,
-                "left": 1539.5,
-                "right": 1739.5,
-                "top": 513,
-                "width": 200,
-                "x": 1539.5,
-                "y": 513
+                "left": 1041,
+                "top": 304.5
             },
             "post_job_actions": {
                 "RenameDatasetActionout_file1": {
@@ -450,11 +417,12 @@
             "tool_version": "1.1.1",
             "type": "tool",
             "uuid": "fe9a084d-06ad-4671-a4d6-85dff2f96138",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "valid pairs in juicebox format MAPQ filtered",
                     "output_name": "out_file1",
-                    "uuid": "679e3356-4f54-4ccf-aa99-f4d93be262bd"
+                    "uuid": "b08373c7-59b2-4ae3-90b7-7c9a05ca81b7"
                 }
             ]
         }
@@ -462,6 +430,6 @@
     "tags": [
         "Hi-C"
     ],
-    "uuid": "ee2e9b80-3ba9-4aca-877c-fec794b87bc5",
-    "version": 18
+    "uuid": "48f579ea-eaac-49ee-b38f-93c82f8b7d76",
+    "version": 2
 }

--- a/workflows/epigenetics/hic-hicup-cooler/hic_juicermediumtabix_to_cool_cooler.ga
+++ b/workflows/epigenetics/hic-hicup-cooler/hic_juicermediumtabix_to_cool_cooler.ga
@@ -10,7 +10,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.1",
+    "release": "0.2",
     "name": "Hi-C_juicermediumtabixToCool_cooler",
     "steps": {
         "0": {
@@ -37,6 +37,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "d0a82863-82f8-426c-addb-06066e9d0a73",
+            "when": null,
             "workflow_outputs": []
         },
         "1": {
@@ -63,6 +64,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "48506f80-b1b5-4d1d-98a6-c6882de026f1",
+            "when": null,
             "workflow_outputs": []
         },
         "2": {
@@ -89,6 +91,7 @@
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "588962a4-8ce4-4929-81fd-a9dfdd032598",
+            "when": null,
             "workflow_outputs": []
         },
         "3": {
@@ -115,6 +118,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "d6375500-a591-47a9-b126-950347e3e7a8",
+            "when": null,
             "workflow_outputs": []
         },
         "4": {
@@ -163,6 +167,7 @@
             "tool_version": "0.8.11+galaxy0",
             "type": "tool",
             "uuid": "34e0a213-93e8-466e-b07b-ede1443ee7d6",
+            "when": null,
             "workflow_outputs": []
         },
         "5": {
@@ -217,6 +222,7 @@
             "tool_version": "0.8.11+galaxy1",
             "type": "tool",
             "uuid": "d411eea7-7996-44f2-af2a-feecb854a067",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "matrix with raw values",
@@ -278,6 +284,7 @@
             "tool_version": "0.8.11+galaxy0",
             "type": "tool",
             "uuid": "44270887-1c96-4ede-8bb9-3db2a07eeb6e",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "matrix with iced values",
@@ -290,6 +297,6 @@
     "tags": [
         "Hi-C"
     ],
-    "uuid": "bb361160-3ee3-4f03-99a3-7870baee168e",
-    "version": 3
+    "uuid": "e6220100-1dde-4701-ac54-db0d1e0dec0f",
+    "version": 2
 }


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/epigenetics/hic-hicup-cooler**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.7+galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy0`
* `toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.7+galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/pygenometracks/pygenomeTracks/3.8+galaxy0`

The workflow release number has been updated from 0.1 to 0.2.
