### PR TITLE
Updating workflows/virology/pox-virus-amplicon from 0.1 to 0.2

### DIFF
--- a/workflows/virology/pox-virus-amplicon/CHANGELOG.md
+++ b/workflows/virology/pox-virus-amplicon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2] 2023-03-17
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/qualimap_bamqc/qualimap_bamqc/2.2.2d+galaxy3` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/qualimap_bamqc/qualimap_bamqc/2.2.2c+galaxy1`
+- `toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy6` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.2+galaxy0`
+
 ## [0.1]
 
 Initial version of Pox Virus Illumina Amplicon workflow (iVar based) for half-genomes sequencing data

--- a/workflows/virology/pox-virus-amplicon/pox-virus-half-genome.ga
+++ b/workflows/virology/pox-virus-amplicon/pox-virus-half-genome.ga
@@ -15,7 +15,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.1",
+    "release": "0.2",
     "name": "Pox Virus Illumina Amplicon Workflow from half-genomes",
     "steps": {
         "0": {
@@ -1145,7 +1145,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: maskseq51/5.0.0",
             "tool_shed_repository": {
-                "changeset_revision": "ce385837c160",
+                "changeset_revision": "63dd26468588",
                 "name": "emboss_5",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1201,7 +1201,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/emboss_5/EMBOSS: maskseq51/5.0.0",
             "tool_shed_repository": {
-                "changeset_revision": "ce385837c160",
+                "changeset_revision": "63dd26468588",
                 "name": "emboss_5",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1781,7 +1781,16 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Samtools merge",
+                    "name": "bed_file"
+                },
+                {
+                    "description": "runtime parameter for tool Samtools merge",
+                    "name": "headerbam"
+                }
+            ],
             "label": null,
             "name": "Samtools merge",
             "outputs": [
@@ -1795,7 +1804,7 @@
                 "top": 508.5
             },
             "post_job_actions": {
-                "RenameDatasetActionoutput1": {
+                "RenameDatasetActionoutput": {
                     "action_arguments": {
                         "newname": "Merged Mappings of both pools"
                     },
@@ -1810,8 +1819,8 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"bamfiles\": {\"__class__\": \"RuntimeValue\"}, \"bed_file\": {\"__class__\": \"RuntimeValue\"}, \"headerbam\": {\"__class__\": \"RuntimeValue\"}, \"idpg\": \"true\", \"idrg\": \"false\", \"region\": \"\", \"seed\": \"1\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": null,
+            "tool_state": "{\"bamfiles\": {\"__class__\": \"ConnectedValue\"}, \"bed_file\": {\"__class__\": \"RuntimeValue\"}, \"headerbam\": {\"__class__\": \"RuntimeValue\"}, \"idpg\": \"true\", \"idrg\": \"false\", \"region\": \"\", \"seed\": \"1\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.15.1+galaxy0",
             "type": "tool",
             "uuid": "8ae30344-c06e-4951-b0e9-45cb102253aa",
             "workflow_outputs": [
@@ -1892,7 +1901,7 @@
         },
         "40": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy6",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.2+galaxy0",
             "errors": null,
             "id": 40,
             "input_connections": {
@@ -1927,15 +1936,15 @@
                     "output_name": "output_bam"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy6",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "f0cc9cf99407",
+                "changeset_revision": "bcaa0d571ce2",
                 "name": "ivar_trim",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"amplicons\": {\"filter_by\": \"yes_compute\", \"__current_case__\": 0}, \"inc_primers\": \"true\", \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"min_len\": \"30\", \"min_qual\": \"20\", \"primer\": {\"source\": \"history\", \"__current_case__\": 0, \"input_bed\": {\"__class__\": \"ConnectedValue\"}}, \"primer_pos_wiggle\": \"0\", \"window_width\": \"4\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.3.1+galaxy6",
+            "tool_version": "1.3.2+galaxy0",
             "type": "tool",
             "uuid": "735ed414-14ed-475c-a01b-c13cc5e708d9",
             "workflow_outputs": [
@@ -2113,7 +2122,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sed_tool/1.1.1",
             "tool_shed_repository": {
-                "changeset_revision": "ddf54b12c295",
+                "changeset_revision": "d698c222f354",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/virology/pox-virus-amplicon**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/iuc/qualimap_bamqc/qualimap_bamqc/2.2.2d+galaxy3` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/qualimap_bamqc/qualimap_bamqc/2.2.2c+galaxy1`
* `toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.1+galaxy6` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/ivar_trim/ivar_trim/1.3.2+galaxy0`

The workflow release number has been updated from 0.1 to 0.2.
