### PR TITLE
Updating workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting from 0.3 to 0.4

### DIFF
--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/CHANGELOG.md
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4] 2023-04-17
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0`
+
 ## [0.3] 2022-10-13
 
 ### Changed

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.ga
@@ -11,77 +11,13 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: variation analysis reporting",
-    "release": "0.3",
+    "release": "0.4",
     "steps": {
         "0": {
-            "annotation": "Allele Frequency Filter. This is the minimum allele frequency required for variants to be included in the reports.",
-            "content_id": null,
-            "errors": null,
-            "id": 0,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "Allele Frequency Filter. This is the minimum allele frequency required for variants to be included in the reports.",
-                    "name": "AF Filter"
-                }
-            ],
-            "label": "AF Filter",
-            "name": "Input parameter",
-            "outputs": [],
-            "position": {
-                "left": -421.578125,
-                "top": 368.4583333333333
-            },
-            "tool_id": null,
-            "tool_state": "{\"default\": 0.05, \"parameter_type\": \"float\", \"optional\": true}",
-            "tool_version": null,
-            "type": "parameter_input",
-            "uuid": "2e5a5b38-c204-45a2-98e2-e113bce5a14b",
-            "workflow_outputs": [
-                {
-                    "label": "af_filter_threshold",
-                    "output_name": "output",
-                    "uuid": "e55d47c5-7ea0-45c4-8844-47bf29b88542"
-                }
-            ]
-        },
-        "1": {
-            "annotation": "Depth Filter. This is the minimum depth of all alignments at a variant site. ",
-            "content_id": null,
-            "errors": null,
-            "id": 1,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "Depth Filter. This is the minimum depth of all alignments at a variant site. ",
-                    "name": "DP Filter"
-                }
-            ],
-            "label": "DP Filter",
-            "name": "Input parameter",
-            "outputs": [],
-            "position": {
-                "left": -426.109375,
-                "top": 466.4739583333333
-            },
-            "tool_id": null,
-            "tool_state": "{\"default\": 1, \"parameter_type\": \"integer\", \"optional\": true}",
-            "tool_version": null,
-            "type": "parameter_input",
-            "uuid": "c7fc64c7-51c7-465b-9184-ca834d4cf6b2",
-            "workflow_outputs": [
-                {
-                    "label": "dp_filter_threshold",
-                    "output_name": "output",
-                    "uuid": "220a9662-8b6f-4161-8539-ecb613b4892a"
-                }
-            ]
-        },
-        "2": {
             "annotation": "Variation data in VCF format. Can be the output of any of the workflows in https://github.com/galaxyproject/iwc/tree/main/workflows/sars-cov-2-variant-calling",
             "content_id": null,
             "errors": null,
-            "id": 2,
+            "id": 0,
             "input_connections": {},
             "inputs": [
                 {
@@ -93,15 +29,82 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "left": -416.609375,
-                "top": 215.63020833333334
+                "left": 10.28125,
+                "top": 34.08333333333334
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"format\": [\"vcf\", \"vcf_bgzip\"], \"collection_type\": \"list\"}",
+            "tool_state": "{\"optional\": false, \"format\": [\"vcf\", \"vcf_bgzip\"], \"tag\": null, \"collection_type\": \"list\"}",
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "577438f0-38b1-4fc1-9145-935566d62347",
+            "when": null,
             "workflow_outputs": []
+        },
+        "1": {
+            "annotation": "Allele Frequency Filter. This is the minimum allele frequency required for variants to be included in the reports.",
+            "content_id": null,
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Allele Frequency Filter. This is the minimum allele frequency required for variants to be included in the reports.",
+                    "name": "AF Filter"
+                }
+            ],
+            "label": "AF Filter",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 5.3125,
+                "top": 186.91145833333331
+            },
+            "tool_id": null,
+            "tool_state": "{\"default\": 0.05, \"parameter_type\": \"float\", \"optional\": true}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "2e5a5b38-c204-45a2-98e2-e113bce5a14b",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "af_filter_threshold",
+                    "output_name": "output",
+                    "uuid": "e55d47c5-7ea0-45c4-8844-47bf29b88542"
+                }
+            ]
+        },
+        "2": {
+            "annotation": "Depth Filter. This is the minimum depth of all alignments at a variant site. ",
+            "content_id": null,
+            "errors": null,
+            "id": 2,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Depth Filter. This is the minimum depth of all alignments at a variant site. ",
+                    "name": "DP Filter"
+                }
+            ],
+            "label": "DP Filter",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 0.78125,
+                "top": 284.9270833333333
+            },
+            "tool_id": null,
+            "tool_state": "{\"default\": 1, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "c7fc64c7-51c7-465b-9184-ca834d4cf6b2",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "dp_filter_threshold",
+                    "output_name": "output",
+                    "uuid": "220a9662-8b6f-4161-8539-ecb613b4892a"
+                }
+            ]
         },
         "3": {
             "annotation": "Depth Filter for variant allele. This is the minimum depth of alignments supporting a variant.",
@@ -119,14 +122,15 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": -426.890625,
-                "top": 548.9739583333334
+                "left": 0.0,
+                "top": 367.42708333333337
             },
             "tool_id": null,
             "tool_state": "{\"default\": 10, \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "145bbc55-8893-413d-9620-f3d85e65527a",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "dp_alt_filter_threshold",
@@ -151,14 +155,15 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 263.125,
-                "top": 219.95833333333334
+                "left": 690.015625,
+                "top": 38.41145833333334
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"format\": [\"tabular\"]}",
+            "tool_state": "{\"optional\": false, \"format\": [\"tabular\"], \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "8b89e674-9012-4f66-a59a-ce05d2fe4223",
+            "when": null,
             "workflow_outputs": []
         },
         "5": {
@@ -177,14 +182,15 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 2986.6875,
-                "top": 853.4583333333334
+                "left": 3413.578125,
+                "top": 671.9114583333334
             },
             "tool_id": null,
             "tool_state": "{\"default\": 1, \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "5ca7b1a7-e1ee-4b52-aab4-eaf23949e1da",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "plot_number_of_clusters",
@@ -200,7 +206,7 @@
             "id": 6,
             "input_connections": {
                 "input": {
-                    "id": 2,
+                    "id": 0,
                     "output_name": "output"
                 }
             },
@@ -214,8 +220,8 @@
                 }
             ],
             "position": {
-                "left": -180.234375,
-                "top": 213.63020833333334
+                "left": 246.65625,
+                "top": 32.08333333333334
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpsift/snpSift_filter/4.3+t.galaxy1",
@@ -225,10 +231,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filter_expression\": {\"type\": \"simple\", \"__current_case__\": 0, \"expr\": \"DP >= 1\"}, \"filtering\": {\"mode\": \"entries\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"inverse\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"filter_expression\": {\"type\": \"simple\", \"__current_case__\": 0, \"expr\": \"DP >= 1\"}, \"filtering\": {\"mode\": \"entries\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"inverse\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "4.3+t.galaxy1",
             "type": "tool",
             "uuid": "386eb313-89c1-47df-bd3d-976780eff740",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "prefiltered_variants",
@@ -244,11 +251,11 @@
             "id": 7,
             "input_connections": {
                 "components_1|param_type|component_value": {
-                    "id": 0,
+                    "id": 1,
                     "output_name": "output"
                 },
                 "components_3|param_type|component_value": {
-                    "id": 1,
+                    "id": 2,
                     "output_name": "output"
                 },
                 "components_5|param_type|component_value": {
@@ -266,8 +273,8 @@
                 }
             ],
             "position": {
-                "left": -181.890625,
-                "top": 337.9114583333333
+                "left": 245.0,
+                "top": 156.36458333333331
             },
             "post_job_actions": {
                 "HideDatasetActionout1": {
@@ -287,6 +294,7 @@
             "tool_version": "0.1.1",
             "type": "tool",
             "uuid": "ec1a4872-b9bc-41f0-8675-1f26fdd19f16",
+            "when": null,
             "workflow_outputs": []
         },
         "8": {
@@ -296,11 +304,11 @@
             "id": 8,
             "input_connections": {
                 "components_1|param_type|component_value": {
-                    "id": 0,
+                    "id": 1,
                     "output_name": "output"
                 },
                 "components_3|param_type|component_value": {
-                    "id": 1,
+                    "id": 2,
                     "output_name": "output"
                 },
                 "components_5|param_type|component_value": {
@@ -318,8 +326,8 @@
                 }
             ],
             "position": {
-                "left": -185.171875,
-                "top": 645.3802083333334
+                "left": 241.71875,
+                "top": 463.83333333333337
             },
             "post_job_actions": {
                 "HideDatasetActionout1": {
@@ -339,6 +347,7 @@
             "tool_version": "0.1.1",
             "type": "tool",
             "uuid": "c9916563-c914-4f5f-90c6-d6c7619e1a98",
+            "when": null,
             "workflow_outputs": []
         },
         "9": {
@@ -370,8 +379,8 @@
                 }
             ],
             "position": {
-                "left": 50.53125,
-                "top": 503.6145833333333
+                "left": 477.421875,
+                "top": 322.0677083333333
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -389,10 +398,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filter_expression\": {\"type\": \"simple\", \"__current_case__\": 0, \"expr\": {\"__class__\": \"ConnectedValue\"}}, \"filtering\": {\"mode\": \"add_filter\", \"__current_case__\": 3, \"add_filter\": {\"__class__\": \"ConnectedValue\"}}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"inverse\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"filter_expression\": {\"type\": \"simple\", \"__current_case__\": 0, \"expr\": {\"__class__\": \"ConnectedValue\"}}, \"filtering\": {\"mode\": \"add_filter\", \"__current_case__\": 3, \"add_filter\": {\"__class__\": \"ConnectedValue\"}}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"inverse\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "4.3+t.galaxy1",
             "type": "tool",
             "uuid": "9a6cb40d-476b-4096-adcc-cb601398d0b4",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "filtered_variants",
@@ -422,8 +432,8 @@
                 }
             ],
             "position": {
-                "left": 286.546875,
-                "top": 400.5989583333333
+                "left": 713.4375,
+                "top": 219.05208333333331
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -441,10 +451,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"empty_text\": \".\", \"extract\": \"CHROM POS FILTER REF ALT DP AF DP4 SB EFF[*].IMPACT EFF[*].FUNCLASS EFF[*].EFFECT EFF[*].GENE EFF[*].CODON EFF[*].AA EFF[*].TRID DP4[2] DP4[3]\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"one_effect_per_line\": \"true\", \"separator\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"empty_text\": \".\", \"extract\": \"CHROM POS FILTER REF ALT DP AF DP4 SB EFF[*].IMPACT EFF[*].FUNCLASS EFF[*].EFFECT EFF[*].GENE EFF[*].CODON EFF[*].AA EFF[*].TRID DP4[2] DP4[3]\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"one_effect_per_line\": true, \"separator\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "4.3+t.galaxy0",
             "type": "tool",
             "uuid": "085e8f20-3eea-4d97-8e52-6e8a9aa3fbd7",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "filtered_extracted_variants",
@@ -478,8 +489,8 @@
                 }
             ],
             "position": {
-                "left": 517.421875,
-                "top": 264.5833333333333
+                "left": 944.3125,
+                "top": 83.03645833333331
             },
             "post_job_actions": {
                 "ChangeDatatypeActionoutfile_replace": {
@@ -508,6 +519,7 @@
             "tool_version": "0.2",
             "type": "tool",
             "uuid": "0850f6d5-ff1f-47f9-8e49-b7eb5782828a",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "filtered_and_renamed_effects",
@@ -527,12 +539,7 @@
                     "output_name": "outfile_replace"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Compute",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Compute",
             "outputs": [
@@ -542,8 +549,8 @@
                 }
             ],
             "position": {
-                "left": 737.84375,
-                "top": 421.8958333333333
+                "left": 1164.734375,
+                "top": 240.34895833333331
             },
             "post_job_actions": {
                 "RenameDatasetActionout_file1": {
@@ -561,10 +568,11 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"avoid_scientific_notation\": \"false\", \"error_handling\": {\"auto_col_types\": \"true\", \"fail_on_non_existent_columns\": \"true\", \"non_computable\": {\"action\": \"--fail-on-non-computable\", \"__current_case__\": 0}}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"ops\": {\"header_lines_select\": \"yes\", \"__current_case__\": 1, \"expressions\": [{\"__index__\": 0, \"cond\": \"c7\", \"add_column\": {\"mode\": \"I\", \"__current_case__\": 1, \"pos\": \"8\"}, \"new_column_name\": \"AFcaller\"}, {\"__index__\": 1, \"cond\": \"round((c18 + c19) / c6, 6)\", \"add_column\": {\"mode\": \"R\", \"__current_case__\": 2, \"pos\": \"7\"}, \"new_column_name\": \"AF\"}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"avoid_scientific_notation\": false, \"error_handling\": {\"auto_col_types\": true, \"fail_on_non_existent_columns\": true, \"non_computable\": {\"action\": \"--fail-on-non-computable\", \"__current_case__\": 0}}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"ops\": {\"header_lines_select\": \"yes\", \"__current_case__\": 1, \"expressions\": [{\"__index__\": 0, \"cond\": \"c7\", \"add_column\": {\"mode\": \"I\", \"__current_case__\": 1, \"pos\": \"8\"}, \"new_column_name\": \"AFcaller\"}, {\"__index__\": 1, \"cond\": \"round((c18 + c19) / c6, 6)\", \"add_column\": {\"mode\": \"R\", \"__current_case__\": 2, \"pos\": \"7\"}, \"new_column_name\": \"AF\"}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.0",
             "type": "tool",
             "uuid": "c457f29e-dea5-449a-84c4-4b192da88257",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "af_recalculated",
@@ -575,7 +583,7 @@
         },
         "13": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0",
             "errors": null,
             "id": 13,
             "input_connections": {
@@ -590,12 +598,12 @@
             "outputs": [
                 {
                     "name": "out_file",
-                    "type": "tabular"
+                    "type": "input"
                 }
             ],
             "position": {
-                "left": 904.265625,
-                "top": 202.13020833333334
+                "left": 1331.15625,
+                "top": 20.583333333333343
             },
             "post_job_actions": {
                 "RenameDatasetActionout_file": {
@@ -606,17 +614,18 @@
                     "output_name": "out_file"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "746e8e4bf929",
+                "changeset_revision": "4c07ddedc198",
                 "name": "datamash_ops",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"grouping\": \"1,2,3,4,5,6,7,8,9,10\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": \"false\", \"need_sort\": \"false\", \"operations\": [{\"__index__\": 0, \"op_name\": \"collapse\", \"op_column\": \"11\"}, {\"__index__\": 1, \"op_name\": \"collapse\", \"op_column\": \"12\"}, {\"__index__\": 2, \"op_name\": \"collapse\", \"op_column\": \"13\"}, {\"__index__\": 3, \"op_name\": \"collapse\", \"op_column\": \"14\"}, {\"__index__\": 4, \"op_name\": \"collapse\", \"op_column\": \"15\"}, {\"__index__\": 5, \"op_name\": \"collapse\", \"op_column\": \"16\"}, {\"__index__\": 6, \"op_name\": \"collapse\", \"op_column\": \"17\"}], \"print_full_line\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.1.0+galaxy2",
+            "tool_state": "{\"grouping\": \"1,2,3,4,5,6,7,8,9,10\", \"header_in\": true, \"header_out\": true, \"ignore_case\": false, \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": false, \"need_sort\": false, \"operations\": [{\"__index__\": 0, \"op_name\": \"collapse\", \"op_column\": \"11\"}, {\"__index__\": 1, \"op_name\": \"collapse\", \"op_column\": \"12\"}, {\"__index__\": 2, \"op_name\": \"collapse\", \"op_column\": \"13\"}, {\"__index__\": 3, \"op_name\": \"collapse\", \"op_column\": \"14\"}, {\"__index__\": 4, \"op_name\": \"collapse\", \"op_column\": \"15\"}, {\"__index__\": 5, \"op_name\": \"collapse\", \"op_column\": \"16\"}, {\"__index__\": 6, \"op_name\": \"collapse\", \"op_column\": \"17\"}], \"print_full_line\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.8+galaxy0",
             "type": "tool",
             "uuid": "ec8aca39-fe1f-404a-9460-7a960cec37e6",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "collapsed_effects",
@@ -646,8 +655,8 @@
                 }
             ],
             "position": {
-                "left": 1254.34375,
-                "top": 181.546875
+                "left": 1681.234375,
+                "top": 0.0
             },
             "post_job_actions": {
                 "RenameDatasetActionoutfile": {
@@ -665,10 +674,11 @@
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\s]+\", \"replace_pattern\": \"\\\\t$1\\\\t$2\\\\t$3\\\\t$4\\\\t$5\\\\t$6\\\\t$7\", \"is_regex\": \"true\", \"global\": \"true\", \"caseinsensitive\": \"false\", \"wholewords\": \"false\", \"skip_first_line\": \"true\", \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}, {\"__index__\": 1, \"find_pattern\": \"(GroupBy|collapse)\\\\(([^)]+)\\\\)\", \"replace_pattern\": \"$2\", \"is_regex\": \"true\", \"global\": \"true\", \"caseinsensitive\": \"false\", \"wholewords\": \"false\", \"skip_first_line\": \"false\", \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\t]+\\\\t([^\\\\t,]+),[^\\\\s]+\", \"replace_pattern\": \"\\\\t$1\\\\t$2\\\\t$3\\\\t$4\\\\t$5\\\\t$6\\\\t$7\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": true, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}, {\"__index__\": 1, \"find_pattern\": \"(GroupBy|collapse)\\\\(([^)]+)\\\\)\", \"replace_pattern\": \"$2\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.4",
             "type": "tool",
             "uuid": "25f665b6-2b6a-49a3-a395-29706cd772ab",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "highest_impact_effects",
@@ -698,8 +708,8 @@
                 }
             ],
             "position": {
-                "left": 1555.609375,
-                "top": 209.61458333333334
+                "left": 1982.5,
+                "top": 28.067708333333343
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -715,10 +725,11 @@
                 "owner": "nml",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filename\": {\"add_name\": \"true\", \"__current_case__\": 0, \"place_name\": \"same_multiple\"}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"filename\": {\"add_name\": true, \"__current_case__\": 0, \"place_name\": \"same_multiple\"}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": true, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "5.1.0",
             "type": "tool",
             "uuid": "e5459c74-11e1-45a5-beee-88c2dde61eab",
+            "when": null,
             "workflow_outputs": []
         },
         "16": {
@@ -742,8 +753,8 @@
                 }
             ],
             "position": {
-                "left": 1801,
-                "top": 393.9270833333333
+                "left": 2227.890625,
+                "top": 212.38020833333331
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -759,10 +770,11 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"avoid_scientific_notation\": \"false\", \"error_handling\": {\"auto_col_types\": \"false\", \"fail_on_non_existent_columns\": \"true\", \"non_computable\": {\"action\": \"--fail-on-non-computable\", \"__current_case__\": 0}}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"ops\": {\"header_lines_select\": \"yes\", \"__current_case__\": 1, \"expressions\": [{\"__index__\": 0, \"cond\": \"c5 + '>' + c6\", \"add_column\": {\"mode\": \"\", \"__current_case__\": 0, \"pos\": \"\"}, \"new_column_name\": \"change\"}, {\"__index__\": 1, \"cond\": \"c3 + ':' + c19\", \"add_column\": {\"mode\": \"\", \"__current_case__\": 0, \"pos\": \"\"}, \"new_column_name\": \"change_with_pos\"}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"avoid_scientific_notation\": false, \"error_handling\": {\"auto_col_types\": false, \"fail_on_non_existent_columns\": true, \"non_computable\": {\"action\": \"--fail-on-non-computable\", \"__current_case__\": 0}}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"ops\": {\"header_lines_select\": \"yes\", \"__current_case__\": 1, \"expressions\": [{\"__index__\": 0, \"cond\": \"c5 + '>' + c6\", \"add_column\": {\"mode\": \"\", \"__current_case__\": 0, \"pos\": \"\"}, \"new_column_name\": \"change\"}, {\"__index__\": 1, \"cond\": \"c3 + ':' + c19\", \"add_column\": {\"mode\": \"\", \"__current_case__\": 0, \"pos\": \"\"}, \"new_column_name\": \"change_with_pos\"}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.0",
             "type": "tool",
             "uuid": "cc8a768f-8078-4bdd-ae98-903f08619070",
+            "when": null,
             "workflow_outputs": []
         },
         "17": {
@@ -785,9 +797,9 @@
                     "type": "input"
                 }
             ],
-           "position": {
-                "left": 2007.171875,
-                "top": 261.7239583333333
+            "position": {
+                "left": 2434.0625,
+                "top": 80.17708333333331
             },
             "post_job_actions": {
                 "RenameDatasetActionoutfile": {
@@ -805,10 +817,11 @@
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"caseinsensitive\": \"false\", \"find_pattern\": \"EFF[*].\", \"global\": \"true\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"is_regex\": \"false\", \"replace_pattern\": \"\", \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}, \"skip_first_line\": \"false\", \"wholewords\": \"false\"}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"EFF[*].\", \"replace_pattern\": \"\", \"is_regex\": false, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.4",
             "type": "tool",
             "uuid": "82276b6c-5c6e-49eb-8ee5-46041c273d30",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "all_variants_all_samples",
@@ -819,7 +832,7 @@
         },
         "18": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0",
             "errors": null,
             "id": 18,
             "input_connections": {
@@ -828,23 +841,18 @@
                     "output_name": "outfile"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Datamash",
-                    "name": "in_file"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Datamash",
             "outputs": [
                 {
                     "name": "out_file",
-                    "type": "tabular"
+                    "type": "input"
                 }
             ],
             "position": {
-                "left": 2258.4375,
-                "top": 213.14583333333334
+                "left": 2685.328125,
+                "top": 31.598958333333343
             },
             "post_job_actions": {
                 "HideDatasetActionout_file": {
@@ -853,17 +861,18 @@
                     "output_name": "out_file"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "746e8e4bf929",
+                "changeset_revision": "4c07ddedc198",
                 "name": "datamash_ops",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"grouping\": \"20\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": \"false\", \"need_sort\": \"true\", \"operations\": [{\"__index__\": 0, \"op_name\": \"countunique\", \"op_column\": \"1\"}, {\"__index__\": 1, \"op_name\": \"min\", \"op_column\": \"8\"}, {\"__index__\": 2, \"op_name\": \"max\", \"op_column\": \"8\"}, {\"__index__\": 3, \"op_name\": \"collapse\", \"op_column\": \"1\"}, {\"__index__\": 4, \"op_name\": \"collapse\", \"op_column\": \"8\"}], \"print_full_line\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.1.0+galaxy2",
+            "tool_state": "{\"grouping\": \"20\", \"header_in\": true, \"header_out\": true, \"ignore_case\": false, \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": false, \"need_sort\": true, \"operations\": [{\"__index__\": 0, \"op_name\": \"countunique\", \"op_column\": \"1\"}, {\"__index__\": 1, \"op_name\": \"min\", \"op_column\": \"8\"}, {\"__index__\": 2, \"op_name\": \"max\", \"op_column\": \"8\"}, {\"__index__\": 3, \"op_name\": \"collapse\", \"op_column\": \"1\"}, {\"__index__\": 4, \"op_name\": \"collapse\", \"op_column\": \"8\"}], \"print_full_line\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.8+galaxy0",
             "type": "tool",
             "uuid": "c40528c9-4fed-48c8-9c34-be2cf2c32745",
+            "when": null,
             "workflow_outputs": []
         },
         "19": {
@@ -887,8 +896,8 @@
                 }
             ],
             "position": {
-                "left": 2251.234375,
-                "top": 426.2864583333333
+                "left": 2678.125,
+                "top": 244.73958333333331
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -902,11 +911,12 @@
             "tool_version": "1.1.1",
             "type": "tool",
             "uuid": "c02e3958-04f4-499e-b78e-f304e0fdaeed",
+            "when": null,
             "workflow_outputs": []
         },
         "20": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0",
             "errors": null,
             "id": 20,
             "input_connections": {
@@ -921,12 +931,12 @@
             "outputs": [
                 {
                     "name": "out_file",
-                    "type": "tabular"
+                    "type": "input"
                 }
             ],
             "position": {
-                "left": 2542.140625,
-                "top": 623.2083333333334
+                "left": 2969.03125,
+                "top": 441.66145833333337
             },
             "post_job_actions": {
                 "HideDatasetActionout_file": {
@@ -940,19 +950,20 @@
                     },
                     "action_type": "RenameDatasetAction",
                     "output_name": "out_file"
-                 }
+                }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "746e8e4bf929",
+                "changeset_revision": "4c07ddedc198",
                 "name": "datamash_ops",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"grouping\": \"3\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": \"false\", \"need_sort\": \"true\", \"operations\": [{\"__index__\": 0, \"op_name\": \"countunique\", \"op_column\": \"1\"}, {\"__index__\": 1, \"op_name\": \"min\", \"op_column\": \"8\"}, {\"__index__\": 2, \"op_name\": \"max\", \"op_column\": \"8\"}, {\"__index__\": 3, \"op_name\": \"countunique\", \"op_column\": \"19\"}, {\"__index__\": 4, \"op_name\": \"countunique\", \"op_column\": \"13\"}], \"print_full_line\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.1.0+galaxy2",
+            "tool_state": "{\"grouping\": \"3\", \"header_in\": true, \"header_out\": true, \"ignore_case\": false, \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": false, \"need_sort\": true, \"operations\": [{\"__index__\": 0, \"op_name\": \"countunique\", \"op_column\": \"1\"}, {\"__index__\": 1, \"op_name\": \"min\", \"op_column\": \"8\"}, {\"__index__\": 2, \"op_name\": \"max\", \"op_column\": \"8\"}, {\"__index__\": 3, \"op_name\": \"countunique\", \"op_column\": \"19\"}, {\"__index__\": 4, \"op_name\": \"countunique\", \"op_column\": \"13\"}], \"print_full_line\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.8+galaxy0",
             "type": "tool",
             "uuid": "a9af0104-3e05-48cb-9650-36f58d174cdf",
+            "when": null,
             "workflow_outputs": []
         },
         "21": {
@@ -980,8 +991,8 @@
                 }
             ],
             "position": {
-                "left": 2499.828125,
-                "top": 233.53645833333334
+                "left": 2926.71875,
+                "top": 51.98958333333334
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -999,20 +1010,21 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
             "tool_shed_repository": {
-                "changeset_revision": "f46f0e4f75c4",
+                "changeset_revision": "d698c222f354",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"column1\": \"20\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": \"true\", \"ignore_case\": \"false\", \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"column1\": \"20\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": true, \"ignore_case\": false, \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.2",
             "type": "tool",
             "uuid": "7e27aac8-1d1e-4d82-88e3-59c4cd61baeb",
+            "when": null,
             "workflow_outputs": []
         },
         "22": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0",
             "errors": null,
             "id": 22,
             "input_connections": {
@@ -1027,12 +1039,12 @@
             "outputs": [
                 {
                     "name": "out_file",
-                    "type": "tabular"
+                    "type": "input"
                 }
             ],
             "position": {
-                "left": 2508.25,
-                "top": 493.6927083333333
+                "left": 2935.140625,
+                "top": 312.1458333333333
             },
             "post_job_actions": {
                 "HideDatasetActionout_file": {
@@ -1041,22 +1053,23 @@
                     "output_name": "out_file"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "746e8e4bf929",
+                "changeset_revision": "4c07ddedc198",
                 "name": "datamash_ops",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"grouping\": \"3\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": \"false\", \"need_sort\": \"true\", \"operations\": [{\"__index__\": 0, \"op_name\": \"countunique\", \"op_column\": \"1\"}], \"print_full_line\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.1.0+galaxy2",
+            "tool_state": "{\"grouping\": \"3\", \"header_in\": true, \"header_out\": true, \"ignore_case\": false, \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": false, \"need_sort\": true, \"operations\": [{\"__index__\": 0, \"op_name\": \"countunique\", \"op_column\": \"1\"}], \"print_full_line\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.8+galaxy0",
             "type": "tool",
             "uuid": "fac0bae2-3415-4aa3-a5f5-7950ea411d98",
+            "when": null,
             "workflow_outputs": []
         },
         "23": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0",
             "errors": null,
             "id": 23,
             "input_connections": {
@@ -1071,12 +1084,12 @@
             "outputs": [
                 {
                     "name": "out_file",
-                    "type": "tabular"
+                    "type": "input"
                 }
             ],
             "position": {
-                "left": 2473.75,
-                "top": 827.9583333333334
+                "left": 2900.640625,
+                "top": 646.4114583333334
             },
             "post_job_actions": {
                 "HideDatasetActionout_file": {
@@ -1085,22 +1098,23 @@
                     "output_name": "out_file"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "746e8e4bf929",
+                "changeset_revision": "4c07ddedc198",
                 "name": "datamash_ops",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"grouping\": \"20\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": \"false\", \"need_sort\": \"true\", \"operations\": [{\"__index__\": 0, \"op_name\": \"countunique\", \"op_column\": \"1\"}], \"print_full_line\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.1.0+galaxy2",
+            "tool_state": "{\"grouping\": \"20\", \"header_in\": true, \"header_out\": true, \"ignore_case\": false, \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": false, \"need_sort\": true, \"operations\": [{\"__index__\": 0, \"op_name\": \"countunique\", \"op_column\": \"1\"}], \"print_full_line\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.8+galaxy0",
             "type": "tool",
             "uuid": "90b934e8-ba30-49aa-9fa4-a371fdf71285",
+            "when": null,
             "workflow_outputs": []
         },
         "24": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0",
             "errors": null,
             "id": 24,
             "input_connections": {
@@ -1115,12 +1129,12 @@
             "outputs": [
                 {
                     "name": "out_file",
-                    "type": "tabular"
+                    "type": "input"
                 }
             ],
             "position": {
-                "left": 2743.9375,
-                "top": 196.64583333333334
+                "left": 3170.828125,
+                "top": 15.098958333333343
             },
             "post_job_actions": {
                 "HideDatasetActionout_file": {
@@ -1129,17 +1143,18 @@
                     "output_name": "out_file"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "746e8e4bf929",
+                "changeset_revision": "4c07ddedc198",
                 "name": "datamash_ops",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"grouping\": \"1\", \"header_in\": \"true\", \"header_out\": \"true\", \"ignore_case\": \"false\", \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": \"false\", \"need_sort\": \"true\", \"operations\": [{\"__index__\": 0, \"op_name\": \"unique\", \"op_column\": \"2\"}], \"print_full_line\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.1.0+galaxy2",
+            "tool_state": "{\"grouping\": \"1\", \"header_in\": true, \"header_out\": true, \"ignore_case\": false, \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": false, \"need_sort\": true, \"operations\": [{\"__index__\": 0, \"op_name\": \"unique\", \"op_column\": \"2\"}], \"print_full_line\": true, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.8+galaxy0",
             "type": "tool",
             "uuid": "5ba44453-dabf-420f-a49e-2918eae031d3",
+            "when": null,
             "workflow_outputs": []
         },
         "25": {
@@ -1167,8 +1182,8 @@
                 }
             ],
             "position": {
-                "left": 2746,
-                "top": 406.2083333333333
+                "left": 3172.890625,
+                "top": 224.66145833333331
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1179,15 +1194,16 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
             "tool_shed_repository": {
-                "changeset_revision": "f46f0e4f75c4",
+                "changeset_revision": "d698c222f354",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"column1\": \"3\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": \"true\", \"ignore_case\": \"false\", \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"column1\": \"3\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": true, \"ignore_case\": false, \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.2",
             "type": "tool",
             "uuid": "3927af37-c003-4fac-a8af-88ba2b656b22",
+            "when": null,
             "workflow_outputs": []
         },
         "26": {
@@ -1215,8 +1231,8 @@
                 }
             ],
             "position": {
-                "left": 2704,
-                "top": 774.4739583333334
+                "left": 3130.890625,
+                "top": 592.9270833333334
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1227,15 +1243,16 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
             "tool_shed_repository": {
-                "changeset_revision": "f46f0e4f75c4",
+                "changeset_revision": "d698c222f354",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"column1\": \"20\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": \"true\", \"ignore_case\": \"false\", \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"column1\": \"20\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": true, \"ignore_case\": false, \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.2",
             "type": "tool",
             "uuid": "472af513-7900-41a5-b049-feb2d630ad2c",
+            "when": null,
             "workflow_outputs": []
         },
         "27": {
@@ -1259,8 +1276,8 @@
                 }
             ],
             "position": {
-                "left": 2968,
-                "top": 301.4427083333333
+                "left": 3394.890625,
+                "top": 119.89583333333331
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -1270,10 +1287,11 @@
                 }
             },
             "tool_id": "Cut1",
-            "tool_state": "{\"columnList\": \"c4,c6,c7,c13,c14,c15,c16,c17,c18,c19,c21,c22,c23,c26,c24,c25,c20\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"columnList\": \"c4,c6,c7,c13,c14,c15,c16,c17,c18,c19,c21,c22,c23,c26,c24,c25,c20\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.2",
             "type": "tool",
             "uuid": "30858ca2-a64b-4841-9bb5-5de4d38350cb",
+            "when": null,
             "workflow_outputs": []
         },
         "28": {
@@ -1301,8 +1319,8 @@
                 }
             ],
             "position": {
-                "left": 2964.03125,
-                "top": 499.3645833333333
+                "left": 3390.921875,
+                "top": 317.8177083333333
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1320,15 +1338,16 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/1.1.2",
             "tool_shed_repository": {
-                "changeset_revision": "f46f0e4f75c4",
+                "changeset_revision": "d698c222f354",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"column1\": \"1\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": \"true\", \"ignore_case\": \"false\", \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"column1\": \"1\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": true, \"ignore_case\": false, \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.2",
             "type": "tool",
             "uuid": "1b250a36-d3ae-415e-9764-006182096a60",
+            "when": null,
             "workflow_outputs": []
         },
         "29": {
@@ -1352,8 +1371,8 @@
                 }
             ],
             "position": {
-                "left": 2929.46875,
-                "top": 710.2239583333334
+                "left": 3356.359375,
+                "top": 528.6770833333334
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -1367,6 +1386,7 @@
             "tool_version": "1.0.2",
             "type": "tool",
             "uuid": "65a8b0dd-4b98-4646-bee8-a89f591816fb",
+            "when": null,
             "workflow_outputs": []
         },
         "30": {
@@ -1390,8 +1410,8 @@
                 }
             ],
             "position": {
-                "left": 3177.46875,
-                "top": 200.88020833333334
+                "left": 3604.359375,
+                "top": 19.333333333333343
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -1414,10 +1434,11 @@
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"caseinsensitive\": \"false\", \"find_pattern\": \"unique\\\\(Sample\\\\)\\\\tcollapse\\\\(Sample\\\\)\\\\tcollapse\\\\(AF\\\\)\", \"global\": \"true\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"is_regex\": \"true\", \"replace_pattern\": \"SAMPLES(above-thresholds)\\\\tSAMPLES(all)\\\\tAFs(all)\", \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}, \"skip_first_line\": \"false\", \"wholewords\": \"false\"}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"unique\\\\(Sample\\\\)\\\\tcollapse\\\\(Sample\\\\)\\\\tcollapse\\\\(AF\\\\)\", \"replace_pattern\": \"SAMPLES(above-thresholds)\\\\tSAMPLES(all)\\\\tAFs(all)\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.4",
             "type": "tool",
             "uuid": "6116c1c6-7c7c-43fe-9c91-609c91c6ed85",
+            "when": null,
             "workflow_outputs": []
         },
         "31": {
@@ -1441,8 +1462,8 @@
                 }
             ],
             "position": {
-                "left": 3181.28125,
-                "top": 525.8645833333334
+                "left": 3608.171875,
+                "top": 344.31770833333337
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -1456,6 +1477,7 @@
             "tool_version": "1.0.2",
             "type": "tool",
             "uuid": "a925b191-2cbc-4f45-b4cf-bbc25ba823d8",
+            "when": null,
             "workflow_outputs": []
         },
         "32": {
@@ -1479,8 +1501,8 @@
                 }
             ],
             "position": {
-                "left": 3152.734375,
-                "top": 710.3958333333334
+                "left": 3579.625,
+                "top": 528.8489583333334
             },
             "post_job_actions": {
                 "RenameDatasetActionlist_output_tab": {
@@ -1502,6 +1524,7 @@
             "tool_version": "0.5.0",
             "type": "tool",
             "uuid": "9f938b6a-e7fb-4509-9c15-271c475092aa",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "variants_for_plotting",
@@ -1512,49 +1535,54 @@
         },
         "33": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpfreqplot/snpfreqplot/1.0+galaxy3",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
             "errors": null,
             "id": 33,
             "input_connections": {
-                "clustering|nclust": {
-                    "id": 5,
-                    "output_name": "output"
-                },
-                "sinputs": {
-                    "id": 32,
-                    "output_name": "list_output_tab"
+                "infile": {
+                    "id": 30,
+                    "output_name": "outfile"
                 }
             },
             "inputs": [],
             "label": null,
-            "name": "Variant Frequency Plot",
+            "name": "Sort",
             "outputs": [
                 {
                     "name": "outfile",
-                    "type": "pdf"
+                    "type": "input"
                 }
             ],
             "position": {
-                "left": 3394.78125,
-                "top": 778.5364583333334
+                "left": 3826.890625,
+                "top": 120.89583333333331
             },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpfreqplot/snpfreqplot/1.0+galaxy3",
+            "post_job_actions": {
+                "RenameDatasetActionoutfile": {
+                    "action_arguments": {
+                        "newname": "Combined Variant Report by Variant"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
             "tool_shed_repository": {
-                "changeset_revision": "3d0adeee3f2b",
-                "name": "snpfreqplot",
-                "owner": "iuc",
+                "changeset_revision": "d698c222f354",
+                "name": "text_processing",
+                "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"advanced\": {\"output_type\": \"svg\", \"ratio\": \"0.67\", \"color\": \"Set3\"}, \"clustering\": {\"do\": \"TRUE\", \"__current_case__\": 0, \"nclust\": {\"__class__\": \"ConnectedValue\"}, \"method\": \"ward.D2\"}, \"sinputs\": {\"__class__\": \"ConnectedValue\"}, \"varfreq\": \"0.0\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0+galaxy3",
+            "tool_state": "{\"header\": \"1\", \"ignore_case\": false, \"infile\": {\"__class__\": \"ConnectedValue\"}, \"sortkeys\": [{\"__index__\": 0, \"column\": \"1\", \"order\": \"\", \"style\": \"g\"}], \"unique\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.1",
             "type": "tool",
-            "uuid": "583b8d59-2cc0-468e-a0b7-3b1a788c7613",
+            "uuid": "0b2f751b-03c6-4302-9060-16856bb4157c",
+            "when": null,
             "workflow_outputs": [
                 {
-                    "label": "variant_frequency_plot",
+                    "label": "by_variant_report",
                     "output_name": "outfile",
-                    "uuid": "986f1d1a-02c0-4d91-9f6e-a09a088732ee"
+                    "uuid": "bbb19b95-70e3-43fb-baae-525f752b86e9"
                 }
             ]
         },
@@ -1579,8 +1607,8 @@
                 }
             ],
             "position": {
-                "left": 3403.796875,
-                "top": 512.0989583333334
+                "left": 3830.6875,
+                "top": 330.55208333333337
             },
             "post_job_actions": {
                 "RenameDatasetActionoutfile": {
@@ -1593,15 +1621,16 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
             "tool_shed_repository": {
-                "changeset_revision": "f46f0e4f75c4",
+                "changeset_revision": "d698c222f354",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"header\": \"1\", \"ignore_case\": \"false\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"sortkeys\": [{\"__index__\": 0, \"column\": \"1\", \"order\": \"\", \"style\": \"\"}, {\"__index__\": 1, \"column\": \"2\", \"order\": \"\", \"style\": \"n\"}], \"unique\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"header\": \"1\", \"ignore_case\": false, \"infile\": {\"__class__\": \"ConnectedValue\"}, \"sortkeys\": [{\"__index__\": 0, \"column\": \"1\", \"order\": \"\", \"style\": \"\"}, {\"__index__\": 1, \"column\": \"2\", \"order\": \"\", \"style\": \"n\"}], \"unique\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.1",
             "type": "tool",
             "uuid": "e55320de-be51-4fa5-908e-76c03de24a77",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "combined_variant_report",
@@ -1612,53 +1641,50 @@
         },
         "35": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpfreqplot/snpfreqplot/1.0+galaxy3",
             "errors": null,
             "id": 35,
             "input_connections": {
-                "infile": {
-                    "id": 30,
-                    "output_name": "outfile"
+                "clustering|nclust": {
+                    "id": 5,
+                    "output_name": "output"
+                },
+                "sinputs": {
+                    "id": 32,
+                    "output_name": "list_output_tab"
                 }
             },
             "inputs": [],
             "label": null,
-            "name": "Sort",
+            "name": "Variant Frequency Plot",
             "outputs": [
                 {
                     "name": "outfile",
-                    "type": "input"
+                    "type": "pdf"
                 }
             ],
             "position": {
-                "left": 3400,
-                "top": 302.4427083333333
+                "left": 3821.671875,
+                "top": 596.9895833333334
             },
-            "post_job_actions": {
-                "RenameDatasetActionoutfile": {
-                    "action_arguments": {
-                        "newname": "Combined Variant Report by Variant"
-                    },
-                    "action_type": "RenameDatasetAction",
-                    "output_name": "outfile"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sort_header_tool/1.1.1",
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snpfreqplot/snpfreqplot/1.0+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "f46f0e4f75c4",
-                "name": "text_processing",
-                "owner": "bgruening",
+                "changeset_revision": "3d0adeee3f2b",
+                "name": "snpfreqplot",
+                "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"header\": \"1\", \"ignore_case\": \"false\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"sortkeys\": [{\"__index__\": 0, \"column\": \"1\", \"order\": \"\", \"style\": \"g\"}], \"unique\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.1.1",
+            "tool_state": "{\"advanced\": {\"output_type\": \"svg\", \"ratio\": \"0.67\", \"color\": \"Set3\"}, \"clustering\": {\"do\": \"TRUE\", \"__current_case__\": 0, \"nclust\": {\"__class__\": \"ConnectedValue\"}, \"method\": \"ward.D2\"}, \"sinputs\": {\"__class__\": \"ConnectedValue\"}, \"varfreq\": \"0.0\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0+galaxy3",
             "type": "tool",
-            "uuid": "0b2f751b-03c6-4302-9060-16856bb4157c",
+            "uuid": "583b8d59-2cc0-468e-a0b7-3b1a788c7613",
+            "when": null,
             "workflow_outputs": [
                 {
-                    "label": "by_variant_report",
+                    "label": "variant_frequency_plot",
                     "output_name": "outfile",
-                    "uuid": "bbb19b95-70e3-43fb-baae-525f752b86e9"
+                    "uuid": "986f1d1a-02c0-4d91-9f6e-a09a088732ee"
                 }
             ]
         }

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: variation analysis reporting",
-    "release": "0.4",
+    "release": "0.5",
     "steps": {
         "0": {
             "annotation": "Variation data in VCF format. Can be the output of any of the workflows in https://github.com/galaxyproject/iwc/tree/main/workflows/sars-cov-2-variant-calling",
@@ -1482,7 +1482,7 @@
         },
         "32": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/split_file_to_collection/0.5.0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/split_file_to_collection/0.5.1",
             "errors": null,
             "id": 32,
             "input_connections": {
@@ -1513,15 +1513,15 @@
                     "output_name": "list_output_tab"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/split_file_to_collection/0.5.0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/split_file_to_collection/split_file_to_collection/0.5.1",
             "tool_shed_repository": {
-                "changeset_revision": "6cbe2f30c2d7",
+                "changeset_revision": "baabc30154cd",
                 "name": "split_file_to_collection",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"split_parms\": {\"select_ftype\": \"tabular\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}, \"top\": \"1\", \"split_by\": {\"select_split_by\": \"col\", \"__current_case__\": 0, \"id_col\": \"1\", \"match_regex\": \"(.*)\", \"sub_regex\": \"\\\\1\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.5.0",
+            "tool_version": "0.5.1",
             "type": "tool",
             "uuid": "9f938b6a-e7fb-4509-9c15-271c475092aa",
             "when": null,


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.1.0+galaxy2` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.8+galaxy0`

The workflow release number has been updated from 0.3 to 0.4.
