### PR TITLE
Updating workflows/epigenetics/chipseq-pe from 0.3 to 0.4

### DIFF
--- a/workflows/epigenetics/chipseq-pe/.dockstore.yml
+++ b/workflows/epigenetics/chipseq-pe/.dockstore.yml
@@ -1,8 +1,11 @@
 version: 1.2
 workflows:
 - name: main
-  primaryDescriptorPath: /chipseq-pe.ga
-  publish: true
   subclass: Galaxy
+  publish: true
+  primaryDescriptorPath: /chipseq-pe.ga
   testParameterFiles:
   - /chipseq-pe-tests.yml
+  authors:
+  - name: Lucille Delisle
+    orcid: 0000-0002-1964-4960

--- a/workflows/epigenetics/chipseq-pe/CHANGELOG.md
+++ b/workflows/epigenetics/chipseq-pe/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Automatic update
 - `toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.0+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.4+galaxy0`
 
+### Manual update
+- New parameter to get normalized profile
+
 ## [0.3] 2022-12-17
 
 ### Automatic update

--- a/workflows/epigenetics/chipseq-pe/CHANGELOG.md
+++ b/workflows/epigenetics/chipseq-pe/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4] 2023-06-17
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.0+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.4+galaxy0`
+
 ## [0.3] 2022-12-17
 
 ### Automatic update

--- a/workflows/epigenetics/chipseq-pe/README.md
+++ b/workflows/epigenetics/chipseq-pe/README.md
@@ -9,19 +9,19 @@
 - adapters sequences: this depends on the library preparation. If you don't know, use FastQC to determine if it is Truseq or Nextera.
 - reference_genome: this field will be adapted to the genomes available for bowtie2.
 - effective_genome_size: this is used by MACS2 and may be entered manually (indications are provided for heavily used genomes).
+- normalize_profile: Whether you want to have a profile normalized as Signal to Million Fragments.
 
 ## Processing
 
 - The workflow will remove illumina adapters and low quality bases and filter out any pair with mate smaller than 15bp.
 - The filtered reads are mapped with bowtie2 with default parameters.
 - The BAM is filtered to keep only MAPQ30 and concordant pairs.
-- The peaks are called with MACS2 which at the same time generates a coverage file.
+- The peaks are called with MACS2 which at the same time generates a coverage file (normalized or not).
 - The coverage is converted to bigwig.
 - A MultiQC is run to have an overview of the QC.
 
 ### Warning
 
-- The coverage output is not normalized.
 - The filtered bam still has PCR duplicates which are removed by MACS2.
 
 ## Contribution

--- a/workflows/epigenetics/chipseq-pe/chipseq-pe-tests.yml
+++ b/workflows/epigenetics/chipseq-pe/chipseq-pe-tests.yml
@@ -20,6 +20,7 @@
     adapter_reverse: 'GATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT'
     reference_genome: 'mm10'
     effective_genome_size: 1870000000
+    normalize_profile: false
   outputs:
     MultiQC webpage:
       asserts:
@@ -38,7 +39,7 @@
         cutadapt:
           asserts:
             has_text: 
-              text: "4.0\t50000\t587\t550\t3693\t46307\t5100000"
+              text: "4.4\t50000\t587\t550\t3693\t46307\t5100000"
         general_stats:
           asserts:
             has_text: 

--- a/workflows/epigenetics/chipseq-pe/chipseq-pe-tests.yml
+++ b/workflows/epigenetics/chipseq-pe/chipseq-pe-tests.yml
@@ -20,7 +20,7 @@
     adapter_reverse: 'GATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT'
     reference_genome: 'mm10'
     effective_genome_size: 1870000000
-    normalize_profile: false
+    normalize_profile: true
   outputs:
     MultiQC webpage:
       asserts:
@@ -96,7 +96,7 @@
         wt_H3K4me3:
            asserts:
               has_size:
-                value: 527913
+                value: 556477
                 delta: 10000
     mapping stats:
       element_tests:

--- a/workflows/epigenetics/chipseq-pe/chipseq-pe.ga
+++ b/workflows/epigenetics/chipseq-pe/chipseq-pe.ga
@@ -10,7 +10,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.3",
+    "release": "0.4",
     "name": "ChIPseq_PE",
     "steps": {
         "0": {
@@ -37,6 +37,7 @@
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "e09c0852-1db3-4a68-b88c-1b94c205cb6c",
+            "when": null,
             "workflow_outputs": []
         },
         "1": {
@@ -63,6 +64,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "30c1d867-5e73-4348-8969-848f58d94015",
+            "when": null,
             "workflow_outputs": []
         },
         "2": {
@@ -89,6 +91,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "ec244ede-8fa3-4d05-85a0-06839f4cf97d",
+            "when": null,
             "workflow_outputs": []
         },
         "3": {
@@ -115,6 +118,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "0119d669-7ce9-46fd-ba6f-3efd92dfb7f2",
+            "when": null,
             "workflow_outputs": []
         },
         "4": {
@@ -141,11 +145,12 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "5bb3b3df-60ab-4ec7-88e4-476be547ffbf",
+            "when": null,
             "workflow_outputs": []
         },
         "5": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.0+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.4+galaxy0",
             "errors": null,
             "id": 5,
             "input_connections": {
@@ -198,17 +203,18 @@
                     "output_name": "report"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.0+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.4+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "135b80fb1ac2",
+                "changeset_revision": "8c0175e03cee",
                 "name": "cutadapt",
                 "owner": "lparsons",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"adapter_options\": {\"action\": \"trim\", \"internal\": \"\", \"error_rate\": \"0.1\", \"no_indels\": \"false\", \"times\": \"1\", \"overlap\": \"3\", \"match_read_wildcards\": \" \", \"revcomp\": \"false\"}, \"filter_options\": {\"discard_trimmed\": \"false\", \"discard_untrimmed\": \"false\", \"minimum_length\": \"15\", \"maximum_length\": null, \"length_R2_options\": {\"length_R2_status\": \"False\", \"__current_case__\": 1}, \"max_n\": null, \"pair_filter\": \"any\", \"max_expected_errors\": null, \"discard_cassava\": \"false\"}, \"library\": {\"type\": \"paired_collection\", \"__current_case__\": 2, \"input_1\": {\"__class__\": \"ConnectedValue\"}, \"r1\": {\"adapters\": [{\"__index__\": 0, \"adapter_source\": {\"adapter_source_list\": \"user\", \"__current_case__\": 0, \"adapter_name\": \"Please use: For R1: - For Nextera: CTGTCTCTTATACACATCTCCGAGCCCACGAGAC - For TrueSeq: GATCGGAAGAGCACACGTCTGAACTCCAGTCAC or AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC \", \"adapter\": {\"__class__\": \"ConnectedValue\"}}, \"single_noindels\": \"false\"}], \"front_adapters\": [], \"anywhere_adapters\": [], \"cut\": \"0\"}, \"r2\": {\"adapters2\": [{\"__index__\": 0, \"adapter_source2\": {\"adapter_source_list2\": \"user\", \"__current_case__\": 0, \"adapter_name2\": \"Please use: For R2: - For Nextera: CTGTCTCTTATACACATCTGACGCTGCCGACGA - For TruSeq: GATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT or AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT\", \"adapter2\": {\"__class__\": \"ConnectedValue\"}}, \"single_noindels\": \"false\"}], \"front_adapters2\": [], \"anywhere_adapters2\": [], \"cut2\": \"0\", \"quality_cutoff2\": \"\"}}, \"output_selector\": [\"report\"], \"read_mod_options\": {\"quality_cutoff\": \"30\", \"nextseq_trim\": \"0\", \"trim_n\": \"false\", \"strip_suffix\": \"\", \"shorten_options\": {\"shorten_values\": \"False\", \"__current_case__\": 1}, \"length_tag\": \"\", \"rename\": \"\", \"zero_cap\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "4.0+galaxy1",
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"adapter_options\": {\"action\": \"trim\", \"internal\": \"\", \"error_rate\": \"0.1\", \"no_indels\": false, \"times\": \"1\", \"overlap\": \"3\", \"match_read_wildcards\": \" \", \"revcomp\": false}, \"filter_options\": {\"discard_trimmed\": false, \"discard_untrimmed\": false, \"minimum_length\": \"15\", \"maximum_length\": null, \"length_R2_options\": {\"length_R2_status\": \"False\", \"__current_case__\": 1}, \"max_n\": null, \"pair_filter\": \"any\", \"max_expected_errors\": null, \"discard_cassava\": false}, \"library\": {\"type\": \"paired_collection\", \"__current_case__\": 2, \"input_1\": {\"__class__\": \"ConnectedValue\"}, \"r1\": {\"adapters\": [{\"__index__\": 0, \"adapter_source\": {\"adapter_source_list\": \"user\", \"__current_case__\": 0, \"adapter_name\": \"Please use: For R1: - For Nextera: CTGTCTCTTATACACATCTCCGAGCCCACGAGAC - For TrueSeq: GATCGGAAGAGCACACGTCTGAACTCCAGTCAC or AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC \", \"adapter\": {\"__class__\": \"ConnectedValue\"}}, \"single_noindels\": false}], \"front_adapters\": [], \"anywhere_adapters\": [], \"cut\": \"0\"}, \"r2\": {\"adapters2\": [{\"__index__\": 0, \"adapter_source2\": {\"adapter_source_list2\": \"user\", \"__current_case__\": 0, \"adapter_name2\": \"Please use: For R2: - For Nextera: CTGTCTCTTATACACATCTGACGCTGCCGACGA - For TruSeq: GATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT or AGATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT\", \"adapter2\": {\"__class__\": \"ConnectedValue\"}}, \"single_noindels\": false}], \"front_adapters2\": [], \"anywhere_adapters2\": [], \"cut2\": \"0\", \"quality_cutoff2\": \"\"}}, \"output_selector\": [\"report\"], \"read_mod_options\": {\"quality_cutoff\": \"30\", \"nextseq_trim\": \"0\", \"trim_n\": false, \"strip_suffix\": \"\", \"shorten_options\": {\"shorten_values\": \"False\", \"__current_case__\": 1}, \"length_tag\": \"\", \"rename\": \"\", \"zero_cap\": false}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "4.4+galaxy0",
             "type": "tool",
             "uuid": "c7846b4c-54fb-458e-982e-c0d8358a9f5d",
+            "when": null,
             "workflow_outputs": []
         },
         "6": {
@@ -271,10 +277,11 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"analysis_type\": {\"analysis_type_selector\": \"simple\", \"__current_case__\": 0, \"presets\": \"no_presets\"}, \"library\": {\"type\": \"paired_collection\", \"__current_case__\": 2, \"input_1\": {\"__class__\": \"ConnectedValue\"}, \"unaligned_file\": \"false\", \"aligned_file\": \"false\", \"paired_options\": {\"paired_options_selector\": \"no\", \"__current_case__\": 1}}, \"reference_genome\": {\"source\": \"indexed\", \"__current_case__\": 0, \"index\": {\"__class__\": \"ConnectedValue\"}}, \"rg\": {\"rg_selector\": \"do_not_set\", \"__current_case__\": 3}, \"sam_options\": {\"sam_options_selector\": \"no\", \"__current_case__\": 1}, \"save_mapping_stats\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"analysis_type\": {\"analysis_type_selector\": \"simple\", \"__current_case__\": 0, \"presets\": \"no_presets\"}, \"library\": {\"type\": \"paired_collection\", \"__current_case__\": 2, \"input_1\": {\"__class__\": \"ConnectedValue\"}, \"unaligned_file\": false, \"aligned_file\": false, \"paired_options\": {\"paired_options_selector\": \"no\", \"__current_case__\": 1}}, \"reference_genome\": {\"source\": \"indexed\", \"__current_case__\": 0, \"index\": {\"__class__\": \"ConnectedValue\"}}, \"rg\": {\"rg_selector\": \"do_not_set\", \"__current_case__\": 3}, \"sam_options\": {\"sam_options_selector\": \"no\", \"__current_case__\": 1}, \"save_mapping_stats\": true, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.5.0+galaxy0",
             "type": "tool",
             "uuid": "6fd8444b-f305-4daa-a33a-5cb44e063f39",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "mapping stats",
@@ -328,10 +335,11 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"bed_file\": {\"__class__\": \"RuntimeValue\"}, \"flag\": {\"filter\": \"yes\", \"__current_case__\": 1, \"reqBits\": [\"0x0002\"], \"skipBits\": null}, \"header\": \"-h\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"library\": \"\", \"mapq\": \"30\", \"outputtype\": \"bam\", \"possibly_select_inverse\": \"false\", \"read_group\": \"\", \"regions\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"bed_file\": {\"__class__\": \"RuntimeValue\"}, \"flag\": {\"filter\": \"yes\", \"__current_case__\": 1, \"reqBits\": [\"0x0002\"], \"skipBits\": null}, \"header\": \"-h\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"library\": \"\", \"mapq\": \"30\", \"outputtype\": \"bam\", \"possibly_select_inverse\": false, \"read_group\": \"\", \"regions\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.8+galaxy1",
             "type": "tool",
             "uuid": "bb6e3ac5-cdb0-493c-b534-264ba530a711",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "filtered BAM",
@@ -447,10 +455,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"advanced_options\": {\"to_large\": \"false\", \"nolambda\": \"false\", \"spmr\": \"false\", \"ratio\": null, \"slocal\": null, \"llocal\": null, \"broad_options\": {\"broad_options_selector\": \"nobroad\", \"__current_case__\": 1, \"call_summits\": \"true\"}, \"keep_dup_options\": {\"keep_dup_options_selector\": \"1\", \"__current_case__\": 1}, \"d_min\": \"20\", \"buffer_size\": \"100000\"}, \"control\": {\"c_select\": \"No\", \"__current_case__\": 1}, \"cutoff_options\": {\"cutoff_options_selector\": \"qvalue\", \"__current_case__\": 1, \"qvalue\": \"0.05\"}, \"effective_genome_size_options\": {\"effective_genome_size_options_selector\": \"user_defined\", \"__current_case__\": 4, \"gsize\": {\"__class__\": \"ConnectedValue\"}}, \"format\": \"BAMPE\", \"nomodel_type\": {\"nomodel_type_selector\": \"create_model\", \"__current_case__\": 0, \"mfold_lower\": \"5\", \"mfold_upper\": \"50\", \"band_width\": \"300\"}, \"outputs\": [\"peaks_tabular\", \"summits\", \"bdg\", \"html\"], \"treatment\": {\"t_multi_select\": \"No\", \"__current_case__\": 0, \"input_treatment_file\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"advanced_options\": {\"to_large\": false, \"nolambda\": false, \"spmr\": false, \"ratio\": null, \"slocal\": null, \"llocal\": null, \"broad_options\": {\"broad_options_selector\": \"nobroad\", \"__current_case__\": 1, \"call_summits\": true}, \"keep_dup_options\": {\"keep_dup_options_selector\": \"1\", \"__current_case__\": 1}, \"d_min\": \"20\", \"buffer_size\": \"100000\"}, \"control\": {\"c_select\": \"No\", \"__current_case__\": 1}, \"cutoff_options\": {\"cutoff_options_selector\": \"qvalue\", \"__current_case__\": 1, \"qvalue\": \"0.05\"}, \"effective_genome_size_options\": {\"effective_genome_size_options_selector\": \"user_defined\", \"__current_case__\": 4, \"gsize\": {\"__class__\": \"ConnectedValue\"}}, \"format\": \"BAMPE\", \"nomodel_type\": {\"nomodel_type_selector\": \"create_model\", \"__current_case__\": 0, \"mfold_lower\": \"5\", \"mfold_upper\": \"50\", \"band_width\": \"300\"}, \"outputs\": [\"peaks_tabular\", \"summits\", \"bdg\", \"html\"], \"treatment\": {\"t_multi_select\": \"No\", \"__current_case__\": 0, \"input_treatment_file\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.2.7.1+galaxy0",
             "type": "tool",
             "uuid": "06ca906e-c512-4376-9ffc-8eb2b5774af1",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "MACS2 summits",
@@ -520,6 +529,7 @@
             "tool_version": "1.1.1",
             "type": "tool",
             "uuid": "95832fa1-e96e-4867-8162-d1e39cb1dc46",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "MACS2 report",
@@ -566,6 +576,7 @@
             "tool_version": "1.1.1",
             "type": "tool",
             "uuid": "0fe57c5d-00a0-4cb6-9bac-97e6d03c6b76",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "coverage from MACS2",
@@ -628,10 +639,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"comment\": \"\", \"export\": \"true\", \"flat\": \"false\", \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"cutadapt\", \"__current_case__\": 5, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"bowtie2\", \"__current_case__\": 3, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"macs2\", \"__current_case__\": 16, \"input\": {\"__class__\": \"ConnectedValue\"}}}], \"saveLog\": \"false\", \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"comment\": \"\", \"export\": true, \"flat\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"cutadapt\", \"__current_case__\": 5, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"bowtie2\", \"__current_case__\": 3, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"macs2\", \"__current_case__\": 16, \"input\": {\"__class__\": \"ConnectedValue\"}}}], \"saveLog\": false, \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.11+galaxy1",
             "type": "tool",
             "uuid": "fb066848-43df-412a-9767-9613bac7d961",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "MultiQC on input dataset(s): Stats",

--- a/workflows/epigenetics/chipseq-pe/chipseq-pe.ga
+++ b/workflows/epigenetics/chipseq-pe/chipseq-pe.ga
@@ -56,8 +56,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 31.01666259765625,
-                "top": 81.5
+                "left": 11.01666259765625,
+                "top": 93.5
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
@@ -83,8 +83,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 72.066650390625,
-                "top": 173.4499969482422
+                "left": 50.066650390625,
+                "top": 189.45001220703125
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
@@ -110,8 +110,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 177.9000244140625,
-                "top": 305.23333740234375
+                "left": 102.9000244140625,
+                "top": 333.23333740234375
             },
             "tool_id": null,
             "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
@@ -137,8 +137,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 235.8499755859375,
-                "top": 399.6166687011719
+                "left": 144.8499755859375,
+                "top": 437.61669921875
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
@@ -149,10 +149,37 @@
             "workflow_outputs": []
         },
         "5": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.4+galaxy0",
+            "annotation": "Whether you want to have a profile normalized as Signal to Million Fragments",
+            "content_id": null,
             "errors": null,
             "id": 5,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Whether you want to have a profile normalized as Signal to Million Fragments",
+                    "name": "normalize_profile"
+                }
+            ],
+            "label": "normalize_profile",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 185,
+                "top": 542
+            },
+            "tool_id": null,
+            "tool_state": "{\"parameter_type\": \"boolean\", \"optional\": false}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "8180a47b-2fa4-404e-b644-1f3ec3bea980",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "6": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.0+galaxy1",
+            "errors": null,
+            "id": 6,
             "input_connections": {
                 "library|input_1": {
                     "id": 0,
@@ -181,8 +208,8 @@
                 }
             ],
             "position": {
-                "left": 326.29998779296875,
-                "top": 4.25
+                "left": 414.29998779296875,
+                "top": 57.25
             },
             "post_job_actions": {
                 "HideDatasetActionout_pairs": {
@@ -217,14 +244,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "6": {
+        "7": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.5.0+galaxy0",
             "errors": null,
-            "id": 6,
+            "id": 7,
             "input_connections": {
                 "library|input_1": {
-                    "id": 5,
+                    "id": 6,
                     "output_name": "out_pairs"
                 },
                 "reference_genome|index": {
@@ -246,8 +273,8 @@
                 }
             ],
             "position": {
-                "left": 621.6000061035156,
-                "top": 383.93333435058594
+                "left": 709.6000061035156,
+                "top": 436.93333435058594
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -277,7 +304,7 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"analysis_type\": {\"analysis_type_selector\": \"simple\", \"__current_case__\": 0, \"presets\": \"no_presets\"}, \"library\": {\"type\": \"paired_collection\", \"__current_case__\": 2, \"input_1\": {\"__class__\": \"ConnectedValue\"}, \"unaligned_file\": false, \"aligned_file\": false, \"paired_options\": {\"paired_options_selector\": \"no\", \"__current_case__\": 1}}, \"reference_genome\": {\"source\": \"indexed\", \"__current_case__\": 0, \"index\": {\"__class__\": \"ConnectedValue\"}}, \"rg\": {\"rg_selector\": \"do_not_set\", \"__current_case__\": 3}, \"sam_options\": {\"sam_options_selector\": \"no\", \"__current_case__\": 1}, \"save_mapping_stats\": true, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"no\", \"__current_case__\": 0}, \"analysis_type\": {\"analysis_type_selector\": \"simple\", \"__current_case__\": 0, \"presets\": \"no_presets\"}, \"library\": {\"type\": \"paired_collection\", \"__current_case__\": 2, \"input_1\": {\"__class__\": \"ConnectedValue\"}, \"unaligned_file\": false, \"aligned_file\": false, \"paired_options\": {\"paired_options_selector\": \"no\", \"__current_case__\": 1}}, \"reference_genome\": {\"source\": \"indexed\", \"__current_case__\": 0, \"index\": {\"__class__\": \"ConnectedValue\"}}, \"rg\": {\"rg_selector\": \"do_not_set\", \"__current_case__\": 3}, \"sam_options\": {\"sam_options_selector\": \"no\", \"__current_case__\": 1}, \"save_mapping_stats\": true, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.5.0+galaxy0",
             "type": "tool",
             "uuid": "6fd8444b-f305-4daa-a33a-5cb44e063f39",
@@ -290,14 +317,14 @@
                 }
             ]
         },
-        "7": {
+        "8": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/1.8+galaxy1",
             "errors": null,
-            "id": 7,
+            "id": 8,
             "input_connections": {
                 "input1": {
-                    "id": 6,
+                    "id": 7,
                     "output_name": "output"
                 }
             },
@@ -316,8 +343,8 @@
                 }
             ],
             "position": {
-                "left": 1017,
-                "top": 528.3833312988281
+                "left": 1105,
+                "top": 581.3833312988281
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput1": {
@@ -348,22 +375,31 @@
                 }
             ]
         },
-        "8": {
+        "9": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.2.7.1+galaxy0",
             "errors": null,
-            "id": 8,
+            "id": 9,
             "input_connections": {
+                "advanced_options|spmr": {
+                    "id": 5,
+                    "output_name": "output"
+                },
                 "effective_genome_size_options|gsize": {
                     "id": 4,
                     "output_name": "output"
                 },
                 "treatment|input_treatment_file": {
-                    "id": 7,
+                    "id": 8,
                     "output_name": "output1"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool MACS2 callpeak",
+                    "name": "treatment"
+                }
+            ],
             "label": "Call Peaks with MACS2",
             "name": "MACS2 callpeak",
             "outputs": [
@@ -393,8 +429,8 @@
                 }
             ],
             "position": {
-                "left": 1458.183349609375,
-                "top": 261.96665954589844
+                "left": 1546.183349609375,
+                "top": 314.96665954589844
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_control_lambda": {
@@ -455,12 +491,17 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"advanced_options\": {\"to_large\": false, \"nolambda\": false, \"spmr\": false, \"ratio\": null, \"slocal\": null, \"llocal\": null, \"broad_options\": {\"broad_options_selector\": \"nobroad\", \"__current_case__\": 1, \"call_summits\": true}, \"keep_dup_options\": {\"keep_dup_options_selector\": \"1\", \"__current_case__\": 1}, \"d_min\": \"20\", \"buffer_size\": \"100000\"}, \"control\": {\"c_select\": \"No\", \"__current_case__\": 1}, \"cutoff_options\": {\"cutoff_options_selector\": \"qvalue\", \"__current_case__\": 1, \"qvalue\": \"0.05\"}, \"effective_genome_size_options\": {\"effective_genome_size_options_selector\": \"user_defined\", \"__current_case__\": 4, \"gsize\": {\"__class__\": \"ConnectedValue\"}}, \"format\": \"BAMPE\", \"nomodel_type\": {\"nomodel_type_selector\": \"create_model\", \"__current_case__\": 0, \"mfold_lower\": \"5\", \"mfold_upper\": \"50\", \"band_width\": \"300\"}, \"outputs\": [\"peaks_tabular\", \"summits\", \"bdg\", \"html\"], \"treatment\": {\"t_multi_select\": \"No\", \"__current_case__\": 0, \"input_treatment_file\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"advanced_options\": {\"to_large\": false, \"nolambda\": false, \"spmr\": {\"__class__\": \"ConnectedValue\"}, \"ratio\": null, \"slocal\": null, \"llocal\": null, \"broad_options\": {\"broad_options_selector\": \"nobroad\", \"__current_case__\": 1, \"call_summits\": true}, \"keep_dup_options\": {\"keep_dup_options_selector\": \"1\", \"__current_case__\": 1}, \"d_min\": \"20\", \"buffer_size\": \"100000\"}, \"control\": {\"c_select\": \"No\", \"__current_case__\": 1}, \"cutoff_options\": {\"cutoff_options_selector\": \"qvalue\", \"__current_case__\": 1, \"qvalue\": \"0.05\"}, \"effective_genome_size_options\": {\"effective_genome_size_options_selector\": \"user_defined\", \"__current_case__\": 4, \"gsize\": {\"__class__\": \"ConnectedValue\"}}, \"format\": \"BAMPE\", \"nomodel_type\": {\"nomodel_type_selector\": \"create_model\", \"__current_case__\": 0, \"mfold_lower\": \"5\", \"mfold_upper\": \"50\", \"band_width\": \"300\"}, \"outputs\": [\"peaks_tabular\", \"summits\", \"bdg\", \"html\"], \"treatment\": {\"t_multi_select\": \"No\", \"__current_case__\": 0, \"input_treatment_file\": {\"__class__\": \"RuntimeValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.2.7.1+galaxy0",
             "type": "tool",
             "uuid": "06ca906e-c512-4376-9ffc-8eb2b5774af1",
             "when": null,
             "workflow_outputs": [
+                {
+                    "label": "MACS2 narrowPeak",
+                    "output_name": "output_narrowpeaks",
+                    "uuid": "7c28605b-1dad-401d-b057-7fad39ee032c"
+                },
                 {
                     "label": "MACS2 summits",
                     "output_name": "output_summits",
@@ -470,22 +511,17 @@
                     "label": "MACS2 peaks",
                     "output_name": "output_tabular",
                     "uuid": "10114173-d06e-4ad1-aa62-0de5ca17b364"
-                },
-                {
-                    "label": "MACS2 narrowPeak",
-                    "output_name": "output_narrowpeaks",
-                    "uuid": "7c28605b-1dad-401d-b057-7fad39ee032c"
                 }
             ]
         },
-        "9": {
+        "10": {
             "annotation": "summary of MACS2",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/1.1.1",
             "errors": null,
-            "id": 9,
+            "id": 10,
             "input_connections": {
                 "infile": {
-                    "id": 8,
+                    "id": 9,
                     "output_name": "output_tabular"
                 }
             },
@@ -499,8 +535,8 @@
                 }
             ],
             "position": {
-                "left": 1868.11669921875,
-                "top": 132.96665954589844
+                "left": 1956.11669921875,
+                "top": 185.96665954589844
             },
             "post_job_actions": {
                 "ChangeDatatypeActionoutput": {
@@ -520,7 +556,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/1.1.1",
             "tool_shed_repository": {
-                "changeset_revision": "d698c222f354",
+                "changeset_revision": "ddf54b12c295",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -538,14 +574,14 @@
                 }
             ]
         },
-        "10": {
+        "11": {
             "annotation": "",
             "content_id": "wig_to_bigWig",
             "errors": null,
-            "id": 10,
+            "id": 11,
             "input_connections": {
                 "input1": {
-                    "id": 8,
+                    "id": 9,
                     "output_name": "output_treat_pileup"
                 }
             },
@@ -559,8 +595,8 @@
                 }
             ],
             "position": {
-                "left": 1929.933349609375,
-                "top": 411.3333282470703
+                "left": 2017.933349609375,
+                "top": 464.3333282470703
             },
             "post_job_actions": {
                 "RenameDatasetActionout_file1": {
@@ -585,22 +621,22 @@
                 }
             ]
         },
-        "11": {
+        "12": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy1",
             "errors": null,
-            "id": 11,
+            "id": 12,
             "input_connections": {
                 "results_0|software_cond|input": {
-                    "id": 5,
+                    "id": 6,
                     "output_name": "report"
                 },
                 "results_1|software_cond|input": {
-                    "id": 6,
+                    "id": 7,
                     "output_name": "mapping_stats"
                 },
                 "results_2|software_cond|input": {
-                    "id": 8,
+                    "id": 9,
                     "output_name": "output_tabular"
                 }
             },
@@ -622,8 +658,8 @@
                 }
             ],
             "position": {
-                "left": 1977.1666870117188,
-                "top": 790.3333129882812
+                "left": 2065.1666870117188,
+                "top": 843.3333129882812
             },
             "post_job_actions": {
                 "HideDatasetActionplots": {
@@ -646,14 +682,14 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "MultiQC on input dataset(s): Stats",
-                    "output_name": "stats",
-                    "uuid": "409a12c8-c81d-4607-a7d8-3f8fe0ab8d02"
-                },
-                {
                     "label": "MultiQC webpage",
                     "output_name": "html_report",
                     "uuid": "175c983c-cb66-430e-aaeb-252b9f520f3b"
+                },
+                {
+                    "label": "MultiQC on input dataset(s): Stats",
+                    "output_name": "stats",
+                    "uuid": "409a12c8-c81d-4607-a7d8-3f8fe0ab8d02"
                 }
             ]
         }
@@ -661,6 +697,6 @@
     "tags": [
         "ChIP"
     ],
-    "uuid": "12593cdc-9a1d-4cf3-810f-edeeee35b9d7",
+    "uuid": "d727eee1-db1c-4005-a315-a783a441fef5",
     "version": 1
 }

--- a/workflows/epigenetics/chipseq-pe/chipseq-pe.ga
+++ b/workflows/epigenetics/chipseq-pe/chipseq-pe.ga
@@ -177,7 +177,7 @@
         },
         "6": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.0+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.4+galaxy0",
             "errors": null,
             "id": 6,
             "input_connections": {


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/epigenetics/chipseq-pe**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.0+galaxy1` should be updated to `toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.4+galaxy0`

The workflow release number has been updated from 0.3 to 0.4.
