### PR TITLE
Updating workflows/epigenetics/chipseq-sr from 0.3 to 0.4

### DIFF
--- a/workflows/epigenetics/chipseq-sr/.dockstore.yml
+++ b/workflows/epigenetics/chipseq-sr/.dockstore.yml
@@ -1,8 +1,11 @@
 version: 1.2
 workflows:
 - name: main
-  primaryDescriptorPath: /chipseq-sr.ga
-  publish: true
   subclass: Galaxy
+  publish: true
+  primaryDescriptorPath: /chipseq-sr.ga
   testParameterFiles:
   - /chipseq-sr-tests.yml
+  authors:
+  - name: Lucille Delisle
+    orcid: 0000-0002-1964-4960

--- a/workflows/epigenetics/chipseq-sr/CHANGELOG.md
+++ b/workflows/epigenetics/chipseq-sr/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Automatic update
 - `toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.0+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.4+galaxy0`
 
+### Manual update
+- New parameter to get normalized profile
+
 ## [0.3] 2022-12-17
 
 ### Automatic update

--- a/workflows/epigenetics/chipseq-sr/CHANGELOG.md
+++ b/workflows/epigenetics/chipseq-sr/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4] 2023-06-17
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.0+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.4+galaxy0`
+
 ## [0.3] 2022-12-17
 
 ### Automatic update

--- a/workflows/epigenetics/chipseq-sr/README.md
+++ b/workflows/epigenetics/chipseq-sr/README.md
@@ -9,17 +9,17 @@
 - adapters sequence_forward: this depends on the library preparation. If you don't know, use FastQC to determine if it is Truseq or Nextera.
 - reference_genome: this field will be adapted to the genomes available for bowtie2.
 - effective_genome_size: this is used by MACS2 and may be entered manually (indications are provided for heavily used genomes).
+- normalize_profile: Whether you want to have a profile normalized as Signal to Million Reads.
 
 ## Processing
 
 - The workflow will remove illumina adapters and low quality bases and filter out any read smaller than 15bp.
 - The filtered reads are mapped with bowtie2 with default parameters.
 - The BAM is filtered to keep only MAPQ30.
-- The peaks are called with MACS2 with a fixed extension of 200bp which at the same time generates a coverage file.
+- The peaks are called with MACS2 with a fixed extension of 200bp which at the same time generates a coverage file (normalized or not).
 - The coverage is converted to bigwig.
 - A MultiQC is run to have an overview of the QC.
 
 ### Warning
 
-- The coverage output is not normalized.
 - The filtered bam still has PCR duplicates which are removed by MACS2.

--- a/workflows/epigenetics/chipseq-sr/chipseq-sr-tests.yml
+++ b/workflows/epigenetics/chipseq-sr/chipseq-sr-tests.yml
@@ -11,7 +11,7 @@
     adapter_forward: 'GATCGGAAGAGCACACGTCTGAACTCCAGTCAC'
     reference_genome: 'mm10'
     effective_genome_size: 1870000000
-    normalize_profile: false
+    normalize_profile: true
   outputs:
     MultiQC webpage:
       asserts:
@@ -87,8 +87,8 @@
         wt_H3K4me3:
            asserts:
               has_size:
-                value: 527913
-                delta: 50000
+                value: 559925
+                delta: 10000
     mapping stats:
       element_tests:
         wt_H3K4me3:

--- a/workflows/epigenetics/chipseq-sr/chipseq-sr-tests.yml
+++ b/workflows/epigenetics/chipseq-sr/chipseq-sr-tests.yml
@@ -11,6 +11,7 @@
     adapter_forward: 'GATCGGAAGAGCACACGTCTGAACTCCAGTCAC'
     reference_genome: 'mm10'
     effective_genome_size: 1870000000
+    normalize_profile: false
   outputs:
     MultiQC webpage:
       asserts:
@@ -29,7 +30,7 @@
         cutadapt:
           asserts:
             has_text: 
-              text: "4.0\t50000\t587\t749\t49251"
+              text: "4.4\t50000\t587\t749\t49251"
         general_stats:
           asserts:
             has_text: 

--- a/workflows/epigenetics/chipseq-sr/chipseq-sr.ga
+++ b/workflows/epigenetics/chipseq-sr/chipseq-sr.ga
@@ -56,8 +56,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 31.033340454101562,
-                "top": 81.44999694824219
+                "left": 39.0333251953125,
+                "top": 77.44999694824219
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
@@ -83,8 +83,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 83.78334045410156,
-                "top": 189.96665954589844
+                "left": 62.7833251953125,
+                "top": 169.9666748046875
             },
             "tool_id": null,
             "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
@@ -110,8 +110,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 148.23333740234375,
-                "top": 292.3999938964844
+                "left": 106.23333740234375,
+                "top": 262.3999938964844
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
@@ -122,10 +122,37 @@
             "workflow_outputs": []
         },
         "4": {
+            "annotation": "Whether you want to have a profile normalized as Signal to Million Reads",
+            "content_id": null,
+            "errors": null,
+            "id": 4,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Whether you want to have a profile normalized as Signal to Million Reads",
+                    "name": "normalize_profile"
+                }
+            ],
+            "label": "normalize_profile",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 163.95545543674132,
+                "top": 359.9555974960296
+            },
+            "tool_id": null,
+            "tool_state": "{\"parameter_type\": \"boolean\", \"optional\": false}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "b89b796d-df4f-416f-8bc4-4f1951efa449",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "5": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.4+galaxy0",
             "errors": null,
-            "id": 4,
+            "id": 5,
             "input_connections": {
                 "library|input_1": {
                     "id": 0,
@@ -150,8 +177,8 @@
                 }
             ],
             "position": {
-                "left": 326.31666564941406,
-                "top": 4.1666717529296875
+                "left": 423.31666564941406,
+                "top": 80.16667175292969
             },
             "post_job_actions": {
                 "HideDatasetActionout1": {
@@ -186,14 +213,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "5": {
+        "6": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.5.0+galaxy0",
             "errors": null,
-            "id": 5,
+            "id": 6,
             "input_connections": {
                 "library|input_1": {
-                    "id": 4,
+                    "id": 5,
                     "output_name": "out1"
                 },
                 "reference_genome|index": {
@@ -215,8 +242,8 @@
                 }
             ],
             "position": {
-                "left": 621.6333312988281,
-                "top": 383.8500061035156
+                "left": 718.6333312988281,
+                "top": 459.8500061035156
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -246,7 +273,7 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"analysis_type\": {\"analysis_type_selector\": \"simple\", \"__current_case__\": 0, \"presets\": \"no_presets\"}, \"library\": {\"type\": \"single\", \"__current_case__\": 0, \"input_1\": {\"__class__\": \"ConnectedValue\"}, \"unaligned_file\": false, \"aligned_file\": false}, \"reference_genome\": {\"source\": \"indexed\", \"__current_case__\": 0, \"index\": {\"__class__\": \"ConnectedValue\"}}, \"rg\": {\"rg_selector\": \"do_not_set\", \"__current_case__\": 3}, \"sam_options\": {\"sam_options_selector\": \"no\", \"__current_case__\": 1}, \"save_mapping_stats\": true, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__job_resource\": {\"__job_resource__select\": \"no\", \"__current_case__\": 0}, \"analysis_type\": {\"analysis_type_selector\": \"simple\", \"__current_case__\": 0, \"presets\": \"no_presets\"}, \"library\": {\"type\": \"single\", \"__current_case__\": 0, \"input_1\": {\"__class__\": \"ConnectedValue\"}, \"unaligned_file\": false, \"aligned_file\": false}, \"reference_genome\": {\"source\": \"indexed\", \"__current_case__\": 0, \"index\": {\"__class__\": \"ConnectedValue\"}}, \"rg\": {\"rg_selector\": \"do_not_set\", \"__current_case__\": 3}, \"sam_options\": {\"sam_options_selector\": \"no\", \"__current_case__\": 1}, \"save_mapping_stats\": true, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.5.0+galaxy0",
             "type": "tool",
             "uuid": "6fd8444b-f305-4daa-a33a-5cb44e063f39",
@@ -259,14 +286,14 @@
                 }
             ]
         },
-        "6": {
+        "7": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtool_filter2/samtool_filter2/1.8+galaxy1",
             "errors": null,
-            "id": 6,
+            "id": 7,
             "input_connections": {
                 "input1": {
-                    "id": 5,
+                    "id": 6,
                     "output_name": "output"
                 }
             },
@@ -285,8 +312,8 @@
                 }
             ],
             "position": {
-                "left": 1017.0499877929688,
-                "top": 528.2999877929688
+                "left": 1114.0499877929688,
+                "top": 604.2999877929688
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput1": {
@@ -317,22 +344,31 @@
                 }
             ]
         },
-        "7": {
+        "8": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/macs2/macs2_callpeak/2.2.7.1+galaxy0",
             "errors": null,
-            "id": 7,
+            "id": 8,
             "input_connections": {
+                "advanced_options|spmr": {
+                    "id": 4,
+                    "output_name": "output"
+                },
                 "effective_genome_size_options|gsize": {
                     "id": 3,
                     "output_name": "output"
                 },
                 "treatment|input_treatment_file": {
-                    "id": 6,
+                    "id": 7,
                     "output_name": "output1"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool MACS2 callpeak",
+                    "name": "treatment"
+                }
+            ],
             "label": "Call Peaks with MACS2",
             "name": "MACS2 callpeak",
             "outputs": [
@@ -362,8 +398,8 @@
                 }
             ],
             "position": {
-                "left": 1458.199951171875,
-                "top": 261.98333740234375
+                "left": 1555.199951171875,
+                "top": 337.98333740234375
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_control_lambda": {
@@ -424,7 +460,7 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"advanced_options\": {\"to_large\": false, \"nolambda\": false, \"spmr\": false, \"ratio\": null, \"slocal\": null, \"llocal\": null, \"broad_options\": {\"broad_options_selector\": \"nobroad\", \"__current_case__\": 1, \"call_summits\": true}, \"keep_dup_options\": {\"keep_dup_options_selector\": \"1\", \"__current_case__\": 1}, \"d_min\": \"20\", \"buffer_size\": \"100000\"}, \"control\": {\"c_select\": \"No\", \"__current_case__\": 1}, \"cutoff_options\": {\"cutoff_options_selector\": \"qvalue\", \"__current_case__\": 1, \"qvalue\": \"0.05\"}, \"effective_genome_size_options\": {\"effective_genome_size_options_selector\": \"user_defined\", \"__current_case__\": 4, \"gsize\": {\"__class__\": \"ConnectedValue\"}}, \"format\": \"BAM\", \"nomodel_type\": {\"nomodel_type_selector\": \"nomodel\", \"__current_case__\": 1, \"extsize\": \"200\", \"shift\": \"0\"}, \"outputs\": [\"peaks_tabular\", \"summits\", \"bdg\", \"html\"], \"treatment\": {\"t_multi_select\": \"No\", \"__current_case__\": 0, \"input_treatment_file\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"advanced_options\": {\"to_large\": false, \"nolambda\": false, \"spmr\": {\"__class__\": \"ConnectedValue\"}, \"ratio\": null, \"slocal\": null, \"llocal\": null, \"broad_options\": {\"broad_options_selector\": \"nobroad\", \"__current_case__\": 1, \"call_summits\": true}, \"keep_dup_options\": {\"keep_dup_options_selector\": \"1\", \"__current_case__\": 1}, \"d_min\": \"20\", \"buffer_size\": \"100000\"}, \"control\": {\"c_select\": \"No\", \"__current_case__\": 1}, \"cutoff_options\": {\"cutoff_options_selector\": \"qvalue\", \"__current_case__\": 1, \"qvalue\": \"0.05\"}, \"effective_genome_size_options\": {\"effective_genome_size_options_selector\": \"user_defined\", \"__current_case__\": 4, \"gsize\": {\"__class__\": \"ConnectedValue\"}}, \"format\": \"BAM\", \"nomodel_type\": {\"nomodel_type_selector\": \"nomodel\", \"__current_case__\": 1, \"extsize\": \"200\", \"shift\": \"0\"}, \"outputs\": [\"peaks_tabular\", \"summits\", \"bdg\", \"html\"], \"treatment\": {\"t_multi_select\": \"No\", \"__current_case__\": 0, \"input_treatment_file\": {\"__class__\": \"RuntimeValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.2.7.1+galaxy0",
             "type": "tool",
             "uuid": "06ca906e-c512-4376-9ffc-8eb2b5774af1",
@@ -447,14 +483,14 @@
                 }
             ]
         },
-        "8": {
+        "9": {
             "annotation": "summary of MACS2",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/1.1.1",
             "errors": null,
-            "id": 8,
+            "id": 9,
             "input_connections": {
                 "infile": {
-                    "id": 7,
+                    "id": 8,
                     "output_name": "output_tabular"
                 }
             },
@@ -468,8 +504,8 @@
                 }
             ],
             "position": {
-                "left": 1868.11669921875,
-                "top": 132.98333740234375
+                "left": 1965.11669921875,
+                "top": 208.98333740234375
             },
             "post_job_actions": {
                 "ChangeDatatypeActionoutput": {
@@ -489,7 +525,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/1.1.1",
             "tool_shed_repository": {
-                "changeset_revision": "d698c222f354",
+                "changeset_revision": "ddf54b12c295",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -507,14 +543,14 @@
                 }
             ]
         },
-        "9": {
+        "10": {
             "annotation": "",
             "content_id": "wig_to_bigWig",
             "errors": null,
-            "id": 9,
+            "id": 10,
             "input_connections": {
                 "input1": {
-                    "id": 7,
+                    "id": 8,
                     "output_name": "output_treat_pileup"
                 }
             },
@@ -528,8 +564,8 @@
                 }
             ],
             "position": {
-                "left": 1929.9666748046875,
-                "top": 411.2833251953125
+                "left": 2026.9666748046875,
+                "top": 487.2833251953125
             },
             "post_job_actions": {
                 "RenameDatasetActionout_file1": {
@@ -554,22 +590,22 @@
                 }
             ]
         },
-        "10": {
+        "11": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy1",
             "errors": null,
-            "id": 10,
+            "id": 11,
             "input_connections": {
                 "results_0|software_cond|input": {
-                    "id": 4,
+                    "id": 5,
                     "output_name": "report"
                 },
                 "results_1|software_cond|input": {
-                    "id": 5,
+                    "id": 6,
                     "output_name": "mapping_stats"
                 },
                 "results_2|software_cond|input": {
-                    "id": 7,
+                    "id": 8,
                     "output_name": "output_tabular"
                 }
             },
@@ -591,8 +627,8 @@
                 }
             ],
             "position": {
-                "left": 1977.183349609375,
-                "top": 790.2833251953125
+                "left": 2074.183349609375,
+                "top": 866.2833251953125
             },
             "post_job_actions": {
                 "HideDatasetActionplots": {
@@ -615,14 +651,14 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "MultiQC on input dataset(s): Stats",
-                    "output_name": "stats",
-                    "uuid": "d4c3e0a7-d5b7-4307-8669-0254a3723ce0"
-                },
-                {
                     "label": "MultiQC webpage",
                     "output_name": "html_report",
                     "uuid": "2167289f-6c78-479a-8d3b-95caf11d0c4e"
+                },
+                {
+                    "label": "MultiQC on input dataset(s): Stats",
+                    "output_name": "stats",
+                    "uuid": "d4c3e0a7-d5b7-4307-8669-0254a3723ce0"
                 }
             ]
         }
@@ -630,6 +666,6 @@
     "tags": [
         "ChIP"
     ],
-    "uuid": "af63dacf-ae85-42b6-88a4-2a15505d8fc9",
+    "uuid": "fe6bda9f-1fc2-4a86-bf8d-e779c79466fc",
     "version": 1
 }

--- a/workflows/epigenetics/chipseq-sr/chipseq-sr.ga
+++ b/workflows/epigenetics/chipseq-sr/chipseq-sr.ga
@@ -10,7 +10,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.3",
+    "release": "0.4",
     "name": "ChIPseq_SR",
     "steps": {
         "0": {
@@ -37,6 +37,7 @@
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "e09c0852-1db3-4a68-b88c-1b94c205cb6c",
+            "when": null,
             "workflow_outputs": []
         },
         "1": {
@@ -63,6 +64,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "30c1d867-5e73-4348-8969-848f58d94015",
+            "when": null,
             "workflow_outputs": []
         },
         "2": {
@@ -89,6 +91,7 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "0119d669-7ce9-46fd-ba6f-3efd92dfb7f2",
+            "when": null,
             "workflow_outputs": []
         },
         "3": {
@@ -115,11 +118,12 @@
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "5bb3b3df-60ab-4ec7-88e4-476be547ffbf",
+            "when": null,
             "workflow_outputs": []
         },
         "4": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.0+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.4+galaxy0",
             "errors": null,
             "id": 4,
             "input_connections": {
@@ -168,17 +172,18 @@
                     "output_name": "report"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.0+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.4+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "135b80fb1ac2",
+                "changeset_revision": "8c0175e03cee",
                 "name": "cutadapt",
                 "owner": "lparsons",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"adapter_options\": {\"action\": \"trim\", \"internal\": \"\", \"error_rate\": \"0.1\", \"no_indels\": \"false\", \"times\": \"1\", \"overlap\": \"3\", \"match_read_wildcards\": \" \", \"revcomp\": \"false\"}, \"filter_options\": {\"discard_trimmed\": \"false\", \"discard_untrimmed\": \"false\", \"minimum_length\": \"15\", \"maximum_length\": null, \"length_R2_options\": {\"length_R2_status\": \"False\", \"__current_case__\": 1}, \"max_n\": null, \"pair_filter\": \"any\", \"max_expected_errors\": null, \"discard_cassava\": \"false\"}, \"library\": {\"type\": \"single\", \"__current_case__\": 0, \"input_1\": {\"__class__\": \"ConnectedValue\"}, \"r1\": {\"adapters\": [{\"__index__\": 0, \"adapter_source\": {\"adapter_source_list\": \"user\", \"__current_case__\": 0, \"adapter_name\": \"Please use: For R1: - For Nextera: CTGTCTCTTATACACATCTCCGAGCCCACGAGAC - For TrueSeq: GATCGGAAGAGCACACGTCTGAACTCCAGTCAC or AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC\", \"adapter\": {\"__class__\": \"ConnectedValue\"}}, \"single_noindels\": \"false\"}], \"front_adapters\": [], \"anywhere_adapters\": [], \"cut\": \"0\"}}, \"output_selector\": [\"report\"], \"read_mod_options\": {\"quality_cutoff\": \"30\", \"nextseq_trim\": \"0\", \"trim_n\": \"false\", \"strip_suffix\": \"\", \"shorten_options\": {\"shorten_values\": \"False\", \"__current_case__\": 1}, \"length_tag\": \"\", \"rename\": \"\", \"zero_cap\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "4.0+galaxy1",
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"adapter_options\": {\"action\": \"trim\", \"internal\": \"\", \"error_rate\": \"0.1\", \"no_indels\": false, \"times\": \"1\", \"overlap\": \"3\", \"match_read_wildcards\": \" \", \"revcomp\": false}, \"filter_options\": {\"discard_trimmed\": false, \"discard_untrimmed\": false, \"minimum_length\": \"15\", \"maximum_length\": null, \"length_R2_options\": {\"length_R2_status\": \"False\", \"__current_case__\": 1}, \"max_n\": null, \"pair_filter\": \"any\", \"max_expected_errors\": null, \"discard_cassava\": false}, \"library\": {\"type\": \"single\", \"__current_case__\": 0, \"input_1\": {\"__class__\": \"ConnectedValue\"}, \"r1\": {\"adapters\": [{\"__index__\": 0, \"adapter_source\": {\"adapter_source_list\": \"user\", \"__current_case__\": 0, \"adapter_name\": \"Please use: For R1: - For Nextera: CTGTCTCTTATACACATCTCCGAGCCCACGAGAC - For TrueSeq: GATCGGAAGAGCACACGTCTGAACTCCAGTCAC or AGATCGGAAGAGCACACGTCTGAACTCCAGTCAC\", \"adapter\": {\"__class__\": \"ConnectedValue\"}}, \"single_noindels\": false}], \"front_adapters\": [], \"anywhere_adapters\": [], \"cut\": \"0\"}}, \"output_selector\": [\"report\"], \"read_mod_options\": {\"quality_cutoff\": \"30\", \"nextseq_trim\": \"0\", \"trim_n\": false, \"strip_suffix\": \"\", \"shorten_options\": {\"shorten_values\": \"False\", \"__current_case__\": 1}, \"length_tag\": \"\", \"rename\": \"\", \"zero_cap\": false}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "4.4+galaxy0",
             "type": "tool",
             "uuid": "c7846b4c-54fb-458e-982e-c0d8358a9f5d",
+            "when": null,
             "workflow_outputs": []
         },
         "5": {
@@ -241,10 +246,11 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"analysis_type\": {\"analysis_type_selector\": \"simple\", \"__current_case__\": 0, \"presets\": \"no_presets\"}, \"library\": {\"type\": \"single\", \"__current_case__\": 0, \"input_1\": {\"__class__\": \"ConnectedValue\"}, \"unaligned_file\": \"false\", \"aligned_file\": \"false\"}, \"reference_genome\": {\"source\": \"indexed\", \"__current_case__\": 0, \"index\": {\"__class__\": \"ConnectedValue\"}}, \"rg\": {\"rg_selector\": \"do_not_set\", \"__current_case__\": 3}, \"sam_options\": {\"sam_options_selector\": \"no\", \"__current_case__\": 1}, \"save_mapping_stats\": \"true\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"analysis_type\": {\"analysis_type_selector\": \"simple\", \"__current_case__\": 0, \"presets\": \"no_presets\"}, \"library\": {\"type\": \"single\", \"__current_case__\": 0, \"input_1\": {\"__class__\": \"ConnectedValue\"}, \"unaligned_file\": false, \"aligned_file\": false}, \"reference_genome\": {\"source\": \"indexed\", \"__current_case__\": 0, \"index\": {\"__class__\": \"ConnectedValue\"}}, \"rg\": {\"rg_selector\": \"do_not_set\", \"__current_case__\": 3}, \"sam_options\": {\"sam_options_selector\": \"no\", \"__current_case__\": 1}, \"save_mapping_stats\": true, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.5.0+galaxy0",
             "type": "tool",
             "uuid": "6fd8444b-f305-4daa-a33a-5cb44e063f39",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "mapping stats",
@@ -298,10 +304,11 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"bed_file\": {\"__class__\": \"RuntimeValue\"}, \"flag\": {\"filter\": \"no\", \"__current_case__\": 0}, \"header\": \"-h\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"library\": \"\", \"mapq\": \"30\", \"outputtype\": \"bam\", \"possibly_select_inverse\": \"false\", \"read_group\": \"\", \"regions\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"bed_file\": {\"__class__\": \"RuntimeValue\"}, \"flag\": {\"filter\": \"no\", \"__current_case__\": 0}, \"header\": \"-h\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"library\": \"\", \"mapq\": \"30\", \"outputtype\": \"bam\", \"possibly_select_inverse\": false, \"read_group\": \"\", \"regions\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.8+galaxy1",
             "type": "tool",
             "uuid": "bb6e3ac5-cdb0-493c-b534-264ba530a711",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "filtered BAM",
@@ -417,10 +424,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"advanced_options\": {\"to_large\": \"false\", \"nolambda\": \"false\", \"spmr\": \"false\", \"ratio\": null, \"slocal\": null, \"llocal\": null, \"broad_options\": {\"broad_options_selector\": \"nobroad\", \"__current_case__\": 1, \"call_summits\": \"true\"}, \"keep_dup_options\": {\"keep_dup_options_selector\": \"1\", \"__current_case__\": 1}, \"d_min\": \"20\", \"buffer_size\": \"100000\"}, \"control\": {\"c_select\": \"No\", \"__current_case__\": 1}, \"cutoff_options\": {\"cutoff_options_selector\": \"qvalue\", \"__current_case__\": 1, \"qvalue\": \"0.05\"}, \"effective_genome_size_options\": {\"effective_genome_size_options_selector\": \"user_defined\", \"__current_case__\": 4, \"gsize\": {\"__class__\": \"ConnectedValue\"}}, \"format\": \"BAM\", \"nomodel_type\": {\"nomodel_type_selector\": \"nomodel\", \"__current_case__\": 1, \"extsize\": \"200\", \"shift\": \"0\"}, \"outputs\": [\"peaks_tabular\", \"summits\", \"bdg\", \"html\"], \"treatment\": {\"t_multi_select\": \"No\", \"__current_case__\": 0, \"input_treatment_file\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"advanced_options\": {\"to_large\": false, \"nolambda\": false, \"spmr\": false, \"ratio\": null, \"slocal\": null, \"llocal\": null, \"broad_options\": {\"broad_options_selector\": \"nobroad\", \"__current_case__\": 1, \"call_summits\": true}, \"keep_dup_options\": {\"keep_dup_options_selector\": \"1\", \"__current_case__\": 1}, \"d_min\": \"20\", \"buffer_size\": \"100000\"}, \"control\": {\"c_select\": \"No\", \"__current_case__\": 1}, \"cutoff_options\": {\"cutoff_options_selector\": \"qvalue\", \"__current_case__\": 1, \"qvalue\": \"0.05\"}, \"effective_genome_size_options\": {\"effective_genome_size_options_selector\": \"user_defined\", \"__current_case__\": 4, \"gsize\": {\"__class__\": \"ConnectedValue\"}}, \"format\": \"BAM\", \"nomodel_type\": {\"nomodel_type_selector\": \"nomodel\", \"__current_case__\": 1, \"extsize\": \"200\", \"shift\": \"0\"}, \"outputs\": [\"peaks_tabular\", \"summits\", \"bdg\", \"html\"], \"treatment\": {\"t_multi_select\": \"No\", \"__current_case__\": 0, \"input_treatment_file\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "2.2.7.1+galaxy0",
             "type": "tool",
             "uuid": "06ca906e-c512-4376-9ffc-8eb2b5774af1",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "MACS2 peaks",
@@ -490,6 +498,7 @@
             "tool_version": "1.1.1",
             "type": "tool",
             "uuid": "95832fa1-e96e-4867-8162-d1e39cb1dc46",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "MACS2 report",
@@ -536,6 +545,7 @@
             "tool_version": "1.1.1",
             "type": "tool",
             "uuid": "0fe57c5d-00a0-4cb6-9bac-97e6d03c6b76",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "coverage from MACS2",
@@ -598,10 +608,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"comment\": \"\", \"export\": \"true\", \"flat\": \"false\", \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"cutadapt\", \"__current_case__\": 5, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"bowtie2\", \"__current_case__\": 3, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"macs2\", \"__current_case__\": 16, \"input\": {\"__class__\": \"ConnectedValue\"}}}], \"saveLog\": \"false\", \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"comment\": \"\", \"export\": true, \"flat\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"cutadapt\", \"__current_case__\": 5, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"bowtie2\", \"__current_case__\": 3, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"macs2\", \"__current_case__\": 16, \"input\": {\"__class__\": \"ConnectedValue\"}}}], \"saveLog\": false, \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.11+galaxy1",
             "type": "tool",
             "uuid": "fb066848-43df-412a-9767-9613bac7d961",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "MultiQC on input dataset(s): Stats",


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/epigenetics/chipseq-sr**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.0+galaxy1` should be updated to `toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/4.4+galaxy0`

The workflow release number has been updated from 0.3 to 0.4.
