### PR TITLE
Updating workflows/data-fetching/parallel-accession-download from 0.1.5 to 0.1.6

### DIFF
--- a/workflows/data-fetching/parallel-accession-download/CHANGELOG.md
+++ b/workflows/data-fetching/parallel-accession-download/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.6] 2023-09-27
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/3.0.5+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/3.0.5+galaxy3`
+
 ## [0.1.5] 2023-09-12
 
 ### Automatic update

--- a/workflows/data-fetching/parallel-accession-download/parallel-accession-download.ga
+++ b/workflows/data-fetching/parallel-accession-download/parallel-accession-download.ga
@@ -15,7 +15,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.1.5",
+    "release": "0.1.6",
     "name": "Parallel Accession Download",
     "steps": {
         "0": {
@@ -131,7 +131,7 @@
         },
         "3": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/3.0.5+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/3.0.5+galaxy3",
             "errors": null,
             "id": 3,
             "input_connections": {
@@ -187,15 +187,15 @@
                     "output_name": "output_collection_other"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/3.0.5+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/3.0.5+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "4317d3cb6cba",
+                "changeset_revision": "734abc7ac21d",
                 "name": "sra_tools",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"adv\": {\"seq_defline\": \"@$sn/$ri\", \"minlen\": null, \"split\": \"--split-3\", \"skip_technical\": true}, \"input\": {\"input_select\": \"accession_number\", \"__current_case__\": 0, \"accession\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "3.0.5+galaxy1",
+            "tool_version": "3.0.5+galaxy3",
             "type": "tool",
             "uuid": "4d328e7b-df7d-4d3e-a60f-1ea12925f317",
             "when": null,


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/data-fetching/parallel-accession-download**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/3.0.5+galaxy1` should be updated to `toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/3.0.5+galaxy3`

The workflow release number has been updated from 0.1.5 to 0.1.6.
