### PR TITLE
Updating workflows/epigenetics/average-bigwig-between-replicates from 0.1 to 0.2

### DIFF
--- a/workflows/epigenetics/average-bigwig-between-replicates/CHANGELOG.md
+++ b/workflows/epigenetics/average-bigwig-between-replicates/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
 
+## [0.2] 2023-09-27
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bigwig_average/deeptools_bigwig_average/3.5.2+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bigwig_average/deeptools_bigwig_average/3.5.4+galaxy0`
+
 ## [0.1] 2023-09-22
 First release.

--- a/workflows/epigenetics/average-bigwig-between-replicates/average-bigwig-between-replicates.ga
+++ b/workflows/epigenetics/average-bigwig-between-replicates/average-bigwig-between-replicates.ga
@@ -10,7 +10,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.1",
+    "release": "0.2",
     "name": "Average Bigwig between replicates",
     "steps": {
         "0": {
@@ -29,20 +29,15 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "bottom": 351.6999969482422,
-                "height": 82.19999694824219,
-                "left": 647,
-                "right": 847,
-                "top": 269.5,
-                "width": 200,
-                "x": 647,
-                "y": 269.5
+                "left": 0,
+                "top": 0.0
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": \"\", \"collection_type\": \"list\"}",
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "45d1d287-ea71-4817-afd2-8ad89aedac46",
+            "when": null,
             "workflow_outputs": []
         },
         "1": {
@@ -61,20 +56,15 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "bottom": 456.3000030517578,
-                "height": 61.80000305175781,
-                "left": 663,
-                "right": 863,
-                "top": 394.5,
-                "width": 200,
-                "x": 663,
-                "y": 394.5
+                "left": 16,
+                "top": 125.0
             },
             "tool_id": null,
             "tool_state": "{\"parameter_type\": \"integer\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "ae41572a-bafb-40d4-8042-87f07552980f",
+            "when": null,
             "workflow_outputs": []
         },
         "2": {
@@ -88,12 +78,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Apply rules",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Apply rules",
             "outputs": [
@@ -103,14 +88,8 @@
                 }
             ],
             "position": {
-                "bottom": 374.1999969482422,
-                "height": 93.19999694824219,
-                "left": 901,
-                "right": 1101,
-                "top": 281,
-                "width": 200,
-                "x": 901,
-                "y": 281
+                "left": 254,
+                "top": 11.5
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -120,15 +99,16 @@
                 }
             },
             "tool_id": "__APPLY_RULES__",
-            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"rules\": {\"mapping\": [{\"collapsible_value\": {\"__class__\": \"RuntimeValue\"}, \"columns\": [1, 2], \"connectable\": true, \"editing\": false, \"is_workflow\": false, \"type\": \"list_identifiers\"}], \"rules\": [{\"collapsible_value\": {\"__class__\": \"RuntimeValue\"}, \"connectable\": true, \"error\": null, \"is_workflow\": false, \"type\": \"add_column_metadata\", \"value\": \"identifier0\", \"warn\": null}, {\"collapsible_value\": {\"__class__\": \"RuntimeValue\"}, \"connectable\": true, \"error\": null, \"expression\": \"^(.*)_([^_]*)$\", \"is_workflow\": false, \"replacement\": \"\\\\1\", \"target_column\": 0, \"type\": \"add_column_regex\", \"warn\": null}, {\"collapsible_value\": {\"__class__\": \"RuntimeValue\"}, \"connectable\": true, \"error\": null, \"expression\": \"^(.*)_([^_]*)$\", \"is_workflow\": false, \"replacement\": \"\\\\2\", \"target_column\": 0, \"type\": \"add_column_regex\", \"warn\": null}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"rules\": {\"mapping\": [{\"collapsible_value\": {\"__class__\": \"RuntimeValue\"}, \"columns\": [1, 2], \"connectable\": true, \"editing\": false, \"is_workflow\": false, \"type\": \"list_identifiers\"}], \"rules\": [{\"collapsible_value\": {\"__class__\": \"RuntimeValue\"}, \"connectable\": true, \"error\": null, \"is_workflow\": false, \"type\": \"add_column_metadata\", \"value\": \"identifier0\", \"warn\": null}, {\"collapsible_value\": {\"__class__\": \"RuntimeValue\"}, \"connectable\": true, \"error\": null, \"expression\": \"^(.*)_([^_]*)$\", \"is_workflow\": false, \"replacement\": \"\\\\1\", \"target_column\": 0, \"type\": \"add_column_regex\", \"warn\": null}, {\"collapsible_value\": {\"__class__\": \"RuntimeValue\"}, \"connectable\": true, \"error\": null, \"expression\": \"^(.*)_([^_]*)$\", \"is_workflow\": false, \"replacement\": \"\\\\2\", \"target_column\": 0, \"type\": \"add_column_regex\", \"warn\": null}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.0",
             "type": "tool",
             "uuid": "5532681e-f2b3-415c-87e2-71d5eb982d62",
+            "when": null,
             "workflow_outputs": []
         },
         "3": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bigwig_average/deeptools_bigwig_average/3.5.2+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bigwig_average/deeptools_bigwig_average/3.5.4+galaxy0",
             "errors": null,
             "id": 3,
             "input_connections": {
@@ -145,10 +125,6 @@
                 {
                     "description": "runtime parameter for tool bigwigAverage",
                     "name": "advancedOpt"
-                },
-                {
-                    "description": "runtime parameter for tool bigwigAverage",
-                    "name": "bigwigs"
                 }
             ],
             "label": "average bigwigs from different replicates",
@@ -160,27 +136,22 @@
                 }
             ],
             "position": {
-                "bottom": 557.3999938964844,
-                "height": 276.3999938964844,
-                "left": 1121,
-                "right": 1321,
-                "top": 281,
-                "width": 200,
-                "x": 1121,
-                "y": 281
+                "left": 474,
+                "top": 11.5
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bigwig_average/deeptools_bigwig_average/3.5.2+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bigwig_average/deeptools_bigwig_average/3.5.4+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "f6f246438eda",
+                "changeset_revision": "4a53856a5b85",
                 "name": "deeptools_bigwig_average",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"advancedOpt\": {\"showAdvancedOpt\": \"yes\", \"__current_case__\": 1, \"binSize\": {\"__class__\": \"ConnectedValue\"}, \"skipNAs\": \"false\", \"scaleFactors\": \"1\", \"blackListFileName\": {\"__class__\": \"RuntimeValue\"}}, \"bigwigs\": {\"__class__\": \"RuntimeValue\"}, \"outFileFormat\": \"bigwig\", \"region\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "3.5.2+galaxy0",
+            "tool_state": "{\"advancedOpt\": {\"showAdvancedOpt\": \"yes\", \"__current_case__\": 1, \"binSize\": {\"__class__\": \"ConnectedValue\"}, \"skipNAs\": false, \"scaleFactors\": \"1\", \"blackListFileName\": {\"__class__\": \"RuntimeValue\"}}, \"bigwigs\": {\"__class__\": \"ConnectedValue\"}, \"outFileFormat\": \"bigwig\", \"region\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "3.5.4+galaxy0",
             "type": "tool",
             "uuid": "f63daf4e-ce9f-4301-be74-e4c263b6e88b",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "average_bigwigs",


### PR DESCRIPTION
Hello! This is an automated update of the following workflow: **workflows/epigenetics/average-bigwig-between-replicates**. I created this PR because I think one or more of the component tools are out of date, i.e. there is a newer version available on the ToolShed.

By comparing with the latest versions available on the ToolShed, it seems the following tools are outdated:
* `toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bigwig_average/deeptools_bigwig_average/3.5.2+galaxy0` should be updated to `toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bigwig_average/deeptools_bigwig_average/3.5.4+galaxy0`

The workflow release number has been updated from 0.1 to 0.2.
