### PR TITLE
Bump pyyaml version

### DIFF
--- a/workflows/requirements.txt
+++ b/workflows/requirements.txt
@@ -1,4 +1,4 @@
 rocrate~=0.4.0
 planemo>=0.74.5
-pyyaml~=5.4.0
+pyyaml~=6.0.0
 requests~=2.26.0


### PR DESCRIPTION
With Python 3.10 or newer, [PyYAML 5.4 fails to install](https://github.com/yaml/pyyaml/issues/724) due to a problem with Cython. This is not affecting the CI now since the github workflows are using Python 3.7, but it will if the Python version is bumped in the future (also, it affects anyone who wants to install locally with a recent Python version).