### PR TITLE
MetaProSIP: add release

### DIFF
--- a/workflows/proteomics/openms-metaprosip/metaprosip.ga
+++ b/workflows/proteomics/openms-metaprosip/metaprosip.ga
@@ -10,6 +10,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
+    "release": "0.1",
     "name": "MetaProSIP OpenMS 2.8",
     "steps": {
         "0": {


### PR DESCRIPTION
https://github.com/galaxyproject/iwc/actions/runs/6208009347/job/16853948282 failed with
`Must set a release version in workflow file
'/home/runner/work/iwc/iwc/workflows/proteomics/openms-metaprosip/metaprosip.ga'`