### PR TITLE
added tag filtering for wf4. rearranged input ordering for wf1 and wf4

### DIFF
--- a/workflows/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/Assembly-Hifi-HiC-phasing-VGP4.ga
+++ b/workflows/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/Assembly-Hifi-HiC-phasing-VGP4.ga
@@ -19,8 +19,7 @@
     ],
     "format-version": "0.1",
     "license": "CC-BY-4.0",
-    "release": "0.1",
-    "name": "Assembly-Hifi-HiC-phasing-VGP4",
+    "name": "Assembly-Hifi-HiC-phasing-VGP4 (imported from URL)",
     "steps": {
         "0": {
             "annotation": "",
@@ -39,7 +38,7 @@
             "outputs": [],
             "position": {
                 "left": 0,
-                "top": 601.6407359730115
+                "top": 600.0407323343393
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\"}",
@@ -65,8 +64,8 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 360.5990149758079,
-                "top": 821.284901012074
+                "left": 52.58746337890625,
+                "top": 729.2749963613278
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": null}",
@@ -92,8 +91,8 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 627.265722101385,
-                "top": 928.5504890210702
+                "left": 127.26248168945312,
+                "top": 858.1499353261715
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": \"\"}",
@@ -119,11 +118,11 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 368.9063158902255,
-                "top": 1208.8194876006157
+                "left": 240.10000610351562,
+                "top": 1024.0124841542965
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"tag\": \"\"}",
+            "tool_state": "{\"optional\": false, \"tag\": \"genomescope_params\"}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "0735f7ce-74e8-4ae0-8142-e6d2fd89c89e",
@@ -146,11 +145,11 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 377.2136225844875,
-                "top": 1460.503688003078
+                "left": 305.2124938964844,
+                "top": 1224.7852478027344
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"tag\": \"\"}",
+            "tool_state": "{\"optional\": false, \"tag\": \"genomescope_summ\"}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "1844cbb3-ba5f-4997-a3cd-ce70f4570a99",
@@ -173,11 +172,11 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 1730.5817343971949,
-                "top": 419.62677926728225
+                "left": 338.18748705505163,
+                "top": 1393.2250061035156
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"tag\": \"\"}",
+            "tool_state": "{\"optional\": false, \"tag\": \"meryl_db\"}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "fcb0f86e-455a-4a6e-9c86-d8994caf0493",
@@ -185,10 +184,43 @@
             "workflow_outputs": []
         },
         "6": {
-            "annotation": "Defaults to 37 if not specified. For genomes much larger than human, applying -f38 or even -f39 is preferred to save memory on k-mer counting.",
+            "annotation": "",
             "content_id": null,
             "errors": null,
             "id": 6,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "SAK input file"
+                }
+            ],
+            "label": "SAK input file",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 358.20002636559843,
+                "top": 1550.8499755859375
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": true, \"tag\": \"\"}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "557a2e2b-008c-4566-836a-6509950aa85b",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "19782069-2309-495f-a249-75893193f27a"
+                }
+            ]
+        },
+        "7": {
+            "annotation": "Defaults to 37 if not specified. For genomes much larger than human, applying -f38 or even -f39 is preferred to save memory on k-mer counting.",
+            "content_id": null,
+            "errors": null,
+            "id": 7,
             "input_connections": {},
             "inputs": [
                 {
@@ -201,7 +233,7 @@
             "outputs": [],
             "position": {
                 "left": 906.03125,
-                "top": 1704.0625
+                "top": 1702.4624963613278
             },
             "tool_id": null,
             "tool_state": "{\"default\": 37, \"parameter_type\": \"integer\", \"optional\": true}",
@@ -213,40 +245,7 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "105bb189-a2d4-4cfc-8cb8-39ab70af0277"
-                }
-            ]
-        },
-        "7": {
-            "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 7,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
-                    "name": "SAK input file"
-                }
-            ],
-            "label": "SAK input file",
-            "name": "Input dataset",
-            "outputs": [],
-            "position": {
-                "left": 1785.3040059407554,
-                "top": 1450.859578450521
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": true, \"tag\": \"\"}",
-            "tool_version": null,
-            "type": "data_input",
-            "uuid": "557a2e2b-008c-4566-836a-6509950aa85b",
-            "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "2a6cc6ed-3248-4048-9208-a683e43f1c0f"
+                    "uuid": "de7c94f5-9275-4ec4-91f1-2ac4f486ab75"
                 }
             ]
         },
@@ -267,7 +266,7 @@
             "outputs": [],
             "position": {
                 "left": 3629.8615195534453,
-                "top": 1523.559107924953
+                "top": 1521.9591042862808
             },
             "tool_id": null,
             "tool_state": "{\"default\": \"Hap1\", \"parameter_type\": \"text\", \"optional\": true}",
@@ -279,7 +278,7 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "2eef5014-6358-446d-9d97-4a9b43f83e75"
+                    "uuid": "423f5dec-facb-45ab-a662-f07d53103ae9"
                 }
             ]
         },
@@ -300,7 +299,7 @@
             "outputs": [],
             "position": {
                 "left": 3641.8580719918923,
-                "top": 1674.3751294685135
+                "top": 1672.7751258298413
             },
             "tool_id": null,
             "tool_state": "{\"default\": \"Hap2\", \"parameter_type\": \"text\", \"optional\": true}",
@@ -312,7 +311,7 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "5f6be88c-dc8a-40ce-8865-c36f26d826d7"
+                    "uuid": "d85aabed-d996-4a80-bb8b-cbbf191a3e0a"
                 }
             ]
         },
@@ -342,7 +341,7 @@
             ],
             "position": {
                 "left": 476.8230091441762,
-                "top": 589.340302438447
+                "top": 587.7402987997748
             },
             "post_job_actions": {
                 "HideDatasetActionreport": {
@@ -407,7 +406,7 @@
             ],
             "position": {
                 "left": 623.1337807395242,
-                "top": 1208.8194876006157
+                "top": 1207.2194839619435
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -452,7 +451,7 @@
             ],
             "position": {
                 "left": 616.7448795203007,
-                "top": 1458.837058327415
+                "top": 1457.2370546887428
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -501,7 +500,7 @@
             ],
             "position": {
                 "left": 1017.3959674257222,
-                "top": 787.7344304865057
+                "top": 786.1344268478335
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.11+galaxy1",
@@ -540,7 +539,7 @@
             ],
             "position": {
                 "left": 875.2518393776635,
-                "top": 1212.2222900390627
+                "top": 1210.6222864003905
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -579,7 +578,7 @@
             ],
             "position": {
                 "left": 872.2483548251066,
-                "top": 1459.5748438979645
+                "top": 1457.9748402592923
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -624,7 +623,7 @@
             ],
             "position": {
                 "left": 1109.154712670362,
-                "top": 1218.6660569445944
+                "top": 1217.0660533059222
             },
             "post_job_actions": {
                 "RenameDatasetActioninteger_param": {
@@ -665,7 +664,7 @@
             ],
             "position": {
                 "left": 1116.4237051299124,
-                "top": 1467.821248372396
+                "top": 1466.2212447337238
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -693,7 +692,7 @@
                     "output_name": "integer_param"
                 },
                 "filter_bits": {
-                    "id": 6,
+                    "id": 7,
                     "output_name": "output"
                 },
                 "hic_partition|h1": {
@@ -744,7 +743,7 @@
             ],
             "position": {
                 "left": 1650.198023834119,
-                "top": 729.0981977671058
+                "top": 727.4981941284336
             },
             "post_job_actions": {
                 "HideDatasetActionhic_acontig_graph": {
@@ -829,7 +828,7 @@
             ],
             "position": {
                 "left": 1364.3925291119203,
-                "top": 1599.019091057055
+                "top": 1597.4190874183828
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -873,7 +872,7 @@
             ],
             "position": {
                 "left": 2078.7762035023084,
-                "top": 3.9236357717803685
+                "top": 2.3236321331081626
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -922,7 +921,7 @@
                     "output_name": "hic_balanced_contig_hap1_graph"
                 },
                 "mode_condition|swiss_army_knife": {
-                    "id": 7,
+                    "id": 6,
                     "output_name": "output"
                 }
             },
@@ -937,7 +936,7 @@
             ],
             "position": {
                 "left": 2233.6199904933123,
-                "top": 369.32299064867425
+                "top": 367.72298701000204
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -971,7 +970,7 @@
                     "output_name": "hic_balanced_contig_hap2_graph"
                 },
                 "mode_condition|swiss_army_knife": {
-                    "id": 7,
+                    "id": 6,
                     "output_name": "output"
                 }
             },
@@ -986,7 +985,7 @@
             ],
             "position": {
                 "left": 2240.694704922763,
-                "top": 636.0591079249527
+                "top": 634.4591042862805
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1035,7 +1034,7 @@
                 }
             ],
             "position": {
-                "left": 2414.062661835642,
+                "left": 2480.4624938964844,
                 "top": 0
             },
             "post_job_actions": {
@@ -1096,7 +1095,7 @@
             ],
             "position": {
                 "left": 2310.4689858176494,
-                "top": 961.6668701171877
+                "top": 960.0668664785155
             },
             "post_job_actions": {
                 "TagDatasetActionoutfile": {
@@ -1143,7 +1142,7 @@
             ],
             "position": {
                 "left": 2835.987005198547,
-                "top": 1467.2530248543883
+                "top": 1465.653021215716
             },
             "post_job_actions": {
                 "RenameDatasetActionstats": {
@@ -1197,7 +1196,7 @@
             ],
             "position": {
                 "left": 2836.927541097006,
-                "top": 1803.8369843454075
+                "top": 1802.2369807067353
             },
             "post_job_actions": {
                 "RenameDatasetActionstats": {
@@ -1251,7 +1250,7 @@
             ],
             "position": {
                 "left": 1645.6251433401399,
-                "top": 1621.8578916607485
+                "top": 1620.2578880220763
             },
             "post_job_actions": {
                 "RenameDatasetActioninteger_param": {
@@ -1304,8 +1303,8 @@
                 }
             ],
             "position": {
-                "left": 2487.5695199677443,
-                "top": 342.17880711411
+                "left": 2490.762481689453,
+                "top": 332.57501220703125
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -1365,7 +1364,7 @@
             ],
             "position": {
                 "left": 2490.9810152920813,
-                "top": 512.5868363813922
+                "top": 510.98683274272
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -1419,7 +1418,7 @@
             "outputs": [],
             "position": {
                 "left": 3927.4223327636723,
-                "top": 833.7675152402937
+                "top": 832.1675116016215
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -1794,7 +1793,7 @@
             "outputs": [],
             "position": {
                 "left": 3922.431136622574,
-                "top": 1057.8214703184187
+                "top": 1056.2214666797465
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -2179,7 +2178,7 @@
             ],
             "position": {
                 "left": 2827.101065895775,
-                "top": 1285.946470318419
+                "top": 1284.3464666797468
             },
             "post_job_actions": {
                 "RenameDatasetActionstats": {
@@ -2237,7 +2236,7 @@
             ],
             "position": {
                 "left": 2835.8424100008883,
-                "top": 1631.1285770300665
+                "top": 1629.5285733913943
             },
             "post_job_actions": {
                 "RenameDatasetActionstats": {
@@ -2303,7 +2302,7 @@
             ],
             "position": {
                 "left": 3074.6484375,
-                "top": 65.95703125
+                "top": 64.3570276113278
             },
             "post_job_actions": {
                 "TagDatasetActionbusco_missing": {
@@ -2349,14 +2348,14 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Busco Summary Image Hap1",
-                    "output_name": "summary_image",
-                    "uuid": "cfac3083-4c1e-4bb4-91a5-eba5d19f2757"
-                },
-                {
                     "label": "Busco Summary Hap1",
                     "output_name": "busco_sum",
                     "uuid": "bd6443ea-5266-4dfc-8f1e-aded27317da8"
+                },
+                {
+                    "label": "Busco Summary Image Hap1",
+                    "output_name": "summary_image",
+                    "uuid": "cfac3083-4c1e-4bb4-91a5-eba5d19f2757"
                 }
             ]
         },
@@ -2402,7 +2401,7 @@
             ],
             "position": {
                 "left": 2855.921875,
-                "top": 789.0859375
+                "top": 787.4859338613278
             },
             "post_job_actions": {
                 "HideDatasetActionlog_file": {
@@ -2507,7 +2506,7 @@
             ],
             "position": {
                 "left": 3079.7265625,
-                "top": 499.28515625
+                "top": 497.6851526113278
             },
             "post_job_actions": {
                 "TagDatasetActionbusco_missing": {
@@ -2553,14 +2552,14 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Busco Summary Hap2",
-                    "output_name": "busco_sum",
-                    "uuid": "bf7e959c-5252-467e-bb58-2b8cabbd0f3b"
-                },
-                {
                     "label": "Busco Summary Image Hap2",
                     "output_name": "summary_image",
                     "uuid": "84725fc4-3480-44a2-abc0-abc8f54addb1"
+                },
+                {
+                    "label": "Busco Summary Hap2",
+                    "output_name": "busco_sum",
+                    "uuid": "bf7e959c-5252-467e-bb58-2b8cabbd0f3b"
                 }
             ]
         },
@@ -2595,7 +2594,7 @@
             "outputs": [],
             "position": {
                 "left": 4346.40625,
-                "top": 866.4609375
+                "top": 864.8609338613278
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -3108,16 +3107,6 @@
                     "label": "Size Plot",
                     "output_name": "Size Plot",
                     "uuid": "03a0d2a8-c2d5-4ca7-80fe-7d04d1c4894a"
-                },
-                {
-                    "label": null,
-                    "output_name": "2:output",
-                    "uuid": "8614c252-637a-48dc-a751-9a3fea85b376"
-                },
-                {
-                    "label": null,
-                    "output_name": "3:output",
-                    "uuid": "b1b37b5e-092a-4bcb-87ab-f8b74abe1ebb"
                 }
             ]
         },
@@ -3143,7 +3132,7 @@
             ],
             "position": {
                 "left": 3176.285044352214,
-                "top": 1140.6685569069605
+                "top": 1139.0685532682883
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -3188,7 +3177,7 @@
             ],
             "position": {
                 "left": 3177.439533580434,
-                "top": 1537.5955292672825
+                "top": 1535.9955256286103
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -3233,7 +3222,7 @@
             ],
             "position": {
                 "left": 3407.691331343218,
-                "top": 1368.6198841441765
+                "top": 1367.0198805055043
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -3276,7 +3265,7 @@
             ],
             "position": {
                 "left": 3649.617149584222,
-                "top": 1140.9336085464017
+                "top": 1139.3336049077295
             },
             "post_job_actions": {
                 "TagDatasetActionout_file1": {
@@ -3306,6 +3295,6 @@
         "VGP",
         "Reviewed"
     ],
-    "uuid": "e6c42d60-3c0c-4c40-890a-0f5db9962b30",
-    "version": 17
+    "uuid": "634604bc-4a32-4c35-9953-81b4f44751d9",
+    "version": 4
 }

--- a/workflows/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/Assembly-Hifi-HiC-phasing-VGP4.ga
+++ b/workflows/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/Assembly-Hifi-HiC-phasing-VGP4.ga
@@ -19,7 +19,7 @@
     ],
     "format-version": "0.1",
     "license": "CC-BY-4.0",
-    "release": "0.2"
+    "release": "0.1.2",
     "name": "Assembly-Hifi-HiC-phasing-VGP4",
     "steps": {
         "0": {

--- a/workflows/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/Assembly-Hifi-HiC-phasing-VGP4.ga
+++ b/workflows/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/Assembly-Hifi-HiC-phasing-VGP4.ga
@@ -19,7 +19,8 @@
     ],
     "format-version": "0.1",
     "license": "CC-BY-4.0",
-    "name": "Assembly-Hifi-HiC-phasing-VGP4 (imported from URL)",
+    "release": "0.2"
+    "name": "Assembly-Hifi-HiC-phasing-VGP4",
     "steps": {
         "0": {
             "annotation": "",

--- a/workflows/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/CHANGELOG.md
+++ b/workflows/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2023-11-07
+
+- Added input filtering based on tags. Rearranged input ordering.
+
 ## [0.1] - 2023-09-27
 
 Creation of workflow for HiFi assembly with Hi-C phasing. 

--- a/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/CHANGELOG.md
+++ b/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2023-11-07
+### Changed
+- Added tag filtering for inputs
+
 ## [0.1.1] - 2023-10-30
 ### Changed
 - Names of the workflow and viles for consistency with other VGP workflows

--- a/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1.ga
+++ b/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1.ga
@@ -14,7 +14,7 @@
     ],
     "format-version": "0.1",
     "license": "CC-BY-4.0",
-    "name": "kmer-profiling-hifi-VGP1 (imported from uploaded file)",
+    "name": "kmer-profiling-hifi-VGP1",
     "steps": {
         "0": {
             "annotation": "",

--- a/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1.ga
+++ b/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1.ga
@@ -14,7 +14,7 @@
     ],
     "format-version": "0.1",
     "license": "CC-BY-4.0",
-    "release": "0.2",
+    "release": "0.1.2",
     "name": "kmer-profiling-hifi-VGP1",
     "steps": {
         "0": {

--- a/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1.ga
+++ b/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1.ga
@@ -14,6 +14,7 @@
     ],
     "format-version": "0.1",
     "license": "CC-BY-4.0",
+    "release": "0.2",
     "name": "kmer-profiling-hifi-VGP1",
     "steps": {
         "0": {

--- a/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1.ga
+++ b/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1.ga
@@ -14,8 +14,7 @@
     ],
     "format-version": "0.1",
     "license": "CC-BY-4.0",
-    "release": "0.1.1",
-    "name": "kmer-profiling-hifi-VGP1",
+    "name": "kmer-profiling-hifi-VGP1 (imported from uploaded file)",
     "steps": {
         "0": {
             "annotation": "",
@@ -33,8 +32,8 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "left": 25.07814953674619,
-                "top": 0
+                "left": 0,
+                "top": 15.427657616021285
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": \"\", \"collection_type\": \"list\"}",
@@ -60,8 +59,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 0,
-                "top": 290.01566057828205
+                "left": 22.121832152706936,
+                "top": 151.04017592656817
             },
             "tool_id": null,
             "tool_state": "{\"default\": 21, \"parameter_type\": \"integer\", \"optional\": true}",
@@ -87,8 +86,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 16.37496564855541,
-                "top": 493.99999877316264
+                "left": 65.68433215270693,
+                "top": 283.0276637195369
             },
             "tool_id": null,
             "tool_state": "{\"default\": 2, \"parameter_type\": \"integer\", \"optional\": true}",
@@ -123,8 +122,8 @@
                 }
             ],
             "position": {
-                "left": 326.0155759265076,
-                "top": 0.9843835878612026
+                "left": 300.9374263897614,
+                "top": 16.412041203882488
             },
             "post_job_actions": {
                 "HideDatasetActionread_db": {
@@ -168,8 +167,8 @@
                 }
             ],
             "position": {
-                "left": 594.7968602779522,
-                "top": 127.82813604153586
+                "left": 569.718710741206,
+                "top": 143.25579365755715
             },
             "post_job_actions": {
                 "TagDatasetActionread_db": {
@@ -221,8 +220,8 @@
                 }
             ],
             "position": {
-                "left": 884.453149536746,
-                "top": 76.92187131948805
+                "left": 859.375,
+                "top": 92.34016036987308
             },
             "post_job_actions": {
                 "HideDatasetActionread_db_hist": {
@@ -298,8 +297,8 @@
                 }
             ],
             "position": {
-                "left": 1172.0166187911489,
-                "top": 96.88919830322266
+                "left": 1198.9374694824219,
+                "top": 0.0
             },
             "post_job_actions": {
                 "TagDatasetActionlinear_plot": {
@@ -366,21 +365,6 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "GenomeScope Model Parameters",
-                    "output_name": "model_params",
-                    "uuid": "cb88b945-413c-4e2d-81a9-dd838df902ff"
-                },
-                {
-                    "label": "GenomeScope log plot",
-                    "output_name": "log_plot",
-                    "uuid": "988e2189-d5f2-4e9e-8fc2-4434e68e8501"
-                },
-                {
-                    "label": "GenomeScope linear plot",
-                    "output_name": "linear_plot",
-                    "uuid": "57230be4-36d5-4307-b4b0-b8a73f6800ce"
-                },
-                {
                     "label": "GenomeScope transformed linear plot",
                     "output_name": "transformed_linear_plot",
                     "uuid": "48e2c4c5-8658-44e6-8981-673a2f1f719e"
@@ -394,6 +378,21 @@
                     "label": "GenomeScope summary",
                     "output_name": "summary",
                     "uuid": "b74004e1-4f4b-4f43-a9f0-2a7a0a70ca1d"
+                },
+                {
+                    "label": "GenomeScope Model Parameters",
+                    "output_name": "model_params",
+                    "uuid": "cb88b945-413c-4e2d-81a9-dd838df902ff"
+                },
+                {
+                    "label": "GenomeScope log plot",
+                    "output_name": "log_plot",
+                    "uuid": "988e2189-d5f2-4e9e-8fc2-4434e68e8501"
+                },
+                {
+                    "label": "GenomeScope linear plot",
+                    "output_name": "linear_plot",
+                    "uuid": "57230be4-36d5-4307-b4b0-b8a73f6800ce"
                 }
             ]
         }
@@ -402,6 +401,6 @@
         "Reviewed",
         "VGP"
     ],
-    "uuid": "3553367b-7f97-41e7-aa93-5856b21770df",
-    "version": 4
+    "uuid": "a3ef9c73-c661-46af-bfde-3daa97d8b473",
+    "version": 2
 }


### PR DESCRIPTION
Adds tag filtering to wf4 to automatically select necessary genomescope and meryl outputs of wf1