### PR TITLE
Fix tests

### DIFF
--- a/workflows/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/Assembly-Hifi-HiC-phasing-VGP4-tests.yml
+++ b/workflows/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/Assembly-Hifi-HiC-phasing-VGP4-tests.yml
@@ -33,8 +33,8 @@
     Name for Haplotype 2: Hap2
   outputs:
     Hifiasm HiC hap1:
-      assert: 
-        has_n_line:
+      asserts:
+        has_n_lines:
           n: 168
     Estimated Genome size: 2288021
     Busco Summary Hap1:
@@ -47,8 +47,8 @@
           value: 65000
           delta: 10000
     usable hap1 gfa:
-      assert: 
-        has_n_line:
+      asserts:
+        has_n_lines:
           n: 173
     Assembly statistics fir Hap1 and Hap2:
       asserts:

--- a/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1-tests.yml
+++ b/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1-tests.yml
@@ -33,15 +33,15 @@
       delta: 10000
     GenomeScope summary:
       asserts:
-        has_text:
+        - has_text:
             text: '27,842 bp'
-        has_text:
+        - has_text:
             text: '35,913 bp'
     GenomeScope Model Parameters:
       asserts:
-        has_text:
+        - has_text:
             text: '0.0918418396430493'
-        has_text:
+        - has_text:
             text: '27.44263'
     Merged Meryl Database:
       asserts:

--- a/workflows/VGP-assembly-v2/kmer-profiling-hifi-trio-VGP2/kmer-profiling-hifi-trio-VGP2-tests.yml
+++ b/workflows/VGP-assembly-v2/kmer-profiling-hifi-trio-VGP2/kmer-profiling-hifi-trio-VGP2-tests.yml
@@ -53,9 +53,9 @@
     GenomeScope summary (child):
       asserts:
         - has_text:
-          text: '39,419 bp'
+            text: '39,419 bp'
         - has_text:
-          text: '43,763 bp'
+            text: '43,763 bp'
     'Meryl database : Child':
       asserts:
         has_size:

--- a/workflows/VGP-assembly-v2/kmer-profiling-hifi-trio-VGP2/kmer-profiling-hifi-trio-VGP2-tests.yml
+++ b/workflows/VGP-assembly-v2/kmer-profiling-hifi-trio-VGP2/kmer-profiling-hifi-trio-VGP2-tests.yml
@@ -52,9 +52,9 @@
       delta: 15000
     GenomeScope summary (child):
       asserts:
-        has_text:
+        - has_text:
           text: '39,419 bp'
-        has_text:
+        - has_text:
           text: '43,763 bp'
     'Meryl database : Child':
       asserts:

--- a/workflows/computational-chemistry/fragment-based-docking-scoring/fragment-based-docking-scoring-tests.yml
+++ b/workflows/computational-chemistry/fragment-based-docking-scoring/fragment-based-docking-scoring-tests.yml
@@ -22,7 +22,7 @@
   outputs:
     Scored and filtered poses:
       class: File
-      assert:
+      asserts:
         has_line:
           line: "$$$$"
           n: 4

--- a/workflows/computational-chemistry/fragment-based-docking-scoring/fragment-based-docking-scoring-tests.yml
+++ b/workflows/computational-chemistry/fragment-based-docking-scoring/fragment-based-docking-scoring-tests.yml
@@ -23,8 +23,9 @@
     Scored and filtered poses:
       class: File
       assert:
-        has_line: "$$$$"
-        n: 4
-      assert:
-        has_test: "SuCOS_Score"
-        n: 4
+        has_line:
+          line: "$$$$"
+          n: 4
+        has_text:
+          text: "SuCOS_Score"
+          n: 4

--- a/workflows/computational-chemistry/gromacs-dctmd/gromacs-dctmd-tests.yml
+++ b/workflows/computational-chemistry/gromacs-dctmd/gromacs-dctmd-tests.yml
@@ -21,16 +21,21 @@
     XTC files:
       element_tests:
         split_file_000000.txt:
-          assert:
-            has_size: 138900
-            delta: 500
+          asserts:
+            has_size:
+              value: 138900
+              delta: 500
     Free energy data:
       class: 'File'
-      assert:
-        has_n_lines: 101
-        has_n_columns: 5
+      asserts:
+        has_n_lines:
+          n: 101
+        has_n_columns:
+          n: 5
     Friction data:
       class: 'File'
-      assert:
-        has_n_lines: 101
-        has_n_columns: 5
+      asserts:
+        has_n_lines:
+          n: 101
+        has_n_columns:
+          n: 5

--- a/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa-tests.yml
+++ b/workflows/computational-chemistry/gromacs-mmgbsa/gromacs-mmgbsa-tests.yml
@@ -16,17 +16,21 @@
   outputs:
     MMGBSA free energy:
       class: 'File'
-      assert:
-        has_n_lines: 2
+      asserts:
+        has_n_lines:
+          n: 2
     MMGBSA statistics:
       element_tests:
         split_file_000000.txt:
-          assert:
-            has_text: 'DELTA TOTAL'
-            has_text: 'Generalized Born ESURF calculated using LCPO'
+          asserts:
+            - has_text:
+                text: 'DELTA TOTAL'
+            - has_text:
+                text: 'Generalized Born ESURF calculated using LCPO'
     XTC files:
       element_tests:
         split_file_000000.txt:
-          assert:
-            has_size: 138900
-            delta: 500
+          asserts:
+            has_size:
+              value: 138900
+              delta: 500

--- a/workflows/data-fetching/parallel-accession-download/parallel-accession-download-tests.yml
+++ b/workflows/data-fetching/parallel-accession-download/parallel-accession-download-tests.yml
@@ -20,7 +20,7 @@
     Paired End Reads:
       element_tests:
         SRR11953971:
-          elements:
+          element_tests:
             forward:
               file: test-data/SRR11953971_1_head.fastq
               decompress: true

--- a/workflows/epigenetics/atacseq/atacseq-tests.yml
+++ b/workflows/epigenetics/atacseq/atacseq-tests.yml
@@ -24,12 +24,12 @@
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
-            - that: "has_text"
-              text: "32872 (11.70%) aligned concordantly 0 times"
-            - that: "has_text"
-              text: "108014 (38.44%) aligned concordantly exactly 1 time"
-            - that: "has_text"
-              text: "140078 (49.86%) aligned concordantly >1 times"
+            - has_text:
+                text: "32872 (11.70%) aligned concordantly 0 times"
+            - has_text:
+                text: "108014 (38.44%) aligned concordantly exactly 1 time"
+            - has_text:
+                text: "140078 (49.86%) aligned concordantly >1 times"
     MarkDuplicates metrics:
       element_tests:
         SRR891268_chr22_enriched:
@@ -60,10 +60,10 @@
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
-            - that: "has_text"
-              text: "# tag size is determined as 47 bps"
-            - that: "has_text"
-              text: "# total tags in treatment: 234432"
+            - has_text:
+                text: "# tag size is determined as 47 bps"
+            - has_text:
+                text: "# total tags in treatment: 234432"
     Coverage from MACS2 (bigwig):
       element_tests:
         SRR891268_chr22_enriched:
@@ -125,9 +125,9 @@
               n: 4
     MultiQC webpage:
           asserts:
-            - that: "has_text"
-              text: "<a href=\"#cutadapt_filtered_reads\" class=\"nav-l2\">Filtered Reads</a>"
-            - that: "has_text"
-              text: "<td>% Aligned</td>"
-            - that: "has_text"
-              text: "<td>% BP Trimmed</td>"
+            - has_text:
+                text: "<a href=\"#cutadapt_filtered_reads\" class=\"nav-l2\">Filtered Reads</a>"
+            - has_text:
+                text: "<td>% Aligned</td>"
+            - has_text:
+                text: "<td>% BP Trimmed</td>"

--- a/workflows/epigenetics/chipseq-pe/chipseq-pe-tests.yml
+++ b/workflows/epigenetics/chipseq-pe/chipseq-pe-tests.yml
@@ -24,12 +24,12 @@
   outputs:
     MultiQC webpage:
       asserts:
-        - that: "has_text"
-          text: "wt_H3K4me3"
-        - that: "has_text"
-          text: <a href="#cutadapt_filtered_reads" class="nav-l2">Filtered Reads</a>
-        - that: "has_text"
-          text: <a href="#bowtie2" class="nav-l1">Bowtie 2 / HiSAT2</a>
+        - has_text:
+            text: "wt_H3K4me3"
+        - has_text:
+            text: <a href="#cutadapt_filtered_reads" class="nav-l2">Filtered Reads</a>
+        - has_text:
+            text: <a href="#bowtie2" class="nav-l1">Bowtie 2 / HiSAT2</a>
     'MultiQC on input dataset(s): Stats':
       element_tests:
         bowtie2:
@@ -69,12 +69,12 @@
       element_tests:
         wt_H3K4me3:
           asserts:
-            - that: "has_text"
-              text: "# effective genome size = 1.87e+09"
-            - that: "has_text"
-              text: "# fragment size is determined as 201 bps"
-            - that: "has_text"
-              text: "# fragments after filtering in treatment: 41787"
+            - has_text:
+                text: "# effective genome size = 1.87e+09"
+            - has_text:
+                text: "# fragment size is determined as 201 bps"
+            - has_text:
+                text: "# fragments after filtering in treatment: 41787"
     MACS2 narrowPeak:
       element_tests:
         wt_H3K4me3:
@@ -85,12 +85,12 @@
       element_tests:
         wt_H3K4me3:
           asserts:
-            - that: "has_text"
-              text: "# effective genome size = 1.87e+09"
-            - that: "has_text"
-              text: "# fragment size is determined as 201 bps"
-            - that: "has_text"
-              text: "# fragments after filtering in treatment: 41787"
+            - has_text:
+                text: "# effective genome size = 1.87e+09"
+            - has_text:
+                text: "# fragment size is determined as 201 bps"
+            - has_text:
+                text: "# fragments after filtering in treatment: 41787"
     coverage from MACS2:
       element_tests:
         wt_H3K4me3:
@@ -102,9 +102,9 @@
       element_tests:
         wt_H3K4me3:
             asserts:
-            - that: "has_text"
-              text: "1622 (3.50%) aligned concordantly 0 times"
-            - that: "has_text"
-              text: "39144 (84.53%) aligned concordantly exactly 1 time"
-            - that: "has_text"
-              text: "5541 (11.97%) aligned concordantly >1 times"
+            - has_text:
+                text: "1622 (3.50%) aligned concordantly 0 times"
+            - has_text:
+                text: "39144 (84.53%) aligned concordantly exactly 1 time"
+            - has_text:
+                text: "5541 (11.97%) aligned concordantly >1 times"

--- a/workflows/epigenetics/chipseq-sr/chipseq-sr-tests.yml
+++ b/workflows/epigenetics/chipseq-sr/chipseq-sr-tests.yml
@@ -15,12 +15,12 @@
   outputs:
     MultiQC webpage:
       asserts:
-        - that: "has_text"
-          text: "wt_H3K4me3"
-        - that: "has_text"
-          text: <a href="#cutadapt_filtered_reads" class="nav-l2">Filtered Reads</a>
-        - that: "has_text"
-          text: <a href="#bowtie2" class="nav-l1">Bowtie 2 / HiSAT2</a>
+        - has_text:
+            text: "wt_H3K4me3"
+        - has_text:
+            text: <a href="#cutadapt_filtered_reads" class="nav-l2">Filtered Reads</a>
+        - has_text:
+            text: <a href="#bowtie2" class="nav-l1">Bowtie 2 / HiSAT2</a>
     'MultiQC on input dataset(s): Stats':
       element_tests:
         bowtie2:
@@ -60,12 +60,12 @@
       element_tests:
         wt_H3K4me3:
           asserts:
-            - that: "has_text"
-              text: "# effective genome size = 1.87e+09"
-            - that: "has_text"
-              text: "# d = 200"
-            - that: "has_text"
-              text: "# tags after filtering in treatment: 44034"
+            - has_text:
+                text: "# effective genome size = 1.87e+09"
+            - has_text:
+                text: "# d = 200"
+            - has_text:
+                text: "# tags after filtering in treatment: 44034"
     MACS2 narrowPeak:
       element_tests:
         wt_H3K4me3:
@@ -76,12 +76,12 @@
       element_tests:
         wt_H3K4me3:
           asserts:
-            - that: "has_text"
-              text: "# effective genome size = 1.87e+09"
-            - that: "has_text"
-              text: "# d = 200"
-            - that: "has_text"
-              text: "# tags after filtering in treatment: 44034"
+            - has_text:
+                text: "# effective genome size = 1.87e+09"
+            - has_text:
+                text: "# d = 200"
+            - has_text:
+                text: "# tags after filtering in treatment: 44034"
     coverage from MACS2:
       element_tests:
         wt_H3K4me3:
@@ -93,9 +93,9 @@
       element_tests:
         wt_H3K4me3:
             asserts:
-            - that: "has_text"
-              text: "49251 reads; of these:"
-            - that: "has_text"
-              text: "43506 (88.34%) aligned exactly 1 time"
-            - that: "has_text"
-              text: "98.38% overall alignment rate"
+            - has_text:
+                text: "49251 reads; of these:"
+            - has_text:
+                text: "43506 (88.34%) aligned exactly 1 time"
+            - has_text:
+                text: "98.38% overall alignment rate"

--- a/workflows/epigenetics/cutandrun/cutandrun-tests.yml
+++ b/workflows/epigenetics/cutandrun/cutandrun-tests.yml
@@ -46,13 +46,15 @@
     MACS2 summits:
       element_tests:
         Rep1:
-          has_n_lines:
-            n: 1856
+          asserts:
+            has_n_lines:
+              n: 1856
     MACS2 narrowPeak:
       element_tests:
         Rep1:
-          has_n_lines:
-            n: 1856
+          asserts:
+            has_n_lines:
+              n: 1856
     MACS2 peaks xls:
       element_tests:
         Rep1:
@@ -109,13 +111,15 @@
     MACS2 summits:
       element_tests:
         Rep1:
-          has_n_lines:
-            n: 3261
+          asserts:
+            has_n_lines:
+              n: 3261
     MACS2 narrowPeak:
       element_tests:
         Rep1:
-          has_n_lines:
-            n: 3261
+          asserts:
+            has_n_lines:
+              n: 3261
     MACS2 peaks xls:
       element_tests:
         Rep1:

--- a/workflows/epigenetics/hic-hicup-cooler/chic-fastq-to-cool-hicup-cooler-tests.yml
+++ b/workflows/epigenetics/hic-hicup-cooler/chic-fastq-to-cool-hicup-cooler-tests.yml
@@ -43,22 +43,22 @@
       element_tests:
         test_dataset:
           asserts:
-            - that: "has_line"
-              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
-            - that: "has_line"
-              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
-            - that: "has_line"
-              line: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
+            - has_line:
+                line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
+            - has_line:
+                line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
+            - has_line:
+                line: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
     valid pairs in juicebox format MAPQ filtered:
       element_tests:
         test_dataset:
           asserts:
-            - that: "has_line"
-              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
-            - that: "has_line"
-              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
-            - that: "not_has_text"
-              text: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
+            - has_line:
+                line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
+            - has_line:
+                line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
+            - not_has_text:
+                text: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
     valid pairs filtered and sorted:
       element_tests:
         test_dataset:

--- a/workflows/epigenetics/hic-hicup-cooler/hic-fastq-to-cool-hicup-cooler-tests.yml
+++ b/workflows/epigenetics/hic-hicup-cooler/hic-fastq-to-cool-hicup-cooler-tests.yml
@@ -41,22 +41,22 @@
       element_tests:
         test_dataset:
           asserts:
-            - that: "has_line"
-              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
-            - that: "has_line"
-              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
-            - that: "has_line"
-              line: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
+            - has_line:
+                line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
+            - has_line:
+                line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
+            - has_line:
+                line: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
     valid pairs in juicebox format MAPQ filtered:
       element_tests:
         test_dataset:
           asserts:
-            - that: "has_line"
-              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
-            - that: "has_line"
-              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
-            - that: "not_has_text"
-              text: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
+            - has_line:
+                line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
+            - has_line:
+                line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
+            - not_has_text:
+                text: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
     valid pairs filtered and sorted:
       element_tests:
         test_dataset:

--- a/workflows/epigenetics/hic-hicup-cooler/hic-fastq-to-pairs-hicup-tests.yml
+++ b/workflows/epigenetics/hic-hicup-cooler/hic-fastq-to-pairs-hicup-tests.yml
@@ -38,19 +38,19 @@
       element_tests:
         test_dataset:
           asserts:
-            - that: "has_line"
-              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
-            - that: "has_line"
-              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
-            - that: "has_line"
-              line: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
+            - has_line:
+                line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
+            - has_line:
+                line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
+            - has_line:
+                line: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
     valid pairs in juicebox format MAPQ filtered:
       element_tests:
         test_dataset:
           asserts:
-            - that: "has_line"
-              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
-            - that: "has_line"
-              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
-            - that: "not_has_text"
-              text: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
+            - has_line:
+                line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
+            - has_line:
+                line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
+            - not_has_text:
+                text: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"

--- a/workflows/metabomics/gcms-metams/Mass-spectrometry__GCMS-with-metaMS-tests.yml
+++ b/workflows/metabomics/gcms-metams/Mass-spectrometry__GCMS-with-metaMS-tests.yml
@@ -38,17 +38,17 @@
       lines_diff: 10
     Multivariate variableMetadata:
       asserts:
-          - that: has_n_lines
-            n: 42
-          - that: has_text
-            text: "Unknown 1\tUnknown\t0.0046\t19.499\t-0.17"
-          - that: has_text
-            text: "Unknown 41\tUnknown\t0.0039\t14.857\t-0.08"
+          - has_n_lines:
+              n: 42
+          - has_text:
+              text: "Unknown 1\tUnknown\t0.0046\t19.499\t-0.17"
+          - has_text:
+              text: "Unknown 41\tUnknown\t0.0039\t14.857\t-0.08"
     Multivariate sampleMetadata:
       asserts:
-          - that: has_n_lines
-            n: 7
-          - that: has_text
-            text: "alg11\tFWS_100perNaCl\t-6.2"
-          - that: has_text
-            text: "alg8\tFWS_5percNaCL\t-0.6"
+          - has_n_lines:
+              n: 7
+          - has_text:
+              text: "alg11\tFWS_100perNaCl\t-6.2"
+          - has_text:
+              text: "alg8\tFWS_5percNaCL\t-0.6"

--- a/workflows/metabomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml
+++ b/workflows/metabomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml
@@ -2,7 +2,7 @@
   job:
     SampleMetadata:
       class: File
-      identifier: sampleMetadata.tsv
+      name: sampleMetadata.tsv
       location: https://zenodo.org/records/10130758/files/sampleMetadata_12samp_completed.tsv
       filetype: tabular
     Mass-spectrometry Dataset Collection:

--- a/workflows/proteomics/openms-metaprosip/metaprosip-tests.yml
+++ b/workflows/proteomics/openms-metaprosip/metaprosip-tests.yml
@@ -21,19 +21,19 @@
       element_tests:
         Zeitz_SIP_13-II_020_picked.mzML:
           asserts:
-          - that: has_n_lines
-            n: 85
-          - that: has_text
-            text: Peptide Sequence
-          - that: has_text
-            text: AATGTPSPAGSPPPIVPAPK
+          - has_n_lines:
+              n: 85
+          - has_text:
+              text: Peptide Sequence
+          - has_text:
+              text: AATGTPSPAGSPPPIVPAPK
     Feature fitting result:
       element_tests:
         Zeitz_SIP_13-II_020_picked.mzML:
           asserts:
-          - that: has_n_lines
-            n: 4091
-          - that: has_text
-            text: Group 1
-          - that: has_text
-            text: LYSFHTLHQTYMK 
+          - has_n_lines:
+              n: 4091
+          - has_text:
+              text: Group 1
+          - has_text:
+              text: LYSFHTLHQTYMK

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation-tests.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation-tests.yml
@@ -5,14 +5,14 @@
       location: 'https://zenodo.org/record/4555735/files/NC_045512.2_reference.fasta?download=1'
     aligned reads data for depth calculation:
       class: Collection
-      collection_type: 'list'
+      collection_type: list
       elements:
         - identifier: SRR11578257
           class: File
           path: test-data/aligned_reads_for_coverage.bam
     Variant calls:
       class: Collection
-      collection_type: 'list'
+      collection_type: list
       elements:
         - identifier: SRR11578257
           class: File

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation-tests.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation-tests.yml
@@ -16,7 +16,6 @@
           location: "https://www.be-md.ncbi.nlm.nih.gov/Traces/sra-reads-be/fastq?acc=SRR12447380"
   outputs:
     annotated_softfiltered_variants:
-      attributes: {}
       element_tests:
         SRR12447380:
           path: test-data/final_snpeff_annotated_variants.vcf

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation-test.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation-test.yml
@@ -30,7 +30,6 @@
             filetype: fastqsanger.gz
   outputs:
     annotated_softfiltered_variants:
-      attributes: {}
       element_tests:
         SRR11578257:
           path: test-data/final_snpeff_annotated_variants.vcf

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/pe-wgs-variation-tests.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/pe-wgs-variation-tests.yml
@@ -19,7 +19,6 @@
             location: "https://zenodo.org/records/10174466/files/SRR11578257_R2.fastq.gz?download=1"
   outputs:
     annotated_variants:
-      attributes: {}
       element_tests:
         SRR11578257:
           path: test-data/final_snpeff_annotated_variants.vcf

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/se-wgs-variation-test.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/se-wgs-variation-test.yml
@@ -12,7 +12,6 @@
           location: "https://sra-pub-sars-cov2.s3.amazonaws.com/sra-src/SRR11605118/VA-DCLS-0041_SC2_R1.fastq.gz"
   outputs:
     annotated_variants:
-      attributes: {}
       element_tests:
         SRR11605118:
           path: test-data/final_snpeff_annotated_variants.vcf

--- a/workflows/scRNAseq/baredsc/baredSC-2d-logNorm-tests.yml
+++ b/workflows/scRNAseq/baredsc/baredSC-2d-logNorm-tests.yml
@@ -55,7 +55,6 @@
         split_file_000001.tabular:
           element_tests:
             convergence:
-            convergence:
               asserts:
                 has_size:
                   value: 28600

--- a/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml
+++ b/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml
@@ -31,12 +31,12 @@
       element_tests:
         GSM461177:
           asserts:
-            - that: "has_text"
-              text: "Number of input reads |\t1032407"
-            - that: "has_text"
-              text: "Uniquely mapped reads number |\t854812"
-            - that: "has_text"
-              text: "Number of reads mapped to multiple loci |\t82072"
+            - has_text:
+                text: "Number of input reads |\t1032407"
+            - has_text:
+                text: "Uniquely mapped reads number |\t854812"
+            - has_text:
+                text: "Number of reads mapped to multiple loci |\t82072"
     mapped-reads:
       element_tests:
         GSM461177:
@@ -64,20 +64,20 @@
               expression: "GSM461177	1032407.0	71.0	854812.0	82.8	70.65	10276[23].0	102412.0	1020[34][0-9].0	679.0	20.0	24.0	0.54	0.0	1.56	0.0	1.43	82072.0	7.95	32881.0	3.18	0.0	5.9	0.17	0	60888	1754"
     MultiQC webpage:
       asserts:
-        - that: "has_text"
-          text: "GSM461177"
-        - that: "has_text"
-          text: "<a href=\"#cutadapt_filtered_reads\" class=\"nav-l2\">Filtered Reads</a>"
-        - that: "has_text"
-          text: "<a href=\"#star\" class=\"nav-l1\">STAR</a>"
+        - has_text:
+            text: "GSM461177"
+        - has_text:
+            text: "<a href=\"#cutadapt_filtered_reads\" class=\"nav-l2\">Filtered Reads</a>"
+        - has_text:
+            text: "<a href=\"#star\" class=\"nav-l1\">STAR</a>"
     reads_per_gene from STAR:
       element_tests:
         GSM461177:
           asserts:
-            - that: "has_text"
-              text: "N_ambiguous	25107	5900	5518"
-            - that: "has_text"
-              text: "FBgn0010247	13	5	8"
+            - has_text:
+                text: "N_ambiguous	25107	5900	5518"
+            - has_text:
+                text: "FBgn0010247	13	5	8"
     HTS count like output:
       element_tests:
         GSM461177:
@@ -87,16 +87,19 @@
     both strands coverage:
       element_tests:
         GSM461177:
+          asserts:
             has_size:
               value: 9885639
               delta: 900000
     stranded coverage:
       element_tests:
         GSM461177_reverse:
+          asserts:
             has_size:
               value: 7756965
               delta: 700000
         GSM461177_forward:
+          asserts:
             has_size:
               value: 7756965
               delta: 700000

--- a/workflows/transcriptomics/rnaseq-sr/rnaseq-sr-tests.yml
+++ b/workflows/transcriptomics/rnaseq-sr/rnaseq-sr-tests.yml
@@ -21,12 +21,12 @@
       element_tests:
         GSM461177:
           asserts:
-            - that: "has_text"
-              text: "Number of input reads |\t1051466"
-            - that: "has_text"
-              text: "Uniquely mapped reads number |\t871202"
-            - that: "has_text"
-              text: "Number of reads mapped to multiple loci |\t91808"
+            - has_text:
+               text: "Number of input reads |\t1051466"
+            - has_text:
+                text: "Uniquely mapped reads number |\t871202"
+            - has_text:
+                text: "Number of reads mapped to multiple loci |\t91808"
     mapped-reads:
       element_tests:
         GSM461177:
@@ -54,20 +54,20 @@
               expression: "GSM461177\t1051466.0\t35.0\t871202.0\t82.86\t35.4\t51184.0\t50995.0\t50810.0\t343.0\t12.0\t19.0\t0.48\t0.0\t1.48\t0.0\t1.36\t9180[89].0\t8.73\t34515.0\t3.28\t0.0\t4.76\t0.37\t0\t5005[01]\t3890"
     MultiQC webpage:
       asserts:
-        - that: "has_text"
-          text: "GSM461177"
-        - that: "has_text"
-          text: "<a href=\"#cutadapt_filtered_reads\" class=\"nav-l2\">Filtered Reads</a>"
-        - that: "has_text"
-          text: "<a href=\"#star\" class=\"nav-l1\">STAR</a>"
+        - has_text:
+            text: "GSM461177"
+        - has_text:
+            text: "<a href=\"#cutadapt_filtered_reads\" class=\"nav-l2\">Filtered Reads</a>"
+        - has_text:
+            text: "<a href=\"#star\" class=\"nav-l1\">STAR</a>"
     reads_per_gene from STAR:
       element_tests:
         GSM461177:
           asserts:
-            - that: "has_text"
-              text: "N_ambiguous\t20961\t5272\t4705"
-            - that: "has_text"
-              text: "FBgn0010247\t14\t6\t8"
+            - has_text:
+                text: "N_ambiguous\t20961\t5272\t4705"
+            - has_text:
+                text: "FBgn0010247\t14\t6\t8"
     HTS count like output:
       element_tests:
         GSM461177:
@@ -95,16 +95,19 @@
     both strands coverage:
       element_tests:
         GSM461177:
+          asserts:
             has_size:
               value: 6075761
               delta: 600000
     stranded coverage:
       element_tests:
         GSM461177_reverse:
+          asserts:
             has_size:
               value: 3103918
               delta: 300000
         GSM461177_forward:
+          asserts:
             has_size:
               value: 3103918
               delta: 300000


### PR DESCRIPTION
Some more cosmetic fixes (`that: "has_text"` -> `has_text`), but also fixes a lot of untested broken things here.
Mostly a WIP to show the impact of https://github.com/galaxyproject/galaxy/pull/17128.

The list of asserts needs to be added to galaxy-tool-util for tests to pass.

