### PR TITLE
Comment on PR with result of workflow test

### DIFF
--- a/.github/workflows/comment_on_pr.yml
+++ b/.github/workflows/comment_on_pr.yml
@@ -9,15 +9,15 @@ on:
       - completed
 
 jobs:
-  upload:
+  download_and_comment:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request'
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v7
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
@@ -25,7 +25,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == 'All tool test results'
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,
@@ -35,13 +35,13 @@ jobs:
             fs.writeFileSync('${{github.workspace}}/upload.zip', Buffer.from(download.data));
       - run: unzip upload.zip
       - name: 'Comment on PR'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             var fs = require('fs');
             var issue_number = Number(fs.readFileSync('./NR'));
-            await github.issues.createComment({
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue_number,

--- a/.github/workflows/comment_on_pr.yml
+++ b/.github/workflows/comment_on_pr.yml
@@ -34,9 +34,6 @@ jobs:
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/upload.zip', Buffer.from(download.data));
       - run: unzip upload.zip
-      - name: Check the output of unzip
-        run: |
-          ls
       - name: 'Comment on PR'
         uses: actions/github-script@v3
         with:
@@ -48,5 +45,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue_number,
-              body: fs.readFileSync('./tool_test_output.md')
+              body: fs.readFileSync('./tool_test_output.md', 'utf-8')
             });

--- a/.github/workflows/comment_on_pr.yml
+++ b/.github/workflows/comment_on_pr.yml
@@ -11,7 +11,9 @@ on:
 jobs:
   download_and_comment:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request'
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'failure'
     steps:
       - name: 'Download artifact'
         uses: actions/github-script@v7

--- a/.github/workflows/comment_on_pr.yml
+++ b/.github/workflows/comment_on_pr.yml
@@ -1,0 +1,52 @@
+name: Comment on the pull request
+
+# read-write repo token
+# access to secrets
+on:
+  workflow_run:
+    workflows: ["Galaxy Workflow Tests for push and PR"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == 'All tool test results'
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/upload.zip', Buffer.from(download.data));
+      - run: unzip upload.zip
+      - name: Check the output of unzip
+        run: |
+          ls
+      - name: 'Comment on PR'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var fs = require('fs');
+            var issue_number = Number(fs.readFileSync('./NR'));
+            await github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: fs.readFileSync('./tool_test_output.md')
+            });

--- a/.github/workflows/workflow_test.yml
+++ b/.github/workflows/workflow_test.yml
@@ -89,6 +89,11 @@ jobs:
         html-report: true
         markdown-report: true
     - run: cat upload/tool_test_output.md >> $GITHUB_STEP_SUMMARY
+    - name: Save PR number
+      run: echo ${{ github.event.number }} > ./upload/NR
+    - name: Debug PR number
+      run: |
+          cat ./upload/NR
     - uses: actions/upload-artifact@v3
       with:
         name: 'All tool test results'
@@ -98,23 +103,6 @@ jobs:
       id: check
       with:
         mode: check
-    - name: Get PR object
-      if: failure()
-      uses: 8BitJonny/gh-get-current-pr@2.2.0
-      id: failed_pr_number
-      with:
-        sha: ${{ github.event.pull_request.head.sha }}
-    - name: Debug GetPR output
-      if: failure()
-      run: |
-          echo ${{ steps.failed_pr_number.outputs.number }}
-    - name: Post comment with test report
-      if: failure()
-      uses: peter-evans/create-or-update-comment@v3
-      with:
-        token: ${{ secrets.PAT }}
-        issue-number: ${{ steps.failed_pr_number.outputs.number }}
-        body-path: upload/tool_test_output.md
 
   # deploy workflows to organization
   deploy:


### PR DESCRIPTION
This is highly inspired from [this post](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).
Contrarily to current code it works for PR from forks.

I deployed it on my fork and the issue I see is that when the PR workflow does not generate a combined test then the action Comment on the pull request fails because there is no artifact. See https://github.com/lldelisle/iwc/actions/runs/7492377134/job/20395726430

But I don't know how to introduce a if within the script to prevent filtering artifact if it is empty.

