### PR TITLE
Simplify parallel accession download workflow

### DIFF
--- a/workflows/data-fetching/parallel-accession-download/CHANGELOG.md
+++ b/workflows/data-fetching/parallel-accession-download/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.12] 2024-04-16
+
+### Skip param file generation
+
+- instead pass ID file directly
+
 ## [0.1.11] 2024-04-08
 
 ### Automatic update

--- a/workflows/data-fetching/parallel-accession-download/parallel-accession-download.ga
+++ b/workflows/data-fetching/parallel-accession-download/parallel-accession-download.ga
@@ -1,6 +1,7 @@
 {
     "a_galaxy_workflow": "true",
     "annotation": "Downloads fastq files for sequencing run accessions provided in a text file using fasterq-dump. Creates one job per listed run accession.",
+    "comments": [],
     "creator": [
         {
             "class": "Person",
@@ -15,7 +16,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.1.11",
+    "release": "0.1.12",
     "name": "Parallel Accession Download",
     "steps": {
         "0": {
@@ -34,8 +35,8 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 0.0,
-                "top": 27.0
+                "left": 0,
+                "top": 0
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"format\": [\"txt\"], \"tag\": null}",
@@ -71,8 +72,8 @@
                 }
             ],
             "position": {
-                "left": 146.51248168945312,
-                "top": 173.01251220703125
+                "left": 279.51666259765625,
+                "top": 86.01666259765625
             },
             "post_job_actions": {
                 "HideDatasetActionlist_output_txt": {
@@ -97,52 +98,13 @@
         },
         "2": {
             "annotation": "",
-            "content_id": "param_value_from_file",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/3.1.0+galaxy0",
             "errors": null,
             "id": 2,
             "input_connections": {
-                "input1": {
+                "input|file_list": {
                     "id": 1,
                     "output_name": "list_output_txt"
-                }
-            },
-            "inputs": [],
-            "label": "to parameter",
-            "name": "Parse parameter value",
-            "outputs": [
-                {
-                    "name": "text_param",
-                    "type": "expression.json"
-                }
-            ],
-            "position": {
-                "left": 338.0375061035156,
-                "top": 0.0
-            },
-            "post_job_actions": {
-                "HideDatasetActiontext_param": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "text_param"
-                }
-            },
-            "tool_id": "param_value_from_file",
-            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"text\", \"remove_newlines\": true, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.1.0",
-            "type": "tool",
-            "uuid": "570d0317-259f-42b1-91f4-74f050e754b5",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "3": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/3.1.0+galaxy0",
-            "errors": null,
-            "id": 3,
-            "input_connections": {
-                "input|accession": {
-                    "id": 2,
-                    "output_name": "text_param"
                 }
             },
             "inputs": [
@@ -172,8 +134,8 @@
                 }
             ],
             "position": {
-                "left": 604.9250183105469,
-                "top": 100.9749755859375
+                "left": 570.9250183105469,
+                "top": 62.9749755859375
             },
             "post_job_actions": {
                 "HideDatasetActionlist_paired": {
@@ -204,21 +166,21 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__job_resource\": {\"__current_case__\": 0, \"__job_resource__select\": \"no\"}, \"adv\": {\"seq_defline\": \"@$sn/$ri\", \"minlen\": null, \"split\": \"--split-3\", \"skip_technical\": true}, \"input\": {\"input_select\": \"accession_number\", \"__current_case__\": 0, \"accession\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"adv\": {\"seq_defline\": \"@$sn/$ri\", \"minlen\": null, \"split\": \"--split-3\", \"skip_technical\": true}, \"input\": {\"input_select\": \"file_list\", \"__current_case__\": 2, \"file_list\": {\"__class__\": \"RuntimeValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "3.1.0+galaxy0",
             "type": "tool",
             "uuid": "4d328e7b-df7d-4d3e-a60f-1ea12925f317",
             "when": null,
             "workflow_outputs": []
         },
-        "4": {
+        "3": {
             "annotation": "",
             "content_id": "__APPLY_RULES__",
             "errors": null,
-            "id": 4,
+            "id": 3,
             "input_connections": {
                 "input": {
-                    "id": 3,
+                    "id": 2,
                     "output_name": "list_paired"
                 }
             },
@@ -232,8 +194,8 @@
                 }
             ],
             "position": {
-                "left": 932.0000305175781,
-                "top": 109.9749755859375
+                "left": 898.0000305175781,
+                "top": 71.9749755859375
             },
             "post_job_actions": {
                 "TagDatasetActionoutput": {
@@ -258,14 +220,14 @@
                 }
             ]
         },
-        "5": {
+        "4": {
             "annotation": "",
             "content_id": "__APPLY_RULES__",
             "errors": null,
-            "id": 5,
+            "id": 4,
             "input_connections": {
                 "input": {
-                    "id": 3,
+                    "id": 2,
                     "output_name": "output_collection"
                 }
             },
@@ -279,8 +241,8 @@
                 }
             ],
             "position": {
-                "left": 939.0499572753906,
-                "top": 253.0250244140625
+                "left": 905.0499572753906,
+                "top": 215.0250244140625
             },
             "post_job_actions": {
                 "TagDatasetActionoutput": {


### PR DESCRIPTION
by passing ID file directly

we could also add a parameter allowing to change the number of IDs per chunk