### PR TITLE
Updating workflows/bacterial_genomics/bacterial_genome_annotation from 1.1.1 to 1.1.2

### DIFF
--- a/workflows/bacterial_genomics/bacterial_genome_annotation/CHANGELOG.md
+++ b/workflows/bacterial_genomics/bacterial_genome_annotation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.2] - 2024-07-19
+
+- PlasmidFinder database correction in .ga
+
 ## [1.1.1] 2024-07-08
 
 ### Automatic update

--- a/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation.ga
+++ b/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation.ga
@@ -27,7 +27,7 @@
     ],
     "format-version": "0.1",
     "license": "GPL-3.0-or-later",
-    "release": "1.1.1",
+    "release": "1.1.2",
     "name": "bacterial_genome_annotation",
     "steps": {
         "0": {
@@ -77,7 +77,7 @@
                 "top": 734.3939210886799
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"plasmidfinder_81c11f4_2023_12_04\", \"restrictions\": [\"plasmidfinder_314d85f_2023_03_17\", \"81c11f4_2023_12_04/\"], \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"default\": \"plasmidfinder_81c11f4_2023_12_04\", \"restrictions\": [\"plasmidfinder_314d85f_2023_03_17\", \"plasmidfinder_81c11f4_2023_12_04\"], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "66c11ad1-7cd5-40b7-b97f-8d15cc097dd9",


### PR DESCRIPTION
Hello 

There is an error in `.ga` file with `81c11f4_2023_12_04` PlasmidFinder database.
I changed it to `plasmidfinder_81c11f4_2023_12_04`

Thanks!