### PR TITLE
Updating workflows/bacterial_genomics/amr_gene_detection from 1.1.1 to 1.1.2

### DIFF
--- a/workflows/bacterial_genomics/amr_gene_detection/CHANGELOG.md
+++ b/workflows/bacterial_genomics/amr_gene_detection/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.2] 2024-09-19
+
+### Manual update
+
+- Change percent identity threshold for Resfinder blast results in StarAMR from 98.0% to 90.0%
+
 ## [1.1.1] 2024-07-08
 
 ### Automatic update

--- a/workflows/bacterial_genomics/amr_gene_detection/amr_gene_detection.ga
+++ b/workflows/bacterial_genomics/amr_gene_detection/amr_gene_detection.ga
@@ -27,7 +27,7 @@
     ],
     "format-version": "0.1",
     "license": "GPL-3.0-or-later",
-    "release": "1.1.1",
+    "release": "1.1.2",
     "name": "amr_gene_detection",
     "steps": {
         "0": {
@@ -311,7 +311,7 @@
                 "owner": "nml",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"advanced\": {\"pid_threshold\": \"98.0\", \"plength_resfinder\": \"60.0\", \"plength_pointfinder\": \"95.0\", \"plength_plasmidfinder\": \"60.0\", \"genome_size_lower_bound\": \"4000000\", \"genome_size_upper_bound\": \"6000000\", \"minimum_N50_value\": \"10000\", \"minimum_contig_length\": \"300\", \"unacceptable_number_contigs\": \"1000\", \"report_all_blast\": false, \"exclude_negatives\": false, \"exclude_resistance_phenotypes\": false, \"mlst_scheme\": \"auto\", \"exclude_genes\": {\"exclude_genes_condition\": \"default\", \"__current_case__\": 0}, \"complex_mutations\": {\"complex_mutations_condition\": \"default\", \"__current_case__\": 0}, \"plasmidfinder_type\": \"include_all\"}, \"genomes\": {\"__class__\": \"ConnectedValue\"}, \"pointfinder_db\": {\"use_pointfinder\": \"disabled\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"advanced\": {\"pid_threshold\": \"90.0\", \"plength_resfinder\": \"60.0\", \"plength_pointfinder\": \"95.0\", \"plength_plasmidfinder\": \"60.0\", \"genome_size_lower_bound\": \"4000000\", \"genome_size_upper_bound\": \"6000000\", \"minimum_N50_value\": \"10000\", \"minimum_contig_length\": \"300\", \"unacceptable_number_contigs\": \"1000\", \"report_all_blast\": false, \"exclude_negatives\": false, \"exclude_resistance_phenotypes\": false, \"mlst_scheme\": \"auto\", \"exclude_genes\": {\"exclude_genes_condition\": \"default\", \"__current_case__\": 0}, \"complex_mutations\": {\"complex_mutations_condition\": \"default\", \"__current_case__\": 0}, \"plasmidfinder_type\": \"include_all\"}, \"genomes\": {\"__class__\": \"ConnectedValue\"}, \"pointfinder_db\": {\"use_pointfinder\": \"disabled\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.10.0+galaxy1",
             "type": "tool",
             "uuid": "10eed503-9e5b-4acf-8cd8-29e81d7668a5",


### PR DESCRIPTION
Change percent identity threshold for Resfinder blast results in StarAMR from 98.0% to 90.0% (the filter is too strict!)

Thanks :smiley: 