### PR TITLE
Tool updates (no expected functional changes) to PE ARTIC WF

### DIFF
--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/CHANGELOG.md
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.3] 2024-10-01
+
+### Tool updates
+
+- `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.4+galaxy0` updated to `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.4+galaxy1`
+- `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.3+galaxy0` updated to `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.3+galaxy1`
+
 ## [0.5.2] 2024-03-05
 
 ### Automatic update

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation.ga
@@ -11,7 +11,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "COVID-19: variation analysis on ARTIC PE data",
-    "release": "0.5.2",
+    "release": "0.5.3",
     "steps": {
         "0": {
             "annotation": "Illumina reads from ARTIC assay with fastqsanger encoding",
@@ -231,7 +231,7 @@
         },
         "8": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.4+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.4+galaxy1",
             "errors": null,
             "id": 8,
             "input_connections": {
@@ -273,15 +273,15 @@
                     "output_name": "report_json"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.4+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.4+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "c59d48774d03",
+                "changeset_revision": "d60c3f704da0",
                 "name": "fastp",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": null, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": \"\", \"umi_len\": null, \"umi_prefix\": \"\"}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": false}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 2, \"paired_input\": {\"__class__\": \"ConnectedValue\"}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": \"\", \"adapter_sequence2\": \"\"}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.23.4+galaxy0",
+            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": null, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": \"\", \"umi_len\": null, \"umi_prefix\": \"\"}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": false}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 2, \"paired_input\": {\"__class__\": \"ConnectedValue\"}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": \"\", \"adapter_sequence2\": \"\", \"detect_adapter_for_pe\": false}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.23.4+galaxy1",
             "type": "tool",
             "uuid": "849d9cac-14b8-4e45-823d-5747709e8b60",
             "when": null,
@@ -1543,7 +1543,7 @@
         },
         "30": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.3+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.3+galaxy1",
             "errors": null,
             "id": 30,
             "input_connections": {
@@ -1571,15 +1571,15 @@
                 "top": 745.546875
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.3+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.3+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "12615d397df7",
+                "changeset_revision": "86755160afbf",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"infile\": {\"__class__\": \"ConnectedValue\"}, \"replacements\": [{\"__index__\": 0, \"find_pattern\": \"^##INFO=<ID=AmpliconBias,.+$\", \"replace_pattern\": \"##INFO=<ID=AmpliconBias,Number=0,Type=Flag,Description=\\\"Indicates that the AF value of the variant could not be corrected for potential amplicon bias.\\\">\"}, {\"__index__\": 1, \"find_pattern\": \"^##INFO=<ID=AF,.+$\", \"replace_pattern\": \"##INFO=<ID=AF,Number=1,Type=Float,Description=\\\"Lofreq Allele Frequency; Fraction of variant-supporting bases with q > --min-bq among all bases at the site\\\">\"}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "9.3+galaxy0",
+            "tool_version": "9.3+galaxy1",
             "type": "tool",
             "uuid": "490dbabb-04ee-426d-a8e5-e2ec9e59de3a",
             "when": null,


### PR DESCRIPTION
These are just the minimal tool updates to make the WF executable on .org without issues.

Other tool updates suggested in #389 I would like to test more carefully first, especially the ivar update to version 1.4.3.
The new version of qualimap (v2.3) suggested there seems to produce less nicely formatted, otherwise identical output than the current version so should likely be avoided permanently.