### PR TITLE
Updating workflows/bacterial_genomics/bacterial_genome_annotation from 1.1.4 to 1.1.5

### DIFF
--- a/workflows/bacterial_genomics/bacterial_genome_annotation/CHANGELOG.md
+++ b/workflows/bacterial_genomics/bacterial_genome_annotation/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.5] 2024-09-30
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy0`
+
 ## [1.1.4] 2024-09-19
 
 ### Manual update

--- a/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation-tests.yml
+++ b/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation-tests.yml
@@ -56,6 +56,4 @@
         - that: "has_text"
           text: "CDS12738(DOp1)"
         - that: "has_text"
-          text: "calin"
-        - that: "has_text"
           text: "PFAM"

--- a/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation.ga
+++ b/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation.ga
@@ -27,7 +27,7 @@
     ],
     "format-version": "0.1",
     "license": "GPL-3.0-or-later",
-    "release": "1.1.4",
+    "release": "1.1.5",
     "name": "bacterial_genome_annotation",
     "steps": {
         "0": {
@@ -982,7 +982,7 @@
         },
         "8": {
             "annotation": "ToolDistillator extracts results from tools and creates a JSON file for each tool",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy0",
             "errors": null,
             "id": 8,
             "input_connections": {
@@ -1120,15 +1120,15 @@
                     "output_name": "output_json"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "a7387ce2a8ca",
+                "changeset_revision": "8d6686664021",
                 "name": "tooldistillator",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"log\": false, \"tool_section\": {\"tools\": [{\"__index__\": 0, \"select_tool\": {\"tool_list\": \"plasmidfinder\", \"__current_case__\": 14, \"input\": {\"__class__\": \"ConnectedValue\"}, \"plasmid_result_tabular_path\": {\"__class__\": \"ConnectedValue\"}, \"genome_hit_path\": {\"__class__\": \"ConnectedValue\"}, \"plasmid_hit_path\": {\"__class__\": \"ConnectedValue\"}, \"analysis_software_version\": \"2.1.6\", \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"select_tool\": {\"tool_list\": \"isescan\", \"__current_case__\": 11, \"input\": {\"__class__\": \"ConnectedValue\"}, \"summary_path\": {\"__class__\": \"ConnectedValue\"}, \"annotation_path\": {\"__class__\": \"ConnectedValue\"}, \"orf_fna_path\": {\"__class__\": \"ConnectedValue\"}, \"orf_faa_path\": {\"__class__\": \"ConnectedValue\"}, \"is_fna_path\": {\"__class__\": \"ConnectedValue\"}, \"analysis_software_version\": \"1.7.2.3\", \"reference_database_version\": null}}, {\"__index__\": 2, \"select_tool\": {\"tool_list\": \"integronfinder2\", \"__current_case__\": 10, \"input\": {\"__class__\": \"ConnectedValue\"}, \"summary_file_path\": {\"__class__\": \"ConnectedValue\"}, \"analysis_software_version\": \"2.0.5\", \"reference_database_version\": null}}, {\"__index__\": 3, \"select_tool\": {\"tool_list\": \"bakta\", \"__current_case__\": 2, \"input\": {\"__class__\": \"ConnectedValue\"}, \"annotation_tabular_path\": {\"__class__\": \"ConnectedValue\"}, \"annotation_genbank_path\": {\"__class__\": \"ConnectedValue\"}, \"annotation_embl_path\": {\"__class__\": \"ConnectedValue\"}, \"contig_sequences_path\": {\"__class__\": \"ConnectedValue\"}, \"hypothetical_protein_path\": {\"__class__\": \"ConnectedValue\"}, \"hypothetical_tabular_path\": {\"__class__\": \"ConnectedValue\"}, \"plot_file_path\": {\"__class__\": \"ConnectedValue\"}, \"summary_result_path\": {\"__class__\": \"ConnectedValue\"}, \"nucleotide_annotation_path\": {\"__class__\": \"ConnectedValue\"}, \"amino_acid_annotation_path\": {\"__class__\": \"ConnectedValue\"}, \"gff_file_path\": {\"__class__\": \"ConnectedValue\"}, \"analysis_software_version\": \"1.9.4\", \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.9+galaxy0",
+            "tool_version": "0.9.1+galaxy0",
             "type": "tool",
             "uuid": "678bdbfe-7a3a-4a91-8ea7-1cb17f53daa6",
             "when": null,
@@ -1142,7 +1142,7 @@
         },
         "9": {
             "annotation": "ToolDistillator summarize groups all JSON file into a unique JSON file",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy0",
             "errors": null,
             "id": 9,
             "input_connections": {
@@ -1180,15 +1180,15 @@
                     "output_name": "summary_json"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "def7a82d23e1",
+                "changeset_revision": "f3233d395549",
                 "name": "tooldistillator_summarize",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"summarize_data\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.9+galaxy0",
+            "tool_version": "0.9.1+galaxy0",
             "type": "tool",
             "uuid": "3427b1f1-79ce-4ade-a350-baf15ac250c2",
             "when": null,


### PR DESCRIPTION
Hello, some tools have been updated (close https://github.com/galaxyproject/iwc/pull/540):

- ToolDistillator `0.9+galaxy0` to `0.9.1+galaxy0`

--> A test had to be corrected

Thanks 😃