### PR TITLE
Updating workflows/genome-assembly/quality-and-contamination-control from 1.1.3 to 1.1.4

### DIFF
--- a/workflows/genome-assembly/quality-and-contamination-control/CHANGELOG.md
+++ b/workflows/genome-assembly/quality-and-contamination-control/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.4] 2024-10-10
+
+### Manual update
+
+- Changed input parameters to select databases in WFs. Use "Attempt restriction based on connections" instead of "Provide list of suggested values".
+
 ## [1.1.3] 2024-09-30
 
 ### Manual update

--- a/workflows/genome-assembly/quality-and-contamination-control/quality_and_contamination_control.ga
+++ b/workflows/genome-assembly/quality-and-contamination-control/quality_and_contamination_control.ga
@@ -27,7 +27,7 @@
     ],
     "format-version": "0.1",
     "license": "GPL-3.0-or-later",
-    "release": "1.1.3",
+    "release": "1.1.4",
     "name": "Quality and Contamination Control For Genome Assembly",
     "steps": {
         "0": {
@@ -104,12 +104,18 @@
                 "top": 307.433349609375
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"k2_minusb_20210517\", \"restrictions\": [\"16S_SILVA138_k2db\", \"2020-11-24T164216Z_silva_kmer-len_35_minimizer-len_31_minimizer-spaces_6_load-factor_0.7\", \"2020-11-24T170532Z_rdp_kmer-len_35_minimizer-len_31_minimizer-spaces_6_load-factor_0.7\", \"2020-11-24T172646Z_greengenes_kmer-len_35_minimizer-len_31_minimizer-spaces_6_load-factor_0.7\", \"2020-11-26T021706Z_standard_kmer-len_35_minimizer-len_31_minimizer-spaces_6_load-factor_0.7\", \"2022-02-02T162953Z_greengenes_kmer-len_35_minimizer-len_31_minimizer-spaces_6_load-factor_0.7\", \"2022-07-06T094102Z_standard_prebuilt_standard_2022-06-07\", \"2022-08-04T105935Z_standard_prebuilt_viral_2022-06-07\", \"2022-09-04T165121Z_standard_prebuilt_pluspf_2022-06-07\", \"2022-09-05T092205Z_standard_prebuilt_pluspfp_2022-06-07\", \"2023-08-17T071759Z_standard_prebuilt_standard_16gb_2022-06-07\", \"k2_minusb_20210517\", \"k2_pluspf_20210517\", \"k2_standard_20210517\", \"kalamari\", \"kraken2_fungi_db\", \"kraken2_plasmid_db\", \"kraken2_viral_db\"], \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "1a56b57e-8893-4cbc-a984-329e0b815cbd",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "62ded62a-d0c4-49ba-b3ef-c97ff39c6c5e"
+                }
+            ]
         },
         "3": {
             "annotation": "Select the ncbi taxonomy database for Recentrifuge.",
@@ -131,12 +137,18 @@
                 "top": 454.91066885428484
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"ncbi-2015-10-05\", \"restrictions\": [\"ncbi-2015-10-05\", \"2020-12-03\", \"2022-03-08\", \"2024-06-05\"], \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "daac0634-bcf4-4fdd-bcd2-67247f5afdd0",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "9b99164e-0a87-4bba-8838-ec4f428cf4d5"
+                }
+            ]
         },
         "4": {
             "annotation": "fastp_triming, quality analaysis and read cleaning",


### PR DESCRIPTION
Changed input parameters to select databases in WFs. Use "`Attempt restriction based on connections`" instead of "`Provide list of suggested values`".

With that, we don't need to give a list of databases which may or **may not** be present in all `usegalaxy.*` instances.

Thanks :smiley: 