### PR TITLE
 Updating workflows/bacterial_genomics/bacterial_genome_annotation from 1.1.5 to 1.1.6

### DIFF
--- a/workflows/bacterial_genomics/bacterial_genome_annotation/CHANGELOG.md
+++ b/workflows/bacterial_genomics/bacterial_genome_annotation/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.6] 2024-10-11
+
+### Manual update
+
+- Changed input parameters to select databases in WFs. Use "Attempt restriction based on connections" instead of "Provide list of suggested values".
+
 ## [1.1.5] 2024-09-30
 
 ### Automatic update

--- a/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation.ga
+++ b/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation.ga
@@ -27,7 +27,7 @@
     ],
     "format-version": "0.1",
     "license": "GPL-3.0-or-later",
-    "release": "1.1.5",
+    "release": "1.1.6",
     "name": "bacterial_genome_annotation",
     "steps": {
         "0": {
@@ -77,7 +77,7 @@
                 "top": 734.3939210886799
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"plasmidfinder_81c11f4_2023_12_04\", \"restrictions\": [\"plasmidfinder_314d85f_2023_03_17\", \"plasmidfinder_81c11f4_2023_12_04\"], \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "66c11ad1-7cd5-40b7-b97f-8d15cc097dd9",
@@ -110,7 +110,7 @@
                 "top": 859.5166625976562
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"V5.1_2024-01-19\", \"restrictions\": [\"V5.0light_2023-02-20\", \"V5.0_2023-02-20\", \"V5.1_2024-01-19\"], \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "4de1f52c-078c-4112-86ad-e4e8f3b62e3a",
@@ -124,14 +124,14 @@
             ]
         },
         "3": {
-            "annotation": "Selecting this database is not necessary if the bacterial genome database (with Bakta) version is greater than 5.0.",
+            "annotation": "Select a database to annotate AMR genes with Bakta.",
             "content_id": null,
             "errors": null,
             "id": 3,
             "input_connections": {},
             "inputs": [
                 {
-                    "description": "Selecting this database is not necessary if the bacterial genome database (with Bakta) version is greater than 5.0.",
+                    "description": "Select a database to annotate AMR genes with Bakta.",
                     "name": "Select a AMRFinderPlus database"
                 }
             ],
@@ -143,7 +143,7 @@
                 "top": 995.2631409484753
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"amrfinderplus_V3.12_2024-05-02.2\", \"restrictions\": [\"amrfinderplus_V3.12_2024-05-02.2\"], \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "aec02a2c-6bf7-476d-91aa-3f1ce49083c7",


### PR DESCRIPTION
Changed input parameters to select databases in WFs. Use "`Attempt restriction based on connections`" instead of "`Provide list of suggested values`".

With that, we don't need to give a list of databases which may or **may not** be present in all `usegalaxy.*` instances.

Thanks :smiley: 