### PR TITLE
Updating workflows/bacterial_genomics/amr_gene_detection from 1.1.3 to 1.1.4

### DIFF
--- a/workflows/bacterial_genomics/amr_gene_detection/CHANGELOG.md
+++ b/workflows/bacterial_genomics/amr_gene_detection/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.4] 2024-10-11
+
+### Manual update
+
+- Changed input parameters to select databases in WFs. Use "Attempt restriction based on connections" instead of "Provide list of suggested values".
+
 ## [1.1.3] 2024-09-30
 
 ### Automatic update

--- a/workflows/bacterial_genomics/amr_gene_detection/amr_gene_detection-tests.yml
+++ b/workflows/bacterial_genomics/amr_gene_detection/amr_gene_detection-tests.yml
@@ -3,6 +3,9 @@
     Input sequence fasta:
       class: File
       path: https://zenodo.org/records/11488310/files/shovill_contigs_fasta
+    Select a taxonomy group point mutation: Enterococcus_faecalis
+    Select a AMR genes detection database: amrfinderplus_V3.12_2024-05-02.2
+    Select a virulence genes detection database: vfdb
   outputs:
     staramr_detailed_summary:
         asserts:

--- a/workflows/bacterial_genomics/amr_gene_detection/amr_gene_detection.ga
+++ b/workflows/bacterial_genomics/amr_gene_detection/amr_gene_detection.ga
@@ -27,7 +27,7 @@
     ],
     "format-version": "0.1",
     "license": "GPL-3.0-or-later",
-    "release": "1.1.3",
+    "release": "1.1.4",
     "name": "amr_gene_detection",
     "steps": {
         "0": {

--- a/workflows/bacterial_genomics/amr_gene_detection/amr_gene_detection.ga
+++ b/workflows/bacterial_genomics/amr_gene_detection/amr_gene_detection.ga
@@ -77,7 +77,7 @@
                 "top": 785.1080080587546
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"Enterococcus_faecalis\", \"restrictions\": [\"Acinetobacter_baumannii\", \"Burkholderia_cepacia\", \"Burkholderia_pseudomallei\", \"Campylobacter\", \"Citrobacter_freundii\", \"Clostridioides_difficile\", \"Enterobacter_cloacae\", \"Enterococcus_faecalis\", \"Enterococcus_faecium\", \"Escherichia\", \"Klebsiella_aerogenes\", \"Klebsiella_oxytoca\", \"Klebsiella_pneumoniae\", \"Neisseria_gonorrhoeae\", \"Neisseria_meningitidis\", \"Pseudomonas_aeruginosa\", \"Salmonella\", \"Serratia_marcescens\", \"Staphylococcus_aureus\", \"Staphylococcus_pseudintermedius\", \"Streptococcus_agalactiae\", \"Streptococcus_pneumoniae\", \"Streptococcus_pyogenes\", \"Vibrio_cholerae\"], \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "6092b401-9042-4ec2-9970-d614afd77441",
@@ -104,7 +104,7 @@
                 "top": 1031.8311633489975
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"amrfinderplus_V3.12_2024-05-02.2\", \"restrictions\": [\"amrfinderplus_V3.12_2024-05-02.2\"], \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "3c9163c4-9393-49ca-8271-b98a89abcfb9",
@@ -131,7 +131,7 @@
                 "top": 1166.9166870117188
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"vfdb\", \"restrictions\": [\"vfdb\"], \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "eba8ebb2-0072-41dd-a9b2-878d05f04ff6",


### PR DESCRIPTION
Changed input parameters to select databases in WFs. Use "`Attempt restriction based on connections`" instead of "`Provide list of suggested values`".

With that, we don't need to give a list of databases which may or **may not** be present in all `usegalaxy.*` instances.

Thanks :smiley: 