### PR TITLE
Fix page scrolls despite children scrolling

### DIFF
--- a/website/app.vue
+++ b/website/app.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="h-svh flex flex-col">
+    <div class="h-dvh flex flex-col">
         <NuxtLoadingIndicator />
         <IWCHeader />
         <main class="flex overflow-hidden">

--- a/website/app.vue
+++ b/website/app.vue
@@ -1,8 +1,8 @@
 <template>
-    <div>
+    <div class="h-svh flex flex-col">
         <NuxtLoadingIndicator />
         <IWCHeader />
-        <main>
+        <main class="flex overflow-hidden">
             <NuxtLayout>
                 <NuxtPage />
             </NuxtLayout>

--- a/website/components/WorkflowList.vue
+++ b/website/components/WorkflowList.vue
@@ -35,7 +35,7 @@ function selectWorkflow(workflow: Workflow) {
 </script>
 
 <template>
-    <div class="flex h-screen">
+    <div class="flex">
         <!-- Left sidebar -->
         <div class="w-1/4 p-4 overflow-y-auto">
             <div class="sticky top-4 h-16">


### PR DESCRIPTION
Setting `h-screen` on the workflow list caused the pages overall size to be the screen height + the header height, causing two scroll bars to appear.
This PR moves the height definition to the app container and uses the dynamic viewport height instead of the viewport height, to avoid height issues in browsers with dynamic ui elements.