### PR TITLE
Unset nuxt base path prefix to support iwc.galaxyproject.org

### DIFF
--- a/.github/workflows/gh-page-build.yml
+++ b/.github/workflows/gh-page-build.yml
@@ -37,8 +37,6 @@ jobs:
       - name: Build Nuxt 3 Static Site
         run: npm run generate
         working-directory: ./website
-        env:
-          NUXT_APP_BASE_URL: /iwc/
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
TODO: work out support for either baseUrl, set on the fly?  Maybe yagni.