### PR TITLE
Add gh-pages preview builder

### DIFF
--- a/.github/workflows/gh-page-preview.yml
+++ b/.github/workflows/gh-page-preview.yml
@@ -1,0 +1,75 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'website/**'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR Branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Run generate_manifest.py
+        run: python ./scripts/workflow_manifest.py
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install NPM Dependencies
+        run: npm install
+        working-directory: ./website
+
+      - name: Build Nuxt 3 Static Site
+        run: npm run generate
+        working-directory: ./website
+
+      - name: Deploy to Publication Branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./website/.output/public
+          publish_branch: gh-pages
+          destination_dir: __preview/pr-${{ github.event.pull_request.number }}
+
+      - name: Create or Update PR Comment with Preview Link
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            ### Preview
+            [View Preview](https://galaxyproject.github.io/iwc/__preview/pr-${{ github.event.pull_request.number }}/)
+
+  cleanup:
+    if: >
+      github.event.pull_request.merged == true ||
+      github.event.pull_request.state == 'closed'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Publication Branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove Preview Directory
+        run: |
+          git rm -rf __preview/pr-${{ github.event.pull_request.number }}
+          git commit -m "Remove preview for PR #${{ github.event.pull_request.number }}"
+          git push origin gh-pages


### PR DESCRIPTION
Limited trigger to changes to `/website/` for now, but we could use this down the road for showing pages for previewing updated workflow artifacts, etc.