### PR TITLE
First pass at generating mermaid diagrams for all workflows

### DIFF
--- a/.github/workflows/gh-page-preview.yml
+++ b/.github/workflows/gh-page-preview.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout PR Branch
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tool_test_output.html
 tool_test_output.json
 .DS_Store
 workflow_manifest.json
+.vscode

--- a/scripts/create_mermaid.py
+++ b/scripts/create_mermaid.py
@@ -1,0 +1,97 @@
+import argparse
+import json
+import os
+from typing import Literal
+
+STEP_TYPE_TO_SHAPE = {
+    "data_input": "@{ shape: doc }",
+    "data_collection_input": "@{ shape: docs }",
+    "parameter_input": "@{ shape: lean-l }",
+    "tool": "@{ shape: process }",
+    "subworkflow": "@{ shape: subprocess }",
+}
+
+
+def step_to_mermaid_item(
+    step_type: Literal[
+        "parameter_input", "data_input", "data_collection_input", "tool", "subworkflow"
+    ],
+    step_label: str,
+):
+    step_label_anchor = f'["{step_label}"]'
+    shape = STEP_TYPE_TO_SHAPE.get(step_type, "")
+    return f"{step_label_anchor}{shape}"
+
+
+def workflow_to_mermaid_diagrams(workflow, workflows = None):
+    """
+    Converts a Galaxy workflow JSON to a Mermaid flowchart diagram.
+
+    Args:
+        workflow_json: The JSON representation of the Galaxy workflow.
+
+    Returns:
+        A string representing the Mermaid flowchart diagram.
+    """
+    if workflows is None:
+        workflows = {}
+
+    mermaid_diagram = "graph LR\n"
+
+    # Create a mapping of step IDs to their labels
+    id_step_labels = {
+        step["id"]: step["label"] or step["name"] or step["content_id"] or step["id"]
+        for step in workflow["steps"].values()
+    }
+
+    # Iterate through each step and its connections
+    for step_id, step in workflow["steps"].items():
+        step_label = id_step_labels.get(int(step_id))
+        mermaid_diagram += (
+            f'{step_id}{step_to_mermaid_item(step["type"], step_label)}\n'
+        )
+        for input_connection in step.get("input_connections", {}).values():
+            if not isinstance(input_connection, list):
+                input_connection = [input_connection]
+                for ic in input_connection:
+                    mermaid_diagram += f"{ic['id']} --> {step_id}\n"
+        
+        if step["type"] == "subworkflow":
+            workflow_to_mermaid_diagrams(step["subworkflow"], workflows=workflows)
+
+    workflows[workflow["name"]] = mermaid_diagram
+
+    return workflows
+
+
+def walk_directory(directory):
+    """
+    Walk directory and call workflow_to_mermaid on each discovered .ga file.
+    """
+    for root, _, paths in os.walk(directory):
+        for path in paths:
+            if path.endswith(".ga"):
+                file_path = os.path.join(root, path)
+                with open(file_path, "r") as f:
+                    workflow_data = json.load(f)
+                    mermaid_diagrams = workflow_to_mermaid_diagrams(workflow_data)
+
+                markdown_items = ["# Workflow diagrams\n"]
+                for workflow_name, diagram in reversed(mermaid_diagrams.items()):
+                    markdown_items.append(f"## {workflow_name}\n")
+                    markdown_items.append(f"```mermaid\n{diagram}```\n")
+
+                mmd_path = f"{os.path.splitext(file_path)[0]}_diagrams.md"
+                with open(mmd_path, "w") as f:
+                    f.write("\n".join(markdown_items))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Process files in a directory")
+    parser.add_argument("directory", type=str, help="Path to the input directory")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    walk_directory(args.directory)

--- a/scripts/create_mermaid.py
+++ b/scripts/create_mermaid.py
@@ -36,7 +36,7 @@ def workflow_to_mermaid_diagrams(workflow, workflows = None):
     if workflows is None:
         workflows = {}
 
-    mermaid_diagram = "graph LR\n"
+    mermaid_diagram = ["graph LR"]
 
     # Create a mapping of step IDs to their labels
     id_step_labels = {
@@ -47,19 +47,19 @@ def workflow_to_mermaid_diagrams(workflow, workflows = None):
     # Iterate through each step and its connections
     for step_id, step in workflow["steps"].items():
         step_label = id_step_labels.get(int(step_id))
-        mermaid_diagram += (
-            f'{step_id}{step_to_mermaid_item(step["type"], step_label)}\n'
+        mermaid_diagram.append(
+            f'{step_id}{step_to_mermaid_item(step["type"], step_label)}'
         )
         for input_connection in step.get("input_connections", {}).values():
             if not isinstance(input_connection, list):
                 input_connection = [input_connection]
                 for ic in input_connection:
-                    mermaid_diagram += f"{ic['id']} --> {step_id}\n"
+                    mermaid_diagram.append(f"{ic['id']} --> {step_id}")
         
         if step["type"] == "subworkflow":
             workflow_to_mermaid_diagrams(step["subworkflow"], workflows=workflows)
 
-    workflows[workflow["name"]] = mermaid_diagram
+    workflows[workflow["name"]] = "\n".join(mermaid_diagram)
 
     return workflows
 
@@ -79,7 +79,7 @@ def walk_directory(directory):
                 markdown_items = ["# Workflow diagrams\n"]
                 for workflow_name, diagram in reversed(mermaid_diagrams.items()):
                     markdown_items.append(f"## {workflow_name}\n")
-                    markdown_items.append(f"```mermaid\n{diagram}```\n")
+                    markdown_items.append(f"```mermaid\n{diagram}\n```\n")
 
                 mmd_path = f"{os.path.splitext(file_path)[0]}_diagrams.md"
                 with open(mmd_path, "w") as f:

--- a/scripts/create_mermaid.py
+++ b/scripts/create_mermaid.py
@@ -13,6 +13,13 @@ STEP_TYPE_TO_SHAPE = {
     "tool": "@{ shape: process }",
     "subworkflow": "@{ shape: subprocess }",
 }
+STEP_TYPE_TO_SYMBOL = {
+    "data_input": "ℹ️ ",
+    "data_collection_input": "ℹ️ ",
+    "parameter_input": "ℹ️ ",
+    "subworkflow": "🛠️ ",
+    "tool": "",
+}
 
 
 def step_to_mermaid_item(
@@ -21,7 +28,8 @@ def step_to_mermaid_item(
     ],
     step_label: str,
 ):
-    step_label_anchor = f'["{step_label}"]'
+    prefix = STEP_TYPE_TO_SYMBOL[step_type]
+    step_label_anchor = f'["{prefix}{step_label}"]'
     shape = STEP_TYPE_TO_SHAPE.get(step_type, "")
     return f"{step_label_anchor}{shape}"
 

--- a/scripts/workflow_manifest.py
+++ b/scripts/workflow_manifest.py
@@ -3,6 +3,18 @@ import json
 import yaml
 
 
+def read_contents(path: str):
+    try:
+        with open(path) as f:
+            return f.read()
+    except FileNotFoundError:
+        print(f"No {os.path.basename(path)} at {path}")
+    except Exception as e:
+        print(
+            f"Error reading file {path}: {e}"
+        )
+
+
 def find_and_load_compliant_workflows(directory):
     """
     Find all .dockstore.yml files in the given directory and its subdirectories.
@@ -57,28 +69,10 @@ def find_and_load_compliant_workflows(directory):
                             f"No workflow file: {os.path.join(root, workflow['primaryDescriptorPath'])}: {e}"
                         )
 
-                    # also try to load a README.md file for each workflow
-                    try:
-                        with open(os.path.join(root, "README.md")) as f:
-                            workflow["readme"] = f.read()
-                    # catch FileNotFound
-                    except FileNotFoundError:
-                        print(f"No README.md at {os.path.join(root, 'README.md')}")
-                    except Exception as e:
-                        print(
-                            f"Error reading file {os.path.join(root, 'README.md')}: {e}"
-                        )
-
-                    # also try to load a CHANGELOG.md file for each workflow
-                    try:
-                        with open(os.path.join(root, "CHANGELOG.md")) as f:
-                            workflow["changelog"] = f.read()
-                    except FileNotFoundError:
-                        print(f"No CHANGELOG.md at {os.path.join(root, 'CHANGELOG.md')}")
-                    except Exception as e:
-                        print(
-                            f"Error reading file {os.path.join(root, 'CHANGELOG.md')}: {e}"
-                        )
+                    # load readme, changelog and diagrams
+                    workflow["readme"] = read_contents(os.path.join(root, "README.md"))
+                    workflow["changelog"] = read_contents(os.path.join(root, "CHANGELOG.md"))
+                    workflow["diagrams"] = read_contents(f"{os.path.splitext(workflow_path)[0]}_diagrams.md")
                     dirname = os.path.dirname(workflow_path).split("/")[-1]
                     workflow["trsID"] = f"#workflow/github.com/iwc-workflows/{dirname}/{workflow['name'] or 'main'}"
 

--- a/scripts/workflow_manifest.py
+++ b/scripts/workflow_manifest.py
@@ -1,6 +1,7 @@
 import os
 import json
 import yaml
+from create_mermaid import walk_directory
 
 
 def read_contents(path: str):
@@ -102,5 +103,6 @@ def write_to_json(data, filename):
 
 
 if __name__ == "__main__":
+    walk_directory("./workflows")
     workflow_data = find_and_load_compliant_workflows("./workflows")
     write_to_json(workflow_data, "workflow_manifest.json")

--- a/website/components/MarkdownRenderer.vue
+++ b/website/components/MarkdownRenderer.vue
@@ -17,10 +17,7 @@ const renderedHtml = ref<string>("");
 // Initialize Mermaid
 mermaid.initialize({
     startOnLoad: false,
-    theme: "default",
-    themeVariables: {
-        background: "#f4f4f4",
-    }
+    theme: "neutral",
 });
 
 // Watch Markdown Content for Changes

--- a/website/components/MarkdownRenderer.vue
+++ b/website/components/MarkdownRenderer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, nextTick, onMounted, watch } from "vue";
+import { ref, nextTick, watch } from "vue";
 import { marked } from "marked";
 import mermaid from "mermaid";
 
@@ -17,7 +17,10 @@ const renderedHtml = ref<string>("");
 // Initialize Mermaid
 mermaid.initialize({
     startOnLoad: false,
-    theme: "neutral",
+    theme: "default",
+    themeVariables: {
+        background: "#f4f4f4",
+    }
 });
 
 // Watch Markdown Content for Changes
@@ -31,7 +34,6 @@ watch(
 
 // Render Markdown Function
 async function renderMarkdown(content: string) {
-    console.log("rendering now");
     renderedHtml.value = await marked(content);
     await nextTick();
     renderMermaidDiagrams();
@@ -47,6 +49,7 @@ function renderMermaidDiagrams() {
             try {
                 const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
                 mermaid.render(id, code).then((value) => (parent.innerHTML = value.svg));
+                parent.classList.add("not-prose");
             } catch (e) {
                 console.error("Mermaid rendering error:", e);
             }

--- a/website/models/workflow.ts
+++ b/website/models/workflow.ts
@@ -16,6 +16,7 @@ export interface Workflow {
     definition: WorkflowDefinition;
     readme: string;
     changelog: string;
+    diagrams: string;
     trsID: string;
 }
 

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,6 @@
     "@nuxt/ui": "^2.19.2",
     "@pinia/nuxt": "^0.5.5",
     "marked": "^14.1.1",
-    "marked-mermaid": "^0.1.0",
     "mermaid": "^11.4.1",
     "nuxt": "^3.11.2",
     "nuxt-icon": "^1.0.0-beta.7",

--- a/website/package.json
+++ b/website/package.json
@@ -15,6 +15,8 @@
     "@nuxt/ui": "^2.19.2",
     "@pinia/nuxt": "^0.5.5",
     "marked": "^14.1.1",
+    "marked-mermaid": "^0.1.0",
+    "mermaid": "^11.4.1",
     "nuxt": "^3.11.2",
     "nuxt-icon": "^1.0.0-beta.7",
     "pinia": "^2.2.4",

--- a/website/pages/workflow/MarkdownRenderer.vue
+++ b/website/pages/workflow/MarkdownRenderer.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { ref, nextTick, onMounted, watch } from "vue";
+import { marked } from "marked";
+import mermaid from "mermaid";
+
+// Props
+const props = defineProps({
+    markdownContent: {
+        type: String,
+        required: true,
+    },
+});
+
+// Refs
+const renderedHtml = ref<string>("");
+
+// Initialize Mermaid
+mermaid.initialize({
+    startOnLoad: false,
+    theme: "neutral",
+});
+
+// Watch Markdown Content for Changes
+watch(
+    () => props.markdownContent,
+    (newContent) => {
+        renderMarkdown(newContent);
+    },
+    { immediate: true },
+);
+
+// Render Markdown Function
+async function renderMarkdown(content: string) {
+    console.log("rendering now");
+    renderedHtml.value = await marked(content);
+    await nextTick();
+    renderMermaidDiagrams();
+}
+
+// Render Mermaid Diagrams
+function renderMermaidDiagrams() {
+    const mermaidElements = document.querySelectorAll(".language-mermaid");
+    mermaidElements.forEach((element) => {
+        const parent = element.parentElement;
+        const code = element.textContent || "";
+        if (parent) {
+            try {
+                const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
+                mermaid.render(id, code).then((value) => (parent.innerHTML = value.svg));
+            } catch (e) {
+                console.error("Mermaid rendering error:", e);
+            }
+        }
+    });
+}
+</script>
+
+<template>
+    <div v-html="renderedHtml"></div>
+</template>

--- a/website/pages/workflow/[id].vue
+++ b/website/pages/workflow/[id].vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onBeforeMount } from "vue";
 import { useRoute } from "vue-router";
-import { marked } from "marked";
+import MarkdownRenderer from "./MarkdownRenderer.vue";
 import Author from "~/components/Author.vue";
 import { useWorkflowStore } from "~/stores/workflows";
 
@@ -15,10 +15,6 @@ const formatDate = (date: string) => {
         month: "long",
         day: "numeric",
     });
-};
-
-const parseMarkdown = (content: string) => {
-    return marked(content);
 };
 
 // TODO: Add a component for authors.  For now, just have a computed that grabs names and joins them
@@ -92,13 +88,13 @@ const tabs = computed(() => [
         content: workflow.value?.changelog || "No CHANGELOG available.",
     },
     {
+        label: "Diagram",
+        content: workflow.value?.diagrams || "No diagram available",
+    },
+    {
         label: "Tools",
         tools: tools || "This tab will show a nice listing of all the tools used in this workflow.",
     },
-    // {
-    //     label: "Preview",
-    //     preview: true,
-    // },
 ]);
 
 /* Instance Selector -- factor out to a component */
@@ -187,13 +183,13 @@ const onInstanceChange = (value: string) => {
                         </template>
                         <template #item="{ item }">
                             <div v-if="item.content" class="mt-6">
-                                <div
-                                    class="prose dark:prose-invert !max-w-none"
-                                    v-html="parseMarkdown(item.content)"></div>
+                                <div class="prose dark:prose-invert !max-w-none">
+                                    <MarkdownRenderer :markdownContent="item.content" />
+                                </div>
                             </div>
                             <div v-else-if="item.tools" class="mt-6">
                                 <div class="prose dark:prose-invert !max-w-none">
-                                    <h3>The following tools are required to run this workflow.</h3>
+                                    <h3>The following tools are used by this workflow.</h3>
                                     <p>
                                         This will eventually be a pretty page with links to each tool in the (new)
                                         toolshed, etc.

--- a/website/pages/workflow/[id].vue
+++ b/website/pages/workflow/[id].vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onBeforeMount } from "vue";
 import { useRoute } from "vue-router";
-import MarkdownRenderer from "./MarkdownRenderer.vue";
+import MarkdownRenderer from "~/components/MarkdownRenderer.vue";
 import Author from "~/components/Author.vue";
 import { useWorkflowStore } from "~/stores/workflows";
 


### PR DESCRIPTION
These are pretty cool.
<img width="1464" alt="Screenshot 2024-12-09 at 15 44 29" src="https://github.com/user-attachments/assets/f5919e22-71c5-4148-9f28-147e30fc2272">



 I guess some possible next steps might be
- [x] render the mermaid diagrams in the static site
- [x] render subworkflow steps into the same markdown file
- [ ] include diagram in readme.md file
- [ ] use hyperlinks to move users to subworkflows
- [ ] explore tool tips to maybe show tool ids