### PR TITLE
Fix stuck colormode in website

### DIFF
--- a/website/plugins/colorMode.ts
+++ b/website/plugins/colorMode.ts
@@ -1,0 +1,9 @@
+// Forces light color mode even if localStorage already contains saved preference.
+// `colorMode.preference` setting from `nuxt.config.ts` is not enough in this case.
+export default defineNuxtPlugin((nuxtApp) => {
+    const colorMode = useColorMode();
+    nuxtApp.hook("app:mounted", () => {
+        colorMode.preference = "light";
+        colorMode.value = "light";
+    });
+});

--- a/website/plugins/colorMode.ts
+++ b/website/plugins/colorMode.ts
@@ -1,5 +1,6 @@
 // Forces light color mode even if localStorage already contains saved preference.
 // `colorMode.preference` setting from `nuxt.config.ts` is not enough in this case.
+// xref https://github.com/nuxt/ui/issues/227
 export default defineNuxtPlugin((nuxtApp) => {
     const colorMode = useColorMode();
     nuxtApp.hook("app:mounted", () => {


### PR DESCRIPTION
If someone happened to visit iwc.galaxyproject.org with dark mode enabled prior to us swapping to a galaxy-themed light mode by default, the browser could get stuck in dark mode due to the way nuxt stores a key in local storage without unsetting it.  This is a workaround that unsticks the stuck mode.

FOR CONTRIBUTOR:
* [x] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [x] License permits unrestricted use (educational + commercial)
* [x] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
