### PR TITLE
Tweak name and description of rnaseq-pe/sr and brew3r workflow

### DIFF
--- a/workflows/transcriptomics/brew3r/BREW3R.ga
+++ b/workflows/transcriptomics/brew3r/BREW3R.ga
@@ -1,6 +1,6 @@
 {
     "a_galaxy_workflow": "true",
-    "annotation": "This workflow takes a collection of BAM (output of STAR) and a gtf. It extends the input gtf using de novo annotation.",
+    "annotation": "Extends 3' ends of gene annotations using BAM files (from STAR alignments) and a reference GTF. Specifically designed for 3'-biased sequencing techniques like 10X scRNA-seq or BRB-seq that primarily capture transcript 3' ends. The BREW3R tool enhances annotations by using evidence from RNA-seq data to improve 3' UTR definitions, which is particularly important for accurate quantification in single-cell and bulk RNA-seq experiments.",
     "comments": [],
     "creator": [
         {

--- a/workflows/transcriptomics/rnaseq-pe/README.md
+++ b/workflows/transcriptomics/rnaseq-pe/README.md
@@ -1,4 +1,4 @@
-# RNA-seq paired-end Workflow
+# RNA-Seq Analysis: Paired-End Read Processing and Quantification
 
 ## Inputs dataset
 

--- a/workflows/transcriptomics/rnaseq-pe/rnaseq-pe.ga
+++ b/workflows/transcriptomics/rnaseq-pe/rnaseq-pe.ga
@@ -1,6 +1,6 @@
 {
     "a_galaxy_workflow": "true",
-    "annotation": "This workflow takes as input a list of paired-end fastqs. Adapters and bad quality bases are removed with fastp. Reads are mapped with STAR with ENCODE parameters and genes are counted simultaneously as well as normalized coverage (per million mapped reads) on uniquely mapped reads. The counts are reprocessed to be similar to HTSeq-count output. Alternatively, featureCounts can be used to count the reads/fragments per gene. FPKM are computed with cufflinks and/or with StringTie. The unstranded normalized coverage is computed with bedtools.\n",
+    "annotation": "Complete RNA-Seq analysis for paired-end data: quality control with fastp to remove adapters and low-quality bases, alignment with STAR using ENCODE parameters, gene quantification via multiple methods (STAR and featureCounts), and expression calculation (FPKM with Cufflinks/StringTie, normalized coverage with bedtools). Processes raw FASTQ files to produce count tables, normalized expression values, and genomic coverage tracks. Supports stranded and unstranded libraries, generating both HTSeq-compatible counts and normalized measures for downstream analysis.",
     "comments": [
         {
             "child_steps": [
@@ -80,7 +80,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "release": "1.2",
-    "name": "RNA-seq for Paired-end fastqs",
+    "name": "RNA-Seq Analysis: Paired-End Read Processing and Quantification",
     "report": {
         "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
     },

--- a/workflows/transcriptomics/rnaseq-sr/README.md
+++ b/workflows/transcriptomics/rnaseq-sr/README.md
@@ -1,4 +1,4 @@
-# RNA-seq single-read Workflow
+# RNA-Seq Analysis: Single-End Read Processing and Quantification
 
 ## Inputs dataset
 

--- a/workflows/transcriptomics/rnaseq-sr/rnaseq-sr.ga
+++ b/workflows/transcriptomics/rnaseq-sr/rnaseq-sr.ga
@@ -1,6 +1,6 @@
 {
     "a_galaxy_workflow": "true",
-    "annotation": "This workflow takes as input a list of single-end fastqs. Adapters and bad quality bases are removed with fastp. Reads are mapped with STAR with ENCODE parameters and genes are counted simultaneously as well as normalized coverage (per million mapped reads) on uniquely mapped reads. The counts are reprocessed to be similar to HTSeq-count output. Alternatively, featureCounts can be used to count the reads/fragments per gene. FPKM are computed with cufflinks and/or with StringTie. The unstranded normalized coverage is computed with bedtools.\n",
+    "annotation": "Complete RNA-Seq analysis for single-end data: quality control with fastp to remove adapters and low-quality bases, alignment with STAR using ENCODE parameters, gene quantification via multiple methods (STAR and featureCounts), and expression calculation (FPKM with Cufflinks/StringTie, normalized coverage with bedtools). Processes raw FASTQ files to produce count tables, normalized expression values, and genomic coverage tracks. Supports stranded and unstranded libraries, generating both HTSeq-compatible counts and normalized measures for downstream analysis.",
     "comments": [
         {
             "child_steps": [
@@ -80,7 +80,7 @@
     "format-version": "0.1",
     "license": "MIT",
     "release": "1.2",
-    "name": "RNA-seq for Single-read fastqs",
+    "name": "RNA-Seq Analysis: Single-End Read Processing and Quantification",
     "report": {
         "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
     },


### PR DESCRIPTION
This is from an attempt with claude code. I think this will look and read a little nicer on iwc.galaxyproject.org and e.g. https://brc-analytics.org/data/assemblies/GCF_000005575_2

FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
