### PR TITLE
Add trsID to workflow page, dump UUID

### DIFF
--- a/website/pages/workflow/[id].vue
+++ b/website/pages/workflow/[id].vue
@@ -146,8 +146,9 @@ const onInstanceChange = (value: string) => {
                     <li><strong>License: </strong>{{ workflow.definition.license }}</li>
                     <li>
                         <strong>TRS: </strong>
-                        <ULink :to="dockstoreWorkflowPageUrl" target="_blank">
+                        <ULink :to="dockstoreWorkflowPageUrl" target="_blank" class="hover:underline">
                             {{ workflow.trsID }}
+                            <UIcon name="i-heroicons-arrow-top-right-on-square" />
                         </ULink>
                     </li>
                 </ul>

--- a/website/pages/workflow/[id].vue
+++ b/website/pages/workflow/[id].vue
@@ -43,6 +43,12 @@ function trsIdAndVersionToDockstoreUrl(trs_id: string, trs_version: string) {
     return `https://dockstore.org/api/ga4gh/trs/v2/tools/${trs_id}/versions/${trs_version}`;
 }
 
+const dockstoreWorkflowPageUrl = computed(() => {
+    const repoPath = workflow.value?.trsID.substring("#workflow/".length);
+    const baseUrl = "https://dockstore.org/workflows/";
+    return baseUrl + repoPath;
+});
+
 async function createLandingPage() {
     const job = testToRequestState();
     const trs_url = trsIdAndVersionToDockstoreUrl(workflow.value?.trsID!, `v${workflow.value?.definition.release}`);
@@ -135,10 +141,15 @@ const onInstanceChange = (value: string) => {
                     <li class="ml-2" v-for="author in workflow.authors" :key="author.name">
                         <Author :author="author" />
                     </li>
-                    <li><strong>Release:</strong> {{ workflow.definition.release }}</li>
-                    <li><strong>Updated:</strong> {{ formatDate(workflow.updated) }}</li>
-                    <li><strong>License:</strong> {{ workflow.definition.license }}</li>
-                    <li><strong>UniqueID:</strong> {{ workflow.definition.uuid }}</li>
+                    <li><strong>Release: </strong>{{ workflow.definition.release }}</li>
+                    <li><strong>Updated: </strong>{{ formatDate(workflow.updated) }}</li>
+                    <li><strong>License: </strong>{{ workflow.definition.license }}</li>
+                    <li>
+                        <strong>TRS: </strong>
+                        <ULink :to="dockstoreWorkflowPageUrl" target="_blank">
+                            {{ workflow.trsID }}
+                        </ULink>
+                    </li>
                 </ul>
                 <UButtonGroup class="mt-4" size="sm" orientation="vertical">
                     <USelect


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/285949e4-663d-4a70-9962-961aea4b19a3)


FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
