### PR TITLE
Implement date extraction from CHANGELOG.md for workflow updates inst…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ marko~=1.0
 packaging~=21.0
 planemo>=0.74.5
 requests~=2.32
-GitPython==3.1.44


### PR DESCRIPTION
…ead of git, filesystem, etc.

Note: Requires several changelogs to be updated.

See output:
```
Could not extract date from CHANGELOG.md for ./workflows/genome\_annotation/functional-annotation/functional-annotation-protein-sequences/Functional\_annotation\_of\_protein\_sequences.ga
No CHANGELOG.md at ./workflows/proteomics/clinicalmp/clinicalmp-quantitation/CHANGELOG.md
Could not extract date from CHANGELOG.md for ./workflows/proteomics/clinicalmp/clinicalmp-quantitation/iwc-clinicalmp-quantitation.ga
Could not extract date from CHANGELOG.md for ./workflows/repeatmasking/RepeatMasking-Workflow.ga
Could not extract date from CHANGELOG.md for ./workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-paired-end/mgnify-amplicon-pipeline-v5-quality-control-paired-end.ga
Could not extract date from CHANGELOG.md for ./workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.ga
Could not extract date from CHANGELOG.md for ./workflows/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2.ga
Could not extract date from CHANGELOG.md for ./workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-its/mgnify-amplicon-pipeline-v5-its.ga
Could not extract date from CHANGELOG.md for ./workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction.ga
Could not extract date from CHANGELOG.md for ./workflows/amplicon-mgnify/mgnify-amplicon-taxonomic-summary-tables/mgnify-amplicon-summary-tables.ga
Could not extract date from CHANGELOG.md for ./workflows/amplicon-mgnify/taxonomic-rank-abundance-summary-table/taxonomic-rank-abundance-summary-table.ga
```


FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
