### PR TITLE
Updating workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete from 0.1 to 0.2

### DIFF
--- a/workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/CHANGELOG.md
+++ b/workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2] - 2025-03-10
+
+- `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy3` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4`
+
 ## [0.1] - 2025-01-27
 
 - First release
+

--- a/workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.ga
+++ b/workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.ga
@@ -24,7 +24,7 @@
     "format-version": "0.1",
     "license": "Apache-2.0",
     "name": "MGnify's amplicon pipeline v5.0",
-    "release": "0.1",
+    "release": "0.2",
     "report": {
         "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
     },
@@ -103,12 +103,18 @@
                 "top": 819.4217522631932
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 4, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 4, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "39e0bbb8-def5-4cbe-875d-0e75d5e37495",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "c5d53876-d142-4894-b4c3-ad8050f99c4e"
+                }
+            ]
         },
         "3": {
             "annotation": "Average quality required.",
@@ -130,12 +136,18 @@
                 "top": 978.9369402822651
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 15, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 15, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "21106922-bb34-4647-9bee-446710c7d8d5",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "e7ef19ff-8b63-44fe-89ad-1af652c4d448"
+                }
+            ]
         },
         "4": {
             "annotation": "Enable base correction in overlapped regions. (Paired-end)",
@@ -157,12 +169,18 @@
                 "top": 1028.289063251411
             },
             "tool_id": null,
-            "tool_state": "{\"default\": false, \"parameter_type\": \"boolean\", \"optional\": true}",
+            "tool_state": "{\"default\": false, \"validators\": [], \"parameter_type\": \"boolean\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "90776758-eb1e-494a-9c34-d891fb22552b",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "d341c6bd-fbd9-4518-a876-a33fe535aefa"
+                }
+            ]
         },
         "5": {
             "annotation": "Cut bases off the start of a read, if below a threshold quality.",
@@ -184,12 +202,18 @@
                 "top": 1146.685722505959
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 3, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 3, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "869e3248-10ca-44f5-98bb-5e520658b9bd",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "32ee6eaf-77d7-434c-a4b4-062a7e7bbf77"
+                }
+            ]
         },
         "6": {
             "annotation": "The quality value that a base is qualified. (Paired-end)",
@@ -211,12 +235,18 @@
                 "top": 1113.6330085401016
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 20, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 20, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "9d0bfec9-8ab2-4d46-af38-65e8d9f38445",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "90b61e87-42f0-48c1-8254-ed1f3f33930e"
+                }
+            ]
         },
         "7": {
             "annotation": "Cut bases off the end of a read, if below a threshold quality.",
@@ -238,12 +268,18 @@
                 "top": 1261.7442025767366
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 3, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 3, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "a5f602ee-06ac-4c40-a5db-2bac77112f97",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "13617016-e6d5-4534-856f-d71f2ab9009e"
+                }
+            ]
         },
         "8": {
             "annotation": "How many percents of bases are allowed to be unqualified (0~100). (Paired-end)",
@@ -265,12 +301,18 @@
                 "top": 1202.899671137758
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 20, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 20, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "3ccea377-db95-4eea-83d8-864f942e3347",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "0a598f79-1f8c-4138-9ab7-0ca37335e019"
+                }
+            ]
         },
         "9": {
             "annotation": "Minimum length of reads to be kept.",
@@ -292,12 +334,18 @@
                 "top": 1361.1919895694223
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 100, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 100, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "183a6499-b9e0-4844-a4cd-f5de8804f1e1",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "b0fa56cc-bee8-44d5-84ad-76807fc1a578"
+                }
+            ]
         },
         "10": {
             "annotation": "Reads shorter than this value will be discarded. (Paired-end)",
@@ -319,12 +367,18 @@
                 "top": 1290.0829902295552
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 70, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 70, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "4c9fd5af-fd9b-45f2-8fe5-31852d05cab1",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "ee33e922-cba5-445b-b9e5-ccdffd94fb26"
+                }
+            ]
         },
         "11": {
             "annotation": "Minimum sequence length.",
@@ -346,12 +400,18 @@
                 "top": 1451.7558900147008
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 100, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 100, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "d5361c5a-2500-4dbd-bbc2-907d0b067fc4",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "18e5d64a-f7aa-4e56-bb23-63ef0c18705c"
+                }
+            ]
         },
         "12": {
             "annotation": "Maximal N percentage threshold to conserve sequences.",
@@ -373,12 +433,18 @@
                 "top": 1678.1509474535085
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 10, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 10, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "1503e81e-64d4-473c-bde9-751ba2bb9143",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "3e8bed6d-72f3-4e26-afb7-bf972f045220"
+                }
+            ]
         },
         "13": {
             "annotation": "",
@@ -400,12 +466,18 @@
                 "top": 312.316
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"SSU taxonomic abundance summary table\", \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"default\": \"SSU taxonomic abundance summary table\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "44cdc1f5-5482-4843-915c-3eeec13e63ff",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "3cc13b6a-e268-4d8e-a90c-48be99907e67"
+                }
+            ]
         },
         "14": {
             "annotation": "",
@@ -427,12 +499,18 @@
                 "top": 434.316
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"SSU phylum level taxonomic abundance summary table\", \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"default\": \"SSU phylum level taxonomic abundance summary table\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "7a186613-22f7-406c-a464-566889fba9b6",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "f4582772-faba-4bbd-a595-8fc34f243827"
+                }
+            ]
         },
         "15": {
             "annotation": "",
@@ -454,12 +532,18 @@
                 "top": 709.316
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"LSU taxonomic abundance summary table\", \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"default\": \"LSU taxonomic abundance summary table\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "c5976795-446d-465b-a17b-89f88cd36609",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "de7596f3-4f46-419f-b0be-5d740b54276d"
+                }
+            ]
         },
         "16": {
             "annotation": "",
@@ -481,12 +565,18 @@
                 "top": 849.316
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"LSU phylum level taxonomic abundance summary table\", \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"default\": \"LSU phylum level taxonomic abundance summary table\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "0d031f24-2524-4111-8199-fde1fed46abd",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "f452f791-82d5-472a-b420-9092e83afe23"
+                }
+            ]
         },
         "17": {
             "annotation": "",
@@ -508,12 +598,18 @@
                 "top": 1091.316
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"ITSoneDB taxonomic abundance summary table\", \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"default\": \"ITSoneDB taxonomic abundance summary table\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "78990ece-405a-4a82-8a7c-87c4efbe396f",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "553f2a89-8c9f-48b7-95fd-435c119196f1"
+                }
+            ]
         },
         "18": {
             "annotation": "",
@@ -535,12 +631,18 @@
                 "top": 1216.316
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"ITSoneDB phylum level taxonomic abundance summary table\", \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"default\": \"ITSoneDB phylum level taxonomic abundance summary table\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "25b414b3-afe1-48b1-81cd-37059285b496",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "aea46859-6247-451c-bdc3-1a55cf1bfb71"
+                }
+            ]
         },
         "19": {
             "annotation": "",
@@ -562,12 +664,18 @@
                 "top": 1502.316
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"ITS UNITE DB taxonomic abundance summary table\", \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"default\": \"ITS UNITE DB taxonomic abundance summary table\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "d6da448e-070a-423e-9f7e-182b7d20340c",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "f5073b25-51e5-4993-9485-ee3ca865d3d7"
+                }
+            ]
         },
         "20": {
             "annotation": "",
@@ -589,12 +697,18 @@
                 "top": 1629.316
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"ITS UNITE DB phylum level taxonomic abundance summary table\", \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"default\": \"ITS UNITE DB phylum level taxonomic abundance summary table\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "2f17ad42-aebe-4069-9907-ca85aec8df82",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "e956ae54-0059-457d-96e0-6c964e1026f4"
+                }
+            ]
         },
         "21": {
             "annotation": "",
@@ -1068,12 +1182,18 @@
                             "top": 0
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": 15, \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_state": "{\"default\": 15, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "7b3ec08b-9dd4-4215-8901-c0eb6f0be3e7",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "dc036460-5da1-4fd8-bc90-39f026ed738f"
+                            }
+                        ]
                     },
                     "2": {
                         "annotation": "Cut bases off the start of a read, if below a threshold quality.",
@@ -1095,12 +1215,18 @@
                             "top": 373.00000000000085
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": 3, \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_state": "{\"default\": 3, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "2f3fe5f1-44e3-4117-9417-d68b8a90aa23",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "cbc31256-f1f7-40f6-a21d-1e2dc968bc64"
+                            }
+                        ]
                     },
                     "3": {
                         "annotation": "Number of bases to average across.",
@@ -1122,12 +1248,18 @@
                             "top": 90.00000000000021
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": 4, \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_state": "{\"default\": 4, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "5b70e0b8-0631-4059-aa36-d1ce896e45b1",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "225ef644-f8cf-489a-8de3-95e7c67d471d"
+                            }
+                        ]
                     },
                     "4": {
                         "annotation": "Cut bases off the end of a read, if below a threshold quality.",
@@ -1149,12 +1281,18 @@
                             "top": 501.2064765902164
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": 3, \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_state": "{\"default\": 3, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "eed3e996-2baf-4908-ba47-449254adc3cb",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "87a0516a-a12b-44ca-b4a4-bc3e3f9ae30b"
+                            }
+                        ]
                     },
                     "5": {
                         "annotation": "Minimum length of reads to be kept.",
@@ -1176,12 +1314,18 @@
                             "top": 624.2064765902168
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": 100, \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_state": "{\"default\": 100, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "08f7f8d1-ad75-42cf-91e0-bb549c8edd14",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "4cf4eeb3-bc3f-4134-bc0b-dc5f31e061c5"
+                            }
+                        ]
                     },
                     "6": {
                         "annotation": "Minimum sequence length.",
@@ -1203,12 +1347,18 @@
                             "top": 219.62078434990826
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": 100, \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_state": "{\"default\": 100, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "5db2e477-4d58-4380-bc0d-e02a2249045c",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "62b85a60-f703-47d4-9e73-6e11cedd4b7b"
+                            }
+                        ]
                     },
                     "7": {
                         "annotation": "Maximal N percentage threshold to conserve sequences.",
@@ -1230,12 +1380,18 @@
                             "top": 192.6829501818756
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": 10, \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_state": "{\"default\": 10, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "1d6681c7-d75f-49ce-a21b-e5779b0cadca",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "d1f7d15b-61fb-425b-81f7-b7345dcebb1d"
+                            }
+                        ]
                     },
                     "8": {
                         "annotation": "",
@@ -2063,6 +2219,31 @@
             "when": null,
             "workflow_outputs": [
                 {
+                    "label": null,
+                    "output_name": "5:output",
+                    "uuid": "b1c6fded-5c97-4745-92e8-3dacd0c6903f"
+                },
+                {
+                    "label": null,
+                    "output_name": "4:output",
+                    "uuid": "0a2b0e91-7e11-44e3-9f23-781ff4354104"
+                },
+                {
+                    "label": null,
+                    "output_name": "6:output",
+                    "uuid": "6da43c77-dd90-4af6-892b-d04dd0e74fe3"
+                },
+                {
+                    "label": null,
+                    "output_name": "7:output",
+                    "uuid": "525097b0-720d-4fd0-b220-62c89a632868"
+                },
+                {
+                    "label": "Single-end MultiQC report",
+                    "output_name": "Single-end MultiQC report",
+                    "uuid": "524978e4-ce01-4152-95e5-4e1ef5d48c3a"
+                },
+                {
                     "label": "Single-end post quality control FASTA files",
                     "output_name": "Single-end post quality control FASTA files",
                     "uuid": "306311fc-4935-4aae-b9ad-ade3901e134d"
@@ -2073,9 +2254,19 @@
                     "uuid": "90e90edf-c318-42bf-a359-02d7d2bab053"
                 },
                 {
-                    "label": "Single-end MultiQC report",
-                    "output_name": "Single-end MultiQC report",
-                    "uuid": "524978e4-ce01-4152-95e5-4e1ef5d48c3a"
+                    "label": null,
+                    "output_name": "1:output",
+                    "uuid": "63dfbed0-86f2-4656-a7c2-35088ec0a1a5"
+                },
+                {
+                    "label": null,
+                    "output_name": "2:output",
+                    "uuid": "f0321ebe-d7db-4627-85f2-826a3354b0f7"
+                },
+                {
+                    "label": null,
+                    "output_name": "3:output",
+                    "uuid": "6f5cf708-fa12-4f5c-bc65-c988983a5c91"
                 }
             ]
         },
@@ -2199,7 +2390,7 @@
                         "outputs": [],
                         "position": {
                             "left": 0,
-                            "top": 15.048431485651236
+                            "top": 134.00843148565127
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list:paired\"}",
@@ -2226,10 +2417,10 @@
                         "outputs": [],
                         "position": {
                             "left": 67.94649253008049,
-                            "top": 198.09430885853078
+                            "top": 317.0543088585308
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": false, \"parameter_type\": \"boolean\", \"optional\": true}",
+                        "tool_state": "{\"default\": false, \"validators\": [], \"parameter_type\": \"boolean\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "81367449-c0ca-41be-b69d-5bf1568e0361",
@@ -2253,10 +2444,10 @@
                         "outputs": [],
                         "position": {
                             "left": 309.2157898611554,
-                            "top": 210.97762085193767
+                            "top": 329.9376208519377
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": 20, \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_state": "{\"default\": 20, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "cb8a7bac-c007-45c6-814b-9aacae0e37b3",
@@ -2280,10 +2471,10 @@
                         "outputs": [],
                         "position": {
                             "left": 311.55821022359305,
-                            "top": 301.16080480578603
+                            "top": 420.12080480578607
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": 20, \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_state": "{\"default\": 20, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "26ed5910-22cf-4a8e-a144-edbb8d6b1d50",
@@ -2307,10 +2498,10 @@
                         "outputs": [],
                         "position": {
                             "left": 310.3870000423742,
-                            "top": 387.830358215978
+                            "top": 506.790358215978
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": 70, \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_state": "{\"default\": 70, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "6521e9f3-6d1b-4e95-8934-3345f858bcf8",
@@ -2334,10 +2525,10 @@
                         "outputs": [],
                         "position": {
                             "left": 310.8945435169014,
-                            "top": 499.8566406435558
+                            "top": 618.8166406435558
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": 4, \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_state": "{\"default\": 4, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "1b2652b0-235b-4120-9c82-e4d3210c9d2f",
@@ -2361,10 +2552,10 @@
                         "outputs": [],
                         "position": {
                             "left": 312.5205763417023,
-                            "top": 632.1894950478717
+                            "top": 751.1494950478717
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": 15, \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_state": "{\"default\": 15, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "53e87ca4-6745-4835-b25f-878705737f0d",
@@ -2388,10 +2579,10 @@
                         "outputs": [],
                         "position": {
                             "left": 315.85885539878177,
-                            "top": 761.5628796617777
+                            "top": 880.5228796617778
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": 3, \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_state": "{\"default\": 3, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "4e1cfaad-b067-4bf3-a6b8-33d3fd826285",
@@ -2415,10 +2606,10 @@
                         "outputs": [],
                         "position": {
                             "left": 330.0774689415621,
-                            "top": 854.9611632212501
+                            "top": 973.9211632212501
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": 3, \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_state": "{\"default\": 3, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "d48c0437-1ab6-4fd4-8dfa-29dd056acaec",
@@ -2426,37 +2617,10 @@
                         "workflow_outputs": []
                     },
                     "9": {
-                        "annotation": "Minimum length of reads to be kept.",
-                        "content_id": null,
-                        "errors": null,
-                        "id": 9,
-                        "input_connections": {},
-                        "inputs": [
-                            {
-                                "description": "Minimum length of reads to be kept.",
-                                "name": "Trimmomatic - MINLEN"
-                            }
-                        ],
-                        "label": "Trimmomatic - MINLEN",
-                        "name": "Input parameter",
-                        "outputs": [],
-                        "position": {
-                            "left": 332.17940873206794,
-                            "top": 943.1950248633116
-                        },
-                        "tool_id": null,
-                        "tool_state": "{\"default\": 100, \"parameter_type\": \"integer\", \"optional\": true}",
-                        "tool_version": null,
-                        "type": "parameter_input",
-                        "uuid": "c898eada-b136-40bf-a78d-240b8d02c660",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "10": {
                         "annotation": "Minimum sequence length.",
                         "content_id": null,
                         "errors": null,
-                        "id": 10,
+                        "id": 9,
                         "input_connections": {},
                         "inputs": [
                             {
@@ -2469,13 +2633,40 @@
                         "outputs": [],
                         "position": {
                             "left": 993.3486541402174,
-                            "top": 245.3668565107227
+                            "top": 364.32685651072273
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": 100, \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_state": "{\"default\": 100, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "2957cfb6-b542-4354-b94f-fd171df4c9b1",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "10": {
+                        "annotation": "Minimum length of reads to be kept.",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 10,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "Minimum length of reads to be kept.",
+                                "name": "Trimmomatic - MINLEN"
+                            }
+                        ],
+                        "label": "Trimmomatic - MINLEN",
+                        "name": "Input parameter",
+                        "outputs": [],
+                        "position": {
+                            "left": 332.17940873206794,
+                            "top": 1062.1550248633116
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"default\": 100, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_version": null,
+                        "type": "parameter_input",
+                        "uuid": "c898eada-b136-40bf-a78d-240b8d02c660",
                         "when": null,
                         "workflow_outputs": []
                     },
@@ -2496,10 +2687,10 @@
                         "outputs": [],
                         "position": {
                             "left": 1443.0933637282412,
-                            "top": 118.73561171734482
+                            "top": 237.69561171734486
                         },
                         "tool_id": null,
-                        "tool_state": "{\"default\": 10, \"parameter_type\": \"integer\", \"optional\": true}",
+                        "tool_state": "{\"default\": 10, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "d8341e6e-1401-48ef-ac1a-68c98309d0e1",
@@ -2508,13 +2699,81 @@
                     },
                     "12": {
                         "annotation": "",
-                        "content_id": "__UNZIP_COLLECTION__",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4",
                         "errors": null,
                         "id": 12,
                         "input_connections": {
-                            "input": {
+                            "filter_options|length_filtering_options|length_required": {
+                                "id": 4,
+                                "output_name": "output"
+                            },
+                            "filter_options|quality_filtering_options|qualified_quality_phred": {
+                                "id": 2,
+                                "output_name": "output"
+                            },
+                            "filter_options|quality_filtering_options|unqualified_percent_limit": {
+                                "id": 3,
+                                "output_name": "output"
+                            },
+                            "read_mod_options|base_correction_options|correction": {
+                                "id": 1,
+                                "output_name": "output"
+                            },
+                            "single_paired|paired_input": {
                                 "id": 0,
                                 "output_name": "output"
+                            }
+                        },
+                        "inputs": [
+                            {
+                                "description": "runtime parameter for tool fastp",
+                                "name": "single_paired"
+                            }
+                        ],
+                        "label": null,
+                        "name": "fastp",
+                        "outputs": [
+                            {
+                                "name": "output_paired_coll",
+                                "type": "input"
+                            },
+                            {
+                                "name": "report_html",
+                                "type": "html"
+                            },
+                            {
+                                "name": "report_json",
+                                "type": "json"
+                            }
+                        ],
+                        "position": {
+                            "left": 331.5,
+                            "top": 0.0
+                        },
+                        "post_job_actions": {},
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4",
+                        "tool_shed_repository": {
+                            "changeset_revision": "10678d49d39e",
+                            "name": "fastp",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": {\"__class__\": \"ConnectedValue\"}, \"unqualified_percent_limit\": {\"__class__\": \"ConnectedValue\"}, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": {\"__class__\": \"ConnectedValue\"}, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": null, \"umi_len\": null, \"umi_prefix\": null}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": {\"__class__\": \"ConnectedValue\"}}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 1, \"paired_input\": {\"__class__\": \"RuntimeValue\"}, \"merge_reads\": {\"merge\": \"\", \"__current_case__\": 1}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": null, \"adapter_sequence2\": null, \"detect_adapter_for_pe\": false}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "0.24.0+galaxy4",
+                        "type": "tool",
+                        "uuid": "9b7f1d2d-d39f-407d-a709-a5095fca62c2",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "13": {
+                        "annotation": "",
+                        "content_id": "__UNZIP_COLLECTION__",
+                        "errors": null,
+                        "id": 13,
+                        "input_connections": {
+                            "input": {
+                                "id": 12,
+                                "output_name": "output_paired_coll"
                             }
                         },
                         "inputs": [],
@@ -2531,8 +2790,8 @@
                             }
                         ],
                         "position": {
-                            "left": 326.2817086942314,
-                            "top": 0
+                            "left": 610.2833251953125,
+                            "top": 342.9666748046875
                         },
                         "post_job_actions": {
                             "ChangeDatatypeActionforward": {
@@ -2568,107 +2827,6 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "13": {
-                        "annotation": "Filtering of forward and reverse paired-end reads.",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy3",
-                        "errors": null,
-                        "id": 13,
-                        "input_connections": {
-                            "filter_options|length_filtering_options|length_required": {
-                                "id": 4,
-                                "output_name": "output"
-                            },
-                            "filter_options|quality_filtering_options|qualified_quality_phred": {
-                                "id": 2,
-                                "output_name": "output"
-                            },
-                            "filter_options|quality_filtering_options|unqualified_percent_limit": {
-                                "id": 3,
-                                "output_name": "output"
-                            },
-                            "read_mod_options|base_correction_options|correction": {
-                                "id": 1,
-                                "output_name": "output"
-                            },
-                            "single_paired|in1": {
-                                "id": 12,
-                                "output_name": "forward"
-                            },
-                            "single_paired|in2": {
-                                "id": 12,
-                                "output_name": "reverse"
-                            }
-                        },
-                        "inputs": [
-                            {
-                                "description": "runtime parameter for tool fastp",
-                                "name": "single_paired"
-                            },
-                            {
-                                "description": "runtime parameter for tool fastp",
-                                "name": "single_paired"
-                            }
-                        ],
-                        "label": "fastp filtering",
-                        "name": "fastp",
-                        "outputs": [
-                            {
-                                "name": "out1",
-                                "type": "input"
-                            },
-                            {
-                                "name": "out2",
-                                "type": "input"
-                            },
-                            {
-                                "name": "report_html",
-                                "type": "html"
-                            },
-                            {
-                                "name": "report_json",
-                                "type": "json"
-                            }
-                        ],
-                        "position": {
-                            "left": 578.1256188749957,
-                            "top": 186.01134288495575
-                        },
-                        "post_job_actions": {
-                            "HideDatasetActionout1": {
-                                "action_arguments": {},
-                                "action_type": "HideDatasetAction",
-                                "output_name": "out1"
-                            },
-                            "HideDatasetActionout2": {
-                                "action_arguments": {},
-                                "action_type": "HideDatasetAction",
-                                "output_name": "out2"
-                            },
-                            "HideDatasetActionreport_html": {
-                                "action_arguments": {},
-                                "action_type": "HideDatasetAction",
-                                "output_name": "report_html"
-                            },
-                            "HideDatasetActionreport_json": {
-                                "action_arguments": {},
-                                "action_type": "HideDatasetAction",
-                                "output_name": "report_json"
-                            }
-                        },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy3",
-                        "tool_shed_repository": {
-                            "changeset_revision": "a626e8c0e1ba",
-                            "name": "fastp",
-                            "owner": "iuc",
-                            "tool_shed": "toolshed.g2.bx.psu.edu"
-                        },
-                        "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": {\"__class__\": \"ConnectedValue\"}, \"unqualified_percent_limit\": {\"__class__\": \"ConnectedValue\"}, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": {\"__class__\": \"ConnectedValue\"}, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": null, \"umi_len\": null, \"umi_prefix\": null}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": {\"__class__\": \"ConnectedValue\"}}}, \"single_paired\": {\"single_paired_selector\": \"paired\", \"__current_case__\": 1, \"in1\": {\"__class__\": \"ConnectedValue\"}, \"in2\": {\"__class__\": \"ConnectedValue\"}, \"merge_reads\": {\"merge\": \"\", \"__current_case__\": 1}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": null, \"adapter_sequence2\": null, \"detect_adapter_for_pe\": false}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "0.24.0+galaxy3",
-                        "type": "tool",
-                        "uuid": "6d9e0ee3-cc0f-423e-8613-0ad0b5b3de0b",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
                     "14": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/mgnify_seqprep/mgnify_seqprep/1.2+galaxy0",
@@ -2677,11 +2835,11 @@
                         "input_connections": {
                             "input1": {
                                 "id": 13,
-                                "output_name": "out1"
+                                "output_name": "forward"
                             },
                             "input2": {
                                 "id": 13,
-                                "output_name": "out2"
+                                "output_name": "reverse"
                             }
                         },
                         "inputs": [],
@@ -2703,7 +2861,7 @@
                         ],
                         "position": {
                             "left": 788.0499877929688,
-                            "top": 530.4190556311589
+                            "top": 649.379055631159
                         },
                         "post_job_actions": {
                             "ChangeDatatypeActionmerged": {
@@ -2766,7 +2924,7 @@
                                 "output_name": "output"
                             },
                             "operations_3|operation|minlen": {
-                                "id": 9,
+                                "id": 10,
                                 "output_name": "output"
                             },
                             "readtype|fastq_in": {
@@ -2790,7 +2948,7 @@
                         ],
                         "position": {
                             "left": 1099.8073621070885,
-                            "top": 359.9795420250569
+                            "top": 478.93954202505694
                         },
                         "post_job_actions": {
                             "HideDatasetActionfastq_out": {
@@ -2852,7 +3010,7 @@
                         ],
                         "position": {
                             "left": 1250.6521000986795,
-                            "top": 1081.9540694839034
+                            "top": 1200.9140694839034
                         },
                         "post_job_actions": {
                             "HideDatasetActionhtml_file": {
@@ -2898,7 +3056,7 @@
                                 "output_name": "fastq_out"
                             },
                             "min_size": {
-                                "id": 10,
+                                "id": 9,
                                 "output_name": "output"
                             }
                         },
@@ -2913,7 +3071,7 @@
                         ],
                         "position": {
                             "left": 1359,
-                            "top": 321.40574133062194
+                            "top": 440.365741330622
                         },
                         "post_job_actions": {
                             "HideDatasetActionoutput_file": {
@@ -2975,7 +3133,7 @@
                         ],
                         "position": {
                             "left": 1546.9682759470388,
-                            "top": 1080.7828593026848
+                            "top": 1199.7428593026848
                         },
                         "post_job_actions": {
                             "HideDatasetActionhtml_file": {
@@ -3032,7 +3190,7 @@
                         ],
                         "position": {
                             "left": 1593.8207131348126,
-                            "top": 1445.0234870611885
+                            "top": 1563.9834870611885
                         },
                         "post_job_actions": {
                             "HideDatasetActionoutfile": {
@@ -3057,9 +3215,72 @@
                     },
                     "20": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.74+galaxy1",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/prinseq/prinseq/0.20.4+galaxy2",
                         "errors": null,
                         "id": 20,
+                        "input_connections": {
+                            "filter_treatments|base_content_filter_treatments|N_percentage_content_filter_treatments|N_percentage_content_filter_treatment_value": {
+                                "id": 11,
+                                "output_name": "output"
+                            },
+                            "seq_type|input_singles": {
+                                "id": 17,
+                                "output_name": "output_file"
+                            }
+                        },
+                        "inputs": [
+                            {
+                                "description": "runtime parameter for tool PRINSEQ",
+                                "name": "seq_type"
+                            }
+                        ],
+                        "label": "Ambiguity filtering",
+                        "name": "PRINSEQ",
+                        "outputs": [
+                            {
+                                "name": "good_sequence_file",
+                                "type": "input"
+                            },
+                            {
+                                "name": "rejected_sequence_file",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 1646.903450664335,
+                            "top": 523.0258360658718
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActiongood_sequence_file": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "good_sequence_file"
+                            },
+                            "HideDatasetActionrejected_sequence_file": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "rejected_sequence_file"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/prinseq/prinseq/0.20.4+galaxy2",
+                        "tool_shed_repository": {
+                            "changeset_revision": "1ee282794de3",
+                            "name": "prinseq",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"filter_treatments\": {\"apply_filter_treatments\": \"true\", \"__current_case__\": 0, \"length_filter_treatments\": {\"apply_length_filter_treatments\": \"false\", \"__current_case__\": 1}, \"quality_filter_treatments\": {\"apply_quality_filter_treatments\": \"false\", \"__current_case__\": 1}, \"base_content_filter_treatments\": {\"apply_base_content_filter_treatments\": \"true\", \"__current_case__\": 0, \"GC_perc_content_filter_treatments\": {\"apply_GC_perc_content_filter_treatments\": \"false\", \"__current_case__\": 1}, \"N_number_content_filter_treatments\": {\"apply_N_number_content_filter_treatments\": \"false\", \"__current_case__\": 1}, \"N_percentage_content_filter_treatments\": {\"apply_N_percentage_content_filter_treatments\": \"true\", \"__current_case__\": 0, \"N_percentage_content_filter_treatment_value\": {\"__class__\": \"ConnectedValue\"}}, \"apply_other_base_content_filter_treatments\": true}, \"complexity_filter_treatments\": {\"apply_complexity_filter_treatments\": \"false\", \"__current_case__\": 1}}, \"seq_type\": {\"seq_type_opt\": \"single\", \"__current_case__\": 0, \"input_singles\": {\"__class__\": \"ConnectedValue\"}}, \"trimming_treatments\": {\"apply_trimming_treatments\": \"false\", \"__current_case__\": 1}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "0.20.4+galaxy2",
+                        "type": "tool",
+                        "uuid": "d65b0e38-5f52-425a-a3c3-9cb126ead9f7",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "21": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.74+galaxy1",
+                        "errors": null,
+                        "id": 21,
                         "input_connections": {
                             "input_file": {
                                 "id": 17,
@@ -3094,7 +3315,7 @@
                         ],
                         "position": {
                             "left": 1536.6496929362308,
-                            "top": 699.2091488145751
+                            "top": 818.1691488145751
                         },
                         "post_job_actions": {
                             "HideDatasetActionhtml_file": {
@@ -3129,69 +3350,6 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "21": {
-                        "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/prinseq/prinseq/0.20.4+galaxy2",
-                        "errors": null,
-                        "id": 21,
-                        "input_connections": {
-                            "filter_treatments|base_content_filter_treatments|N_percentage_content_filter_treatments|N_percentage_content_filter_treatment_value": {
-                                "id": 11,
-                                "output_name": "output"
-                            },
-                            "seq_type|input_singles": {
-                                "id": 17,
-                                "output_name": "output_file"
-                            }
-                        },
-                        "inputs": [
-                            {
-                                "description": "runtime parameter for tool PRINSEQ",
-                                "name": "seq_type"
-                            }
-                        ],
-                        "label": "Ambiguity filtering",
-                        "name": "PRINSEQ",
-                        "outputs": [
-                            {
-                                "name": "good_sequence_file",
-                                "type": "input"
-                            },
-                            {
-                                "name": "rejected_sequence_file",
-                                "type": "input"
-                            }
-                        ],
-                        "position": {
-                            "left": 1646.903450664335,
-                            "top": 404.0658360658717
-                        },
-                        "post_job_actions": {
-                            "HideDatasetActiongood_sequence_file": {
-                                "action_arguments": {},
-                                "action_type": "HideDatasetAction",
-                                "output_name": "good_sequence_file"
-                            },
-                            "HideDatasetActionrejected_sequence_file": {
-                                "action_arguments": {},
-                                "action_type": "HideDatasetAction",
-                                "output_name": "rejected_sequence_file"
-                            }
-                        },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/prinseq/prinseq/0.20.4+galaxy2",
-                        "tool_shed_repository": {
-                            "changeset_revision": "1ee282794de3",
-                            "name": "prinseq",
-                            "owner": "iuc",
-                            "tool_shed": "toolshed.g2.bx.psu.edu"
-                        },
-                        "tool_state": "{\"filter_treatments\": {\"apply_filter_treatments\": \"true\", \"__current_case__\": 0, \"length_filter_treatments\": {\"apply_length_filter_treatments\": \"false\", \"__current_case__\": 1}, \"quality_filter_treatments\": {\"apply_quality_filter_treatments\": \"false\", \"__current_case__\": 1}, \"base_content_filter_treatments\": {\"apply_base_content_filter_treatments\": \"true\", \"__current_case__\": 0, \"GC_perc_content_filter_treatments\": {\"apply_GC_perc_content_filter_treatments\": \"false\", \"__current_case__\": 1}, \"N_number_content_filter_treatments\": {\"apply_N_number_content_filter_treatments\": \"false\", \"__current_case__\": 1}, \"N_percentage_content_filter_treatments\": {\"apply_N_percentage_content_filter_treatments\": \"true\", \"__current_case__\": 0, \"N_percentage_content_filter_treatment_value\": {\"__class__\": \"ConnectedValue\"}}, \"apply_other_base_content_filter_treatments\": true}, \"complexity_filter_treatments\": {\"apply_complexity_filter_treatments\": \"false\", \"__current_case__\": 1}}, \"seq_type\": {\"seq_type_opt\": \"single\", \"__current_case__\": 0, \"input_singles\": {\"__class__\": \"ConnectedValue\"}}, \"trimming_treatments\": {\"apply_trimming_treatments\": \"false\", \"__current_case__\": 1}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "0.20.4+galaxy2",
-                        "type": "tool",
-                        "uuid": "d65b0e38-5f52-425a-a3c3-9cb126ead9f7",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
                     "22": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
@@ -3214,7 +3372,7 @@
                         ],
                         "position": {
                             "left": 1919.413113574621,
-                            "top": 1045.64655386612
+                            "top": 1164.60655386612
                         },
                         "post_job_actions": {
                             "HideDatasetActionoutfile": {
@@ -3239,57 +3397,12 @@
                     },
                     "23": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqtofasta/fastq_to_fasta_python/1.1.5+galaxy2",
                         "errors": null,
                         "id": 23,
                         "input_connections": {
-                            "infile": {
-                                "id": 20,
-                                "output_name": "text_file"
-                            }
-                        },
-                        "inputs": [],
-                        "label": null,
-                        "name": "Replace",
-                        "outputs": [
-                            {
-                                "name": "outfile",
-                                "type": "input"
-                            }
-                        ],
-                        "position": {
-                            "left": 2169.018738976497,
-                            "top": 877.5344763313531
-                        },
-                        "post_job_actions": {
-                            "HideDatasetActionoutfile": {
-                                "action_arguments": {},
-                                "action_type": "HideDatasetAction",
-                                "output_name": "outfile"
-                            }
-                        },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
-                        "tool_shed_repository": {
-                            "changeset_revision": "86755160afbf",
-                            "name": "text_processing",
-                            "owner": "bgruening",
-                            "tool_shed": "toolshed.g2.bx.psu.edu"
-                        },
-                        "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"\\\\t(.*?)\\\\.gz\", \"replace_pattern\": \"\\\\t$1_length_filtering\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "9.3+galaxy1",
-                        "type": "tool",
-                        "uuid": "8c5dc662-6bcc-4772-bc0e-d0b747113ef3",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "24": {
-                        "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqtofasta/fastq_to_fasta_python/1.1.5+galaxy2",
-                        "errors": null,
-                        "id": 24,
-                        "input_connections": {
                             "input_file": {
-                                "id": 21,
+                                "id": 20,
                                 "output_name": "good_sequence_file"
                             }
                         },
@@ -3304,7 +3417,7 @@
                         ],
                         "position": {
                             "left": 1952.1162504932327,
-                            "top": 422.9194796760812
+                            "top": 541.8794796760812
                         },
                         "post_job_actions": {
                             "HideDatasetActionoutput_file": {
@@ -3327,14 +3440,14 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "25": {
+                    "24": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.74+galaxy1",
                         "errors": null,
-                        "id": 25,
+                        "id": 24,
                         "input_connections": {
                             "input_file": {
-                                "id": 21,
+                                "id": 20,
                                 "output_name": "good_sequence_file"
                             }
                         },
@@ -3366,7 +3479,7 @@
                         ],
                         "position": {
                             "left": 2282.6440047444867,
-                            "top": 547.9029867716423
+                            "top": 666.8629867716423
                         },
                         "post_job_actions": {
                             "HideDatasetActionhtml_file": {
@@ -3401,6 +3514,51 @@
                         "when": null,
                         "workflow_outputs": []
                     },
+                    "25": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+                        "errors": null,
+                        "id": 25,
+                        "input_connections": {
+                            "infile": {
+                                "id": 21,
+                                "output_name": "text_file"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Replace",
+                        "outputs": [
+                            {
+                                "name": "outfile",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 2169.018738976497,
+                            "top": 996.4944763313531
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionoutfile": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "outfile"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+                        "tool_shed_repository": {
+                            "changeset_revision": "86755160afbf",
+                            "name": "text_processing",
+                            "owner": "bgruening",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"\\\\t(.*?)\\\\.gz\", \"replace_pattern\": \"\\\\t$1_length_filtering\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "9.3+galaxy1",
+                        "type": "tool",
+                        "uuid": "8c5dc662-6bcc-4772-bc0e-d0b747113ef3",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
                     "26": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_formatter/cshl_fasta_formatter/1.0.1+galaxy2",
@@ -3408,7 +3566,7 @@
                         "id": 26,
                         "input_connections": {
                             "input": {
-                                "id": 24,
+                                "id": 23,
                                 "output_name": "output_file"
                             }
                         },
@@ -3423,7 +3581,7 @@
                         ],
                         "position": {
                             "left": 2306.5295226390967,
-                            "top": 283.3337627748787
+                            "top": 402.29376277487876
                         },
                         "post_job_actions": {
                             "RenameDatasetActionoutput": {
@@ -3461,7 +3619,7 @@
                         "id": 27,
                         "input_connections": {
                             "infile": {
-                                "id": 25,
+                                "id": 24,
                                 "output_name": "text_file"
                             }
                         },
@@ -3476,7 +3634,7 @@
                         ],
                         "position": {
                             "left": 2529.1111984955273,
-                            "top": 712.6491291601473
+                            "top": 831.6091291601473
                         },
                         "post_job_actions": {
                             "HideDatasetActionoutfile": {
@@ -3514,7 +3672,7 @@
                                 "output_name": "outfile"
                             },
                             "results_0|software_cond|output_2|input": {
-                                "id": 23,
+                                "id": 25,
                                 "output_name": "outfile"
                             },
                             "results_0|software_cond|output_3|input": {
@@ -3537,7 +3695,7 @@
                         ],
                         "position": {
                             "left": 2884.8980879090345,
-                            "top": 478.96236806163165
+                            "top": 597.9223680616317
                         },
                         "post_job_actions": {
                             "RenameDatasetActionhtml_report": {
@@ -3562,33 +3720,73 @@
                             "owner": "iuc",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastqc\", \"__current_case__\": 8, \"output\": [{\"__index__\": 0, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 1, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 2, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 3, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}]}}], \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+                        "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastqc\", \"__current_case__\": 8, \"output\": [{\"__index__\": 0, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 2, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 3, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}]}}], \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
                         "tool_version": "1.27+galaxy0",
                         "type": "tool",
                         "uuid": "e04ee136-c52f-4d7e-85c5-3b3ed78b0cce",
                         "when": null,
                         "workflow_outputs": [
                             {
-                                "label": "Paired-end MultiQC statistics",
-                                "output_name": "stats",
-                                "uuid": "fc6047b2-201d-4e77-ab0d-9c8107897088"
-                            },
-                            {
                                 "label": "Paired-end MultiQC report",
                                 "output_name": "html_report",
                                 "uuid": "1d870a5b-942b-4f61-b8fd-a68b121b7f8c"
+                            },
+                            {
+                                "label": "Paired-end MultiQC statistics",
+                                "output_name": "stats",
+                                "uuid": "fc6047b2-201d-4e77-ab0d-9c8107897088"
                             }
                         ]
                     }
                 },
                 "tags": [],
-                "uuid": "a9df547d-8f99-4740-b884-73d1e83a89b5"
+                "uuid": "3af45a28-126d-4c9d-9948-cabfe43566f3"
             },
             "tool_id": null,
             "type": "subworkflow",
             "uuid": "a6cb4bbc-057a-4326-b5c8-2c2a17514a62",
             "when": null,
             "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "10:output",
+                    "uuid": "e6694be3-641d-40a6-b6da-50422c5f98e6"
+                },
+                {
+                    "label": null,
+                    "output_name": "4:output",
+                    "uuid": "c6c742f2-f3b4-400e-8aee-f02f29f0553a"
+                },
+                {
+                    "label": null,
+                    "output_name": "5:output",
+                    "uuid": "babd2e76-ec89-4735-926c-c3980c73af44"
+                },
+                {
+                    "label": null,
+                    "output_name": "6:output",
+                    "uuid": "580cba9e-395e-4517-ae55-dc4853d2040e"
+                },
+                {
+                    "label": null,
+                    "output_name": "7:output",
+                    "uuid": "f90f4c39-e7cd-4026-817e-ee5b6587f24e"
+                },
+                {
+                    "label": null,
+                    "output_name": "8:output",
+                    "uuid": "4ff844f7-fcca-41f4-872f-5789d44bc709"
+                },
+                {
+                    "label": null,
+                    "output_name": "9:output",
+                    "uuid": "c882ff1b-e97a-45e0-aaaa-d4a68717fbd5"
+                },
+                {
+                    "label": null,
+                    "output_name": "11:output",
+                    "uuid": "62f154e1-7c5d-4657-b361-d0ac65e01ad1"
+                },
                 {
                     "label": "Paired-end MultiQC report",
                     "output_name": "Paired-end MultiQC report",
@@ -3603,6 +3801,21 @@
                     "label": "Paired-end post quality control FASTA files",
                     "output_name": "Paired-end post quality control FASTA files",
                     "uuid": "6b08b8f6-8f53-4a23-92a1-40a064674f17"
+                },
+                {
+                    "label": null,
+                    "output_name": "1:output",
+                    "uuid": "c72f9c4b-e92d-49ff-ab09-2c7b250cf207"
+                },
+                {
+                    "label": null,
+                    "output_name": "2:output",
+                    "uuid": "d958cb30-b912-4497-bcd1-869edddb2e8b"
+                },
+                {
+                    "label": null,
+                    "output_name": "3:output",
+                    "uuid": "4c9778e4-f785-4a89-9a66-fb7d55c29cff"
                 }
             ]
         },
@@ -4667,7 +4880,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_getfastabed/2.31.1+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "64e2edfe7a2c",
+                            "changeset_revision": "2892111d91f8",
                             "name": "bedtools",
                             "owner": "iuc",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -4721,7 +4934,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_getfastabed/2.31.1+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "64e2edfe7a2c",
+                            "changeset_revision": "2892111d91f8",
                             "name": "bedtools",
                             "owner": "iuc",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -7043,24 +7256,14 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "LSU and SSU BED regions",
-                    "output_name": "LSU and SSU BED regions",
-                    "uuid": "2c0868a6-e45b-4738-9f2e-8395c49f6af1"
+                    "label": "LSU taxonomic classifications using SILVA DB",
+                    "output_name": "LSU taxonomic classifications using SILVA DB",
+                    "uuid": "09f8843c-6250-4c8a-a2b3-3ceee8915d23"
                 },
                 {
-                    "label": "LSU OTU tables (SILVA DB)",
-                    "output_name": "LSU OTU tables (SILVA DB)",
-                    "uuid": "6b36b9af-d003-4cc2-a179-a2a6c05090ad"
-                },
-                {
-                    "label": "SSU taxonomic classifications using SILVA DB",
-                    "output_name": "SSU taxonomic classifications using SILVA DB",
-                    "uuid": "3d7739ed-d444-4dbd-b686-b27e1aa1b7d0"
-                },
-                {
-                    "label": "SSU FASTA files",
-                    "output_name": "SSU FASTA files",
-                    "uuid": "ee71d9de-28d9-4177-acb6-9ef170d2ce25"
+                    "label": "LSU OTU tables in JSON format (SILVA DB)",
+                    "output_name": "LSU OTU tables in JSON format (SILVA DB)",
+                    "uuid": "800565e9-4663-4b11-869a-d68fd09152ea"
                 },
                 {
                     "label": "LSU OTU tables in HDF5 format (SILVA DB)",
@@ -7083,9 +7286,9 @@
                     "uuid": "45a9891a-b535-4f6b-9a66-e86c53ee154b"
                 },
                 {
-                    "label": "LSU taxonomic classifications using SILVA DB",
-                    "output_name": "LSU taxonomic classifications using SILVA DB",
-                    "uuid": "09f8843c-6250-4c8a-a2b3-3ceee8915d23"
+                    "label": "SSU FASTA files",
+                    "output_name": "SSU FASTA files",
+                    "uuid": "ee71d9de-28d9-4177-acb6-9ef170d2ce25"
                 },
                 {
                     "label": "LSU FASTA files",
@@ -7103,9 +7306,19 @@
                     "uuid": "c57d0bc6-d624-4be5-a10b-74c3ad15ab17"
                 },
                 {
-                    "label": "LSU OTU tables in JSON format (SILVA DB)",
-                    "output_name": "LSU OTU tables in JSON format (SILVA DB)",
-                    "uuid": "800565e9-4663-4b11-869a-d68fd09152ea"
+                    "label": "LSU and SSU BED regions",
+                    "output_name": "LSU and SSU BED regions",
+                    "uuid": "2c0868a6-e45b-4738-9f2e-8395c49f6af1"
+                },
+                {
+                    "label": "LSU OTU tables (SILVA DB)",
+                    "output_name": "LSU OTU tables (SILVA DB)",
+                    "uuid": "6b36b9af-d003-4cc2-a179-a2a6c05090ad"
+                },
+                {
+                    "label": "SSU taxonomic classifications using SILVA DB",
+                    "output_name": "SSU taxonomic classifications using SILVA DB",
+                    "uuid": "3d7739ed-d444-4dbd-b686-b27e1aa1b7d0"
                 }
             ]
         },
@@ -7396,7 +7609,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_maskfastabed/2.31.1",
                         "tool_shed_repository": {
-                            "changeset_revision": "64e2edfe7a2c",
+                            "changeset_revision": "2892111d91f8",
                             "name": "bedtools",
                             "owner": "iuc",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -9618,9 +9831,44 @@
             "when": null,
             "workflow_outputs": [
                 {
+                    "label": "ITS OTU tables in JSON format (ITSoneDB)",
+                    "output_name": "ITS OTU tables in JSON format (ITSoneDB)",
+                    "uuid": "13e54088-7391-4c8c-9fde-2dd63080fafd"
+                },
+                {
+                    "label": "ITS taxonomic abundance pie charts (ITSoneDB)",
+                    "output_name": "ITS taxonomic abundance pie charts (ITSoneDB)",
+                    "uuid": "db0a8042-4964-4619-93e1-0d6a4ffdc5f1"
+                },
+                {
+                    "label": "ITS taxonomic classifications using UNITE DB",
+                    "output_name": "ITS taxonomic classifications using UNITE DB",
+                    "uuid": "384bb22d-6926-4833-89ed-1c9ec309aa7f"
+                },
+                {
+                    "label": "ITS taxonomic abundance pie charts (UNITE DB)",
+                    "output_name": "ITS taxonomic abundance pie charts (UNITE DB)",
+                    "uuid": "f9c37e34-a124-4a1f-b9df-e834efbe0e53"
+                },
+                {
+                    "label": "ITS OTU tables (UNITE DB)",
+                    "output_name": "ITS OTU tables (UNITE DB)",
+                    "uuid": "582f0478-2a6b-4158-bd78-8144fc3a47bc"
+                },
+                {
                     "label": "ITS FASTA files",
                     "output_name": "ITS FASTA files",
                     "uuid": "b7a20037-e419-4d1d-9e05-b96c6a9efca5"
+                },
+                {
+                    "label": "ITS OTU tables (ITSoneDB)",
+                    "output_name": "ITS OTU tables (ITSoneDB)",
+                    "uuid": "9d7fe164-5af7-4ef2-a439-a163705abfbb"
+                },
+                {
+                    "label": "ITS OTU tables in HDF5 format (ITSoneDB)",
+                    "output_name": "ITS OTU tables in HDF5 format (ITSoneDB)",
+                    "uuid": "d7b793f8-f828-44e3-9af5-798158bd11d6"
                 },
                 {
                     "label": "ITS OTU tables in JSON format (UNITE DB)",
@@ -9636,41 +9884,6 @@
                     "label": "ITS taxonomic classifications using ITSoneDB",
                     "output_name": "ITS taxonomic classifications using ITSoneDB",
                     "uuid": "2aa27435-9a26-4f50-8d2a-9e07cfda66ba"
-                },
-                {
-                    "label": "ITS OTU tables in JSON format (ITSoneDB)",
-                    "output_name": "ITS OTU tables in JSON format (ITSoneDB)",
-                    "uuid": "13e54088-7391-4c8c-9fde-2dd63080fafd"
-                },
-                {
-                    "label": "ITS OTU tables in HDF5 format (ITSoneDB)",
-                    "output_name": "ITS OTU tables in HDF5 format (ITSoneDB)",
-                    "uuid": "d7b793f8-f828-44e3-9af5-798158bd11d6"
-                },
-                {
-                    "label": "ITS OTU tables (UNITE DB)",
-                    "output_name": "ITS OTU tables (UNITE DB)",
-                    "uuid": "582f0478-2a6b-4158-bd78-8144fc3a47bc"
-                },
-                {
-                    "label": "ITS taxonomic abundance pie charts (UNITE DB)",
-                    "output_name": "ITS taxonomic abundance pie charts (UNITE DB)",
-                    "uuid": "f9c37e34-a124-4a1f-b9df-e834efbe0e53"
-                },
-                {
-                    "label": "ITS taxonomic classifications using UNITE DB",
-                    "output_name": "ITS taxonomic classifications using UNITE DB",
-                    "uuid": "384bb22d-6926-4833-89ed-1c9ec309aa7f"
-                },
-                {
-                    "label": "ITS taxonomic abundance pie charts (ITSoneDB)",
-                    "output_name": "ITS taxonomic abundance pie charts (ITSoneDB)",
-                    "uuid": "db0a8042-4964-4619-93e1-0d6a4ffdc5f1"
-                },
-                {
-                    "label": "ITS OTU tables (ITSoneDB)",
-                    "output_name": "ITS OTU tables (ITSoneDB)",
-                    "uuid": "9d7fe164-5af7-4ef2-a439-a163705abfbb"
                 }
             ]
         },
@@ -10781,12 +10994,18 @@
                             "top": 0
                         },
                         "tool_id": null,
-                        "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
+                        "tool_state": "{\"validators\": [], \"parameter_type\": \"text\", \"optional\": false}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "98862eac-2fa1-4e7d-95f9-ef4832b40b45",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "1b0794db-a154-4fd8-a701-763bd96c309e"
+                            }
+                        ]
                     },
                     "2": {
                         "annotation": "specifies the name of taxonomic summary file, for phylum level.",
@@ -10808,12 +11027,18 @@
                             "top": 643.2277124832184
                         },
                         "tool_id": null,
-                        "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
+                        "tool_state": "{\"validators\": [], \"parameter_type\": \"text\", \"optional\": false}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "e948e6d0-a7f3-4d47-a50f-003ee055865a",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "c890d873-bb58-49ae-a1e7-a3e6d19368e0"
+                            }
+                        ]
                     },
                     "3": {
                         "annotation": "",
@@ -11290,6 +11515,16 @@
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
+                    "label": null,
+                    "output_name": "2:output",
+                    "uuid": "ae453900-5f5b-481d-a562-710525d87ad8"
+                },
+                {
+                    "label": null,
+                    "output_name": "1:output",
+                    "uuid": "65a32ca3-7458-41d9-9605-378a45d6b63b"
+                },
+                {
                     "label": "SSU phylum level taxonomic abundance summary table",
                     "output_name": "phylum level taxonomic abundance summary table",
                     "uuid": "b8be6baa-41d2-4652-87dc-f1fb9abc07ee"
@@ -11432,12 +11667,18 @@
                             "top": 0
                         },
                         "tool_id": null,
-                        "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
+                        "tool_state": "{\"validators\": [], \"parameter_type\": \"text\", \"optional\": false}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "98862eac-2fa1-4e7d-95f9-ef4832b40b45",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "1b0794db-a154-4fd8-a701-763bd96c309e"
+                            }
+                        ]
                     },
                     "2": {
                         "annotation": "specifies the name of taxonomic summary file, for phylum level.",
@@ -11459,12 +11700,18 @@
                             "top": 643.2277124832184
                         },
                         "tool_id": null,
-                        "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
+                        "tool_state": "{\"validators\": [], \"parameter_type\": \"text\", \"optional\": false}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "e948e6d0-a7f3-4d47-a50f-003ee055865a",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "c890d873-bb58-49ae-a1e7-a3e6d19368e0"
+                            }
+                        ]
                     },
                     "3": {
                         "annotation": "",
@@ -11941,6 +12188,11 @@
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
+                    "label": null,
+                    "output_name": "2:output",
+                    "uuid": "ecd7fcb5-84b5-4f4d-a8b6-953814167b6e"
+                },
+                {
                     "label": "LSU phylum level taxonomic abundance summary table",
                     "output_name": "phylum level taxonomic abundance summary table",
                     "uuid": "e7425613-0d16-47f5-86c9-b881908ca21e"
@@ -11949,6 +12201,11 @@
                     "label": "LSU taxonomic abundance summary table",
                     "output_name": "Taxonomic abundance summary table",
                     "uuid": "203f7e9c-346a-44b3-82fb-c00beab8049f"
+                },
+                {
+                    "label": null,
+                    "output_name": "1:output",
+                    "uuid": "7ce321a3-9fa6-4d00-8dd6-09a09aef03c6"
                 }
             ]
         },
@@ -12088,12 +12345,18 @@
                             "top": 0
                         },
                         "tool_id": null,
-                        "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
+                        "tool_state": "{\"validators\": [], \"parameter_type\": \"text\", \"optional\": false}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "98862eac-2fa1-4e7d-95f9-ef4832b40b45",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "1b0794db-a154-4fd8-a701-763bd96c309e"
+                            }
+                        ]
                     },
                     "2": {
                         "annotation": "specifies the name of taxonomic summary file, for phylum level.",
@@ -12115,12 +12378,18 @@
                             "top": 643.2277124832184
                         },
                         "tool_id": null,
-                        "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
+                        "tool_state": "{\"validators\": [], \"parameter_type\": \"text\", \"optional\": false}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "e948e6d0-a7f3-4d47-a50f-003ee055865a",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "c890d873-bb58-49ae-a1e7-a3e6d19368e0"
+                            }
+                        ]
                     },
                     "3": {
                         "annotation": "",
@@ -12597,14 +12866,24 @@
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
+                    "label": "ITSoneDB phylum level taxonomic abundance summary table",
+                    "output_name": "phylum level taxonomic abundance summary table",
+                    "uuid": "82dce358-6820-47c4-a1a1-6e02506e66be"
+                },
+                {
                     "label": "ITSoneDB taxonomic abundance summary table",
                     "output_name": "Taxonomic abundance summary table",
                     "uuid": "05613f35-22d4-4a32-8ddc-69d6a7281470"
                 },
                 {
-                    "label": "ITSoneDB phylum level taxonomic abundance summary table",
-                    "output_name": "phylum level taxonomic abundance summary table",
-                    "uuid": "82dce358-6820-47c4-a1a1-6e02506e66be"
+                    "label": null,
+                    "output_name": "1:output",
+                    "uuid": "e45fb38d-8b7a-419b-bb14-4c470fc934ef"
+                },
+                {
+                    "label": null,
+                    "output_name": "2:output",
+                    "uuid": "5e729547-0f7c-4b82-878f-2efe75794dab"
                 }
             ]
         },
@@ -12744,12 +13023,18 @@
                             "top": 0
                         },
                         "tool_id": null,
-                        "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
+                        "tool_state": "{\"validators\": [], \"parameter_type\": \"text\", \"optional\": false}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "98862eac-2fa1-4e7d-95f9-ef4832b40b45",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "1b0794db-a154-4fd8-a701-763bd96c309e"
+                            }
+                        ]
                     },
                     "2": {
                         "annotation": "specifies the name of taxonomic summary file, for phylum level.",
@@ -12771,12 +13056,18 @@
                             "top": 643.2277124832184
                         },
                         "tool_id": null,
-                        "tool_state": "{\"parameter_type\": \"text\", \"optional\": false}",
+                        "tool_state": "{\"validators\": [], \"parameter_type\": \"text\", \"optional\": false}",
                         "tool_version": null,
                         "type": "parameter_input",
                         "uuid": "e948e6d0-a7f3-4d47-a50f-003ee055865a",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "c890d873-bb58-49ae-a1e7-a3e6d19368e0"
+                            }
+                        ]
                     },
                     "3": {
                         "annotation": "",
@@ -13253,6 +13544,16 @@
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
+                    "label": null,
+                    "output_name": "1:output",
+                    "uuid": "74602444-fe5e-4bdb-8385-888b1c6015e8"
+                },
+                {
+                    "label": null,
+                    "output_name": "2:output",
+                    "uuid": "71a87ad9-6250-406c-81e7-6ecfe937ac03"
+                },
+                {
                     "label": "ITS UNITE DB phylum level taxonomic abundance summary table",
                     "output_name": "phylum level taxonomic abundance summary table",
                     "uuid": "1813a260-c36c-4b3d-862a-fb244ce8f4a9"
@@ -13271,6 +13572,6 @@
         "amplicon",
         "name:microgalaxy"
     ],
-    "uuid": "cdf82f4c-734e-4441-941a-2626aa7d8dae",
-    "version": 151
+    "uuid": "e1106ef2-1922-4ad2-802f-44dd4482efa5",
+    "version": 153
 }

--- a/workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.ga
+++ b/workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.ga
@@ -919,7 +919,7 @@
             "post_job_actions": {
                 "ChangeDatatypeActionoutput1": {
                     "action_arguments": {
-                        "newtype": "fastq.gz"
+                        "newtype": "fastqsanger.gz"
                     },
                     "action_type": "ChangeDatatypeAction",
                     "output_name": "output1"
@@ -3665,14 +3665,14 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Paired-end post quality control FASTA files",
-                    "output_name": "Paired-end post quality control FASTA files",
-                    "uuid": "6b08b8f6-8f53-4a23-92a1-40a064674f17"
-                },
-                {
                     "label": "Paired-end MultiQC statistics",
                     "output_name": "Paired-end MultiQC statistics",
                     "uuid": "9f83bbc4-916e-4379-a018-cef375aa6abb"
+                },
+                {
+                    "label": "Paired-end post quality control FASTA files",
+                    "output_name": "Paired-end post quality control FASTA files",
+                    "uuid": "6b08b8f6-8f53-4a23-92a1-40a064674f17"
                 },
                 {
                     "label": "Paired-end MultiQC report",
@@ -7133,9 +7133,14 @@
                     "uuid": "3d7739ed-d444-4dbd-b686-b27e1aa1b7d0"
                 },
                 {
-                    "label": "SSU FASTA files",
-                    "output_name": "SSU FASTA files",
-                    "uuid": "ee71d9de-28d9-4177-acb6-9ef170d2ce25"
+                    "label": "SSU OTU tables in HDF5 format (SILVA DB)",
+                    "output_name": "SSU OTU tables in HDF5 format (SILVA DB)",
+                    "uuid": "6028cb8e-cb14-4447-a619-f848d39c4f57"
+                },
+                {
+                    "label": "SSU OTU tables (SILVA DB)",
+                    "output_name": "SSU OTU tables (SILVA DB)",
+                    "uuid": "7f21d964-f8bc-47b6-972d-7b39eb4b7b02"
                 },
                 {
                     "label": "LSU taxonomic classifications using SILVA DB",
@@ -7153,11 +7158,6 @@
                     "uuid": "42c9e089-6d5b-4af5-9c7e-23165c8569eb"
                 },
                 {
-                    "label": "SSU OTU tables in HDF5 format (SILVA DB)",
-                    "output_name": "SSU OTU tables in HDF5 format (SILVA DB)",
-                    "uuid": "6028cb8e-cb14-4447-a619-f848d39c4f57"
-                },
-                {
                     "label": "SSU OTU tables in JSON format (SILVA DB)",
                     "output_name": "SSU OTU tables in JSON format (SILVA DB)",
                     "uuid": "480b5147-b6f0-404b-838c-36f2818100f8"
@@ -7168,14 +7168,14 @@
                     "uuid": "45a9891a-b535-4f6b-9a66-e86c53ee154b"
                 },
                 {
+                    "label": "SSU FASTA files",
+                    "output_name": "SSU FASTA files",
+                    "uuid": "ee71d9de-28d9-4177-acb6-9ef170d2ce25"
+                },
+                {
                     "label": "LSU FASTA files",
                     "output_name": "LSU FASTA files",
                     "uuid": "a4371314-8837-4670-a6b2-1e528264ebd4"
-                },
-                {
-                    "label": "SSU OTU tables (SILVA DB)",
-                    "output_name": "SSU OTU tables (SILVA DB)",
-                    "uuid": "7f21d964-f8bc-47b6-972d-7b39eb4b7b02"
                 },
                 {
                     "label": "SSU taxonomic abundance pie charts (SILVA DB)",
@@ -9698,11 +9698,6 @@
                     "uuid": "d7b793f8-f828-44e3-9af5-798158bd11d6"
                 },
                 {
-                    "label": "ITS OTU tables (UNITE DB)",
-                    "output_name": "ITS OTU tables (UNITE DB)",
-                    "uuid": "582f0478-2a6b-4158-bd78-8144fc3a47bc"
-                },
-                {
                     "label": "ITS FASTA files",
                     "output_name": "ITS FASTA files",
                     "uuid": "b7a20037-e419-4d1d-9e05-b96c6a9efca5"
@@ -9746,6 +9741,11 @@
                     "label": "ITS OTU tables in JSON format (ITSoneDB)",
                     "output_name": "ITS OTU tables in JSON format (ITSoneDB)",
                     "uuid": "13e54088-7391-4c8c-9fde-2dd63080fafd"
+                },
+                {
+                    "label": "ITS OTU tables (UNITE DB)",
+                    "output_name": "ITS OTU tables (UNITE DB)",
+                    "uuid": "582f0478-2a6b-4158-bd78-8144fc3a47bc"
                 }
             ]
         },
@@ -11377,14 +11377,14 @@
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
-                    "label": "SSU phylum level taxonomic abundance summary table",
-                    "output_name": "phylum level taxonomic abundance summary table",
-                    "uuid": "b8be6baa-41d2-4652-87dc-f1fb9abc07ee"
-                },
-                {
                     "label": "SSU taxonomic abundance summary table",
                     "output_name": "Taxonomic abundance summary table",
                     "uuid": "4efd5e53-32f9-4e1b-b850-ed9c6e96cbb3"
+                },
+                {
+                    "label": "SSU phylum level taxonomic abundance summary table",
+                    "output_name": "phylum level taxonomic abundance summary table",
+                    "uuid": "b8be6baa-41d2-4652-87dc-f1fb9abc07ee"
                 }
             ]
         },
@@ -12040,14 +12040,14 @@
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
-                    "label": "LSU taxonomic abundance summary table",
-                    "output_name": "Taxonomic abundance summary table",
-                    "uuid": "203f7e9c-346a-44b3-82fb-c00beab8049f"
-                },
-                {
                     "label": "LSU phylum level taxonomic abundance summary table",
                     "output_name": "phylum level taxonomic abundance summary table",
                     "uuid": "e7425613-0d16-47f5-86c9-b881908ca21e"
+                },
+                {
+                    "label": "LSU taxonomic abundance summary table",
+                    "output_name": "Taxonomic abundance summary table",
+                    "uuid": "203f7e9c-346a-44b3-82fb-c00beab8049f"
                 }
             ]
         },
@@ -13394,6 +13394,6 @@
         "amplicon",
         "name:microgalaxy"
     ],
-    "uuid": "fdbc9b75-5788-4346-a7c7-c41e42d4f61f",
-    "version": 154
+    "uuid": "5d06fcca-ca23-4a0b-9361-89812a67f9e9",
+    "version": 155
 }

--- a/workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.ga
+++ b/workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.ga
@@ -108,13 +108,7 @@
             "type": "parameter_input",
             "uuid": "39e0bbb8-def5-4cbe-875d-0e75d5e37495",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "c5d53876-d142-4894-b4c3-ad8050f99c4e"
-                }
-            ]
+            "workflow_outputs": []
         },
         "3": {
             "annotation": "Average quality required.",
@@ -141,13 +135,7 @@
             "type": "parameter_input",
             "uuid": "21106922-bb34-4647-9bee-446710c7d8d5",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "e7ef19ff-8b63-44fe-89ad-1af652c4d448"
-                }
-            ]
+            "workflow_outputs": []
         },
         "4": {
             "annotation": "Enable base correction in overlapped regions. (Paired-end)",
@@ -174,13 +162,7 @@
             "type": "parameter_input",
             "uuid": "90776758-eb1e-494a-9c34-d891fb22552b",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "d341c6bd-fbd9-4518-a876-a33fe535aefa"
-                }
-            ]
+            "workflow_outputs": []
         },
         "5": {
             "annotation": "Cut bases off the start of a read, if below a threshold quality.",
@@ -207,13 +189,7 @@
             "type": "parameter_input",
             "uuid": "869e3248-10ca-44f5-98bb-5e520658b9bd",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "32ee6eaf-77d7-434c-a4b4-062a7e7bbf77"
-                }
-            ]
+            "workflow_outputs": []
         },
         "6": {
             "annotation": "The quality value that a base is qualified. (Paired-end)",
@@ -240,13 +216,7 @@
             "type": "parameter_input",
             "uuid": "9d0bfec9-8ab2-4d46-af38-65e8d9f38445",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "90b61e87-42f0-48c1-8254-ed1f3f33930e"
-                }
-            ]
+            "workflow_outputs": []
         },
         "7": {
             "annotation": "Cut bases off the end of a read, if below a threshold quality.",
@@ -273,13 +243,7 @@
             "type": "parameter_input",
             "uuid": "a5f602ee-06ac-4c40-a5db-2bac77112f97",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "13617016-e6d5-4534-856f-d71f2ab9009e"
-                }
-            ]
+            "workflow_outputs": []
         },
         "8": {
             "annotation": "How many percents of bases are allowed to be unqualified (0~100). (Paired-end)",
@@ -306,13 +270,7 @@
             "type": "parameter_input",
             "uuid": "3ccea377-db95-4eea-83d8-864f942e3347",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "0a598f79-1f8c-4138-9ab7-0ca37335e019"
-                }
-            ]
+            "workflow_outputs": []
         },
         "9": {
             "annotation": "Minimum length of reads to be kept.",
@@ -339,13 +297,7 @@
             "type": "parameter_input",
             "uuid": "183a6499-b9e0-4844-a4cd-f5de8804f1e1",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "b0fa56cc-bee8-44d5-84ad-76807fc1a578"
-                }
-            ]
+            "workflow_outputs": []
         },
         "10": {
             "annotation": "Reads shorter than this value will be discarded. (Paired-end)",
@@ -372,13 +324,7 @@
             "type": "parameter_input",
             "uuid": "4c9fd5af-fd9b-45f2-8fe5-31852d05cab1",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "ee33e922-cba5-445b-b9e5-ccdffd94fb26"
-                }
-            ]
+            "workflow_outputs": []
         },
         "11": {
             "annotation": "Minimum sequence length.",
@@ -405,13 +351,7 @@
             "type": "parameter_input",
             "uuid": "d5361c5a-2500-4dbd-bbc2-907d0b067fc4",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "18e5d64a-f7aa-4e56-bb23-63ef0c18705c"
-                }
-            ]
+            "workflow_outputs": []
         },
         "12": {
             "annotation": "Maximal N percentage threshold to conserve sequences.",
@@ -438,13 +378,7 @@
             "type": "parameter_input",
             "uuid": "1503e81e-64d4-473c-bde9-751ba2bb9143",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "3e8bed6d-72f3-4e26-afb7-bf972f045220"
-                }
-            ]
+            "workflow_outputs": []
         },
         "13": {
             "annotation": "",
@@ -471,13 +405,7 @@
             "type": "parameter_input",
             "uuid": "44cdc1f5-5482-4843-915c-3eeec13e63ff",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "3cc13b6a-e268-4d8e-a90c-48be99907e67"
-                }
-            ]
+            "workflow_outputs": []
         },
         "14": {
             "annotation": "",
@@ -504,13 +432,7 @@
             "type": "parameter_input",
             "uuid": "7a186613-22f7-406c-a464-566889fba9b6",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "f4582772-faba-4bbd-a595-8fc34f243827"
-                }
-            ]
+            "workflow_outputs": []
         },
         "15": {
             "annotation": "",
@@ -537,13 +459,7 @@
             "type": "parameter_input",
             "uuid": "c5976795-446d-465b-a17b-89f88cd36609",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "de7596f3-4f46-419f-b0be-5d740b54276d"
-                }
-            ]
+            "workflow_outputs": []
         },
         "16": {
             "annotation": "",
@@ -570,13 +486,7 @@
             "type": "parameter_input",
             "uuid": "0d031f24-2524-4111-8199-fde1fed46abd",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "f452f791-82d5-472a-b420-9092e83afe23"
-                }
-            ]
+            "workflow_outputs": []
         },
         "17": {
             "annotation": "",
@@ -603,13 +513,7 @@
             "type": "parameter_input",
             "uuid": "78990ece-405a-4a82-8a7c-87c4efbe396f",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "553f2a89-8c9f-48b7-95fd-435c119196f1"
-                }
-            ]
+            "workflow_outputs": []
         },
         "18": {
             "annotation": "",
@@ -636,13 +540,7 @@
             "type": "parameter_input",
             "uuid": "25b414b3-afe1-48b1-81cd-37059285b496",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "aea46859-6247-451c-bdc3-1a55cf1bfb71"
-                }
-            ]
+            "workflow_outputs": []
         },
         "19": {
             "annotation": "",
@@ -669,13 +567,7 @@
             "type": "parameter_input",
             "uuid": "d6da448e-070a-423e-9f7e-182b7d20340c",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "f5073b25-51e5-4993-9485-ee3ca865d3d7"
-                }
-            ]
+            "workflow_outputs": []
         },
         "20": {
             "annotation": "",
@@ -702,13 +594,7 @@
             "type": "parameter_input",
             "uuid": "2f17ad42-aebe-4069-9907-ca85aec8df82",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "e956ae54-0059-457d-96e0-6c964e1026f4"
-                }
-            ]
+            "workflow_outputs": []
         },
         "21": {
             "annotation": "",
@@ -987,7 +873,7 @@
             "post_job_actions": {
                 "ChangeDatatypeActionoutput1": {
                     "action_arguments": {
-                        "newtype": "fastq.gz"
+                        "newtype": "fastqsanger.gz"
                     },
                     "action_type": "ChangeDatatypeAction",
                     "output_name": "output1"
@@ -2219,26 +2105,6 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": null,
-                    "output_name": "5:output",
-                    "uuid": "b1c6fded-5c97-4745-92e8-3dacd0c6903f"
-                },
-                {
-                    "label": null,
-                    "output_name": "4:output",
-                    "uuid": "0a2b0e91-7e11-44e3-9f23-781ff4354104"
-                },
-                {
-                    "label": null,
-                    "output_name": "6:output",
-                    "uuid": "6da43c77-dd90-4af6-892b-d04dd0e74fe3"
-                },
-                {
-                    "label": null,
-                    "output_name": "7:output",
-                    "uuid": "525097b0-720d-4fd0-b220-62c89a632868"
-                },
-                {
                     "label": "Single-end MultiQC report",
                     "output_name": "Single-end MultiQC report",
                     "uuid": "524978e4-ce01-4152-95e5-4e1ef5d48c3a"
@@ -2252,21 +2118,6 @@
                     "label": "Single-end MultiQC statistics",
                     "output_name": "Single-end MultiQC statistics",
                     "uuid": "90e90edf-c318-42bf-a359-02d7d2bab053"
-                },
-                {
-                    "label": null,
-                    "output_name": "1:output",
-                    "uuid": "63dfbed0-86f2-4656-a7c2-35088ec0a1a5"
-                },
-                {
-                    "label": null,
-                    "output_name": "2:output",
-                    "uuid": "f0321ebe-d7db-4627-85f2-826a3354b0f7"
-                },
-                {
-                    "label": null,
-                    "output_name": "3:output",
-                    "uuid": "6f5cf708-fa12-4f5c-bc65-c988983a5c91"
                 }
             ]
         },
@@ -2281,7 +2132,7 @@
                 },
                 "Length filtering - Minimum size": {
                     "id": 11,
-                    "input_subworkflow_step_id": 10,
+                    "input_subworkflow_step_id": 9,
                     "output_name": "output"
                 },
                 "Paired-end reads": {
@@ -2296,7 +2147,7 @@
                 },
                 "Trimmomatic - MINLEN": {
                     "id": 9,
-                    "input_subworkflow_step_id": 9,
+                    "input_subworkflow_step_id": 10,
                     "output_name": "output"
                 },
                 "Trimmomatic - SLIDINGWINDOW - Average quality required": {
@@ -2425,7 +2276,13 @@
                         "type": "parameter_input",
                         "uuid": "81367449-c0ca-41be-b69d-5bf1568e0361",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "2cc2526b-c51d-42bd-94ac-540d45cce0aa"
+                            }
+                        ]
                     },
                     "2": {
                         "annotation": "The quality value that a base is qualified.",
@@ -2452,7 +2309,13 @@
                         "type": "parameter_input",
                         "uuid": "cb8a7bac-c007-45c6-814b-9aacae0e37b3",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "8ed6f5eb-5fa9-4d25-8e8b-5f1252c4cf59"
+                            }
+                        ]
                     },
                     "3": {
                         "annotation": "How many percents of bases are allowed to be unqualified (0~100).",
@@ -2479,7 +2342,13 @@
                         "type": "parameter_input",
                         "uuid": "26ed5910-22cf-4a8e-a144-edbb8d6b1d50",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "c24e8e77-678b-4fa3-9436-8f0d6592ed7e"
+                            }
+                        ]
                     },
                     "4": {
                         "annotation": "Reads shorter than this value will be discarded.",
@@ -2506,7 +2375,13 @@
                         "type": "parameter_input",
                         "uuid": "6521e9f3-6d1b-4e95-8934-3345f858bcf8",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "3221d128-de9e-489e-8497-e357f686112f"
+                            }
+                        ]
                     },
                     "5": {
                         "annotation": "Number of bases to average across.",
@@ -2533,7 +2408,13 @@
                         "type": "parameter_input",
                         "uuid": "1b2652b0-235b-4120-9c82-e4d3210c9d2f",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "77bf0209-c48a-4422-8478-722a924ee1f3"
+                            }
+                        ]
                     },
                     "6": {
                         "annotation": "Average quality required.",
@@ -2560,7 +2441,13 @@
                         "type": "parameter_input",
                         "uuid": "53e87ca4-6745-4835-b25f-878705737f0d",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "d4ea0915-89cf-4a64-8c27-3e0a1443168d"
+                            }
+                        ]
                     },
                     "7": {
                         "annotation": "Minimum quality required to keep a base.",
@@ -2587,7 +2474,13 @@
                         "type": "parameter_input",
                         "uuid": "4e1cfaad-b067-4bf3-a6b8-33d3fd826285",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "fe7fcea9-5651-491a-b079-db434960e968"
+                            }
+                        ]
                     },
                     "8": {
                         "annotation": "Minimum quality required to keep a base.",
@@ -2614,7 +2507,13 @@
                         "type": "parameter_input",
                         "uuid": "d48c0437-1ab6-4fd4-8dfa-29dd056acaec",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "5f620484-e1bf-4bc5-a227-1b40d783eadd"
+                            }
+                        ]
                     },
                     "9": {
                         "annotation": "Minimum sequence length.",
@@ -2641,7 +2540,13 @@
                         "type": "parameter_input",
                         "uuid": "2957cfb6-b542-4354-b94f-fd171df4c9b1",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "4792bf14-48e1-43da-b086-5e137cd9c2a0"
+                            }
+                        ]
                     },
                     "10": {
                         "annotation": "Minimum length of reads to be kept.",
@@ -2668,7 +2573,13 @@
                         "type": "parameter_input",
                         "uuid": "c898eada-b136-40bf-a78d-240b8d02c660",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "b5501135-286f-410f-8aaa-ce79dfa52b38"
+                            }
+                        ]
                     },
                     "11": {
                         "annotation": "Maximal N percentage threshold to conserve sequences.",
@@ -2695,7 +2606,13 @@
                         "type": "parameter_input",
                         "uuid": "d8341e6e-1401-48ef-ac1a-68c98309d0e1",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "f55c448d-f67e-4e0f-bede-c7937f2eb298"
+                            }
+                        ]
                     },
                     "12": {
                         "annotation": "",
@@ -3748,49 +3665,9 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": null,
-                    "output_name": "10:output",
-                    "uuid": "e6694be3-641d-40a6-b6da-50422c5f98e6"
-                },
-                {
-                    "label": null,
-                    "output_name": "4:output",
-                    "uuid": "c6c742f2-f3b4-400e-8aee-f02f29f0553a"
-                },
-                {
-                    "label": null,
-                    "output_name": "5:output",
-                    "uuid": "babd2e76-ec89-4735-926c-c3980c73af44"
-                },
-                {
-                    "label": null,
-                    "output_name": "6:output",
-                    "uuid": "580cba9e-395e-4517-ae55-dc4853d2040e"
-                },
-                {
-                    "label": null,
-                    "output_name": "7:output",
-                    "uuid": "f90f4c39-e7cd-4026-817e-ee5b6587f24e"
-                },
-                {
-                    "label": null,
-                    "output_name": "8:output",
-                    "uuid": "4ff844f7-fcca-41f4-872f-5789d44bc709"
-                },
-                {
-                    "label": null,
-                    "output_name": "9:output",
-                    "uuid": "c882ff1b-e97a-45e0-aaaa-d4a68717fbd5"
-                },
-                {
-                    "label": null,
-                    "output_name": "11:output",
-                    "uuid": "62f154e1-7c5d-4657-b361-d0ac65e01ad1"
-                },
-                {
-                    "label": "Paired-end MultiQC report",
-                    "output_name": "Paired-end MultiQC report",
-                    "uuid": "ec044dec-9f20-447f-8108-6040204f6054"
+                    "label": "Paired-end post quality control FASTA files",
+                    "output_name": "Paired-end post quality control FASTA files",
+                    "uuid": "6b08b8f6-8f53-4a23-92a1-40a064674f17"
                 },
                 {
                     "label": "Paired-end MultiQC statistics",
@@ -3798,24 +3675,9 @@
                     "uuid": "9f83bbc4-916e-4379-a018-cef375aa6abb"
                 },
                 {
-                    "label": "Paired-end post quality control FASTA files",
-                    "output_name": "Paired-end post quality control FASTA files",
-                    "uuid": "6b08b8f6-8f53-4a23-92a1-40a064674f17"
-                },
-                {
-                    "label": null,
-                    "output_name": "1:output",
-                    "uuid": "c72f9c4b-e92d-49ff-ab09-2c7b250cf207"
-                },
-                {
-                    "label": null,
-                    "output_name": "2:output",
-                    "uuid": "d958cb30-b912-4497-bcd1-869edddb2e8b"
-                },
-                {
-                    "label": null,
-                    "output_name": "3:output",
-                    "uuid": "4c9778e4-f785-4a89-9a66-fb7d55c29cff"
+                    "label": "Paired-end MultiQC report",
+                    "output_name": "Paired-end MultiQC report",
+                    "uuid": "ec044dec-9f20-447f-8108-6040204f6054"
                 }
             ]
         },
@@ -7256,6 +7118,26 @@
             "when": null,
             "workflow_outputs": [
                 {
+                    "label": "LSU and SSU BED regions",
+                    "output_name": "LSU and SSU BED regions",
+                    "uuid": "2c0868a6-e45b-4738-9f2e-8395c49f6af1"
+                },
+                {
+                    "label": "LSU OTU tables (SILVA DB)",
+                    "output_name": "LSU OTU tables (SILVA DB)",
+                    "uuid": "6b36b9af-d003-4cc2-a179-a2a6c05090ad"
+                },
+                {
+                    "label": "SSU taxonomic classifications using SILVA DB",
+                    "output_name": "SSU taxonomic classifications using SILVA DB",
+                    "uuid": "3d7739ed-d444-4dbd-b686-b27e1aa1b7d0"
+                },
+                {
+                    "label": "SSU FASTA files",
+                    "output_name": "SSU FASTA files",
+                    "uuid": "ee71d9de-28d9-4177-acb6-9ef170d2ce25"
+                },
+                {
                     "label": "LSU taxonomic classifications using SILVA DB",
                     "output_name": "LSU taxonomic classifications using SILVA DB",
                     "uuid": "09f8843c-6250-4c8a-a2b3-3ceee8915d23"
@@ -7286,11 +7168,6 @@
                     "uuid": "45a9891a-b535-4f6b-9a66-e86c53ee154b"
                 },
                 {
-                    "label": "SSU FASTA files",
-                    "output_name": "SSU FASTA files",
-                    "uuid": "ee71d9de-28d9-4177-acb6-9ef170d2ce25"
-                },
-                {
                     "label": "LSU FASTA files",
                     "output_name": "LSU FASTA files",
                     "uuid": "a4371314-8837-4670-a6b2-1e528264ebd4"
@@ -7304,21 +7181,6 @@
                     "label": "SSU taxonomic abundance pie charts (SILVA DB)",
                     "output_name": "SSU taxonomic abundance pie charts (SILVA DB)",
                     "uuid": "c57d0bc6-d624-4be5-a10b-74c3ad15ab17"
-                },
-                {
-                    "label": "LSU and SSU BED regions",
-                    "output_name": "LSU and SSU BED regions",
-                    "uuid": "2c0868a6-e45b-4738-9f2e-8395c49f6af1"
-                },
-                {
-                    "label": "LSU OTU tables (SILVA DB)",
-                    "output_name": "LSU OTU tables (SILVA DB)",
-                    "uuid": "6b36b9af-d003-4cc2-a179-a2a6c05090ad"
-                },
-                {
-                    "label": "SSU taxonomic classifications using SILVA DB",
-                    "output_name": "SSU taxonomic classifications using SILVA DB",
-                    "uuid": "3d7739ed-d444-4dbd-b686-b27e1aa1b7d0"
                 }
             ]
         },
@@ -9831,24 +9693,9 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "ITS OTU tables in JSON format (ITSoneDB)",
-                    "output_name": "ITS OTU tables in JSON format (ITSoneDB)",
-                    "uuid": "13e54088-7391-4c8c-9fde-2dd63080fafd"
-                },
-                {
-                    "label": "ITS taxonomic abundance pie charts (ITSoneDB)",
-                    "output_name": "ITS taxonomic abundance pie charts (ITSoneDB)",
-                    "uuid": "db0a8042-4964-4619-93e1-0d6a4ffdc5f1"
-                },
-                {
-                    "label": "ITS taxonomic classifications using UNITE DB",
-                    "output_name": "ITS taxonomic classifications using UNITE DB",
-                    "uuid": "384bb22d-6926-4833-89ed-1c9ec309aa7f"
-                },
-                {
-                    "label": "ITS taxonomic abundance pie charts (UNITE DB)",
-                    "output_name": "ITS taxonomic abundance pie charts (UNITE DB)",
-                    "uuid": "f9c37e34-a124-4a1f-b9df-e834efbe0e53"
+                    "label": "ITS OTU tables in HDF5 format (ITSoneDB)",
+                    "output_name": "ITS OTU tables in HDF5 format (ITSoneDB)",
+                    "uuid": "d7b793f8-f828-44e3-9af5-798158bd11d6"
                 },
                 {
                     "label": "ITS OTU tables (UNITE DB)",
@@ -9866,11 +9713,6 @@
                     "uuid": "9d7fe164-5af7-4ef2-a439-a163705abfbb"
                 },
                 {
-                    "label": "ITS OTU tables in HDF5 format (ITSoneDB)",
-                    "output_name": "ITS OTU tables in HDF5 format (ITSoneDB)",
-                    "uuid": "d7b793f8-f828-44e3-9af5-798158bd11d6"
-                },
-                {
                     "label": "ITS OTU tables in JSON format (UNITE DB)",
                     "output_name": "ITS OTU tables in JSON format (UNITE DB)",
                     "uuid": "6ef5a97b-63a2-4308-90a2-08a0f81057ea"
@@ -9884,6 +9726,26 @@
                     "label": "ITS taxonomic classifications using ITSoneDB",
                     "output_name": "ITS taxonomic classifications using ITSoneDB",
                     "uuid": "2aa27435-9a26-4f50-8d2a-9e07cfda66ba"
+                },
+                {
+                    "label": "ITS taxonomic abundance pie charts (UNITE DB)",
+                    "output_name": "ITS taxonomic abundance pie charts (UNITE DB)",
+                    "uuid": "f9c37e34-a124-4a1f-b9df-e834efbe0e53"
+                },
+                {
+                    "label": "ITS taxonomic classifications using UNITE DB",
+                    "output_name": "ITS taxonomic classifications using UNITE DB",
+                    "uuid": "384bb22d-6926-4833-89ed-1c9ec309aa7f"
+                },
+                {
+                    "label": "ITS taxonomic abundance pie charts (ITSoneDB)",
+                    "output_name": "ITS taxonomic abundance pie charts (ITSoneDB)",
+                    "uuid": "db0a8042-4964-4619-93e1-0d6a4ffdc5f1"
+                },
+                {
+                    "label": "ITS OTU tables in JSON format (ITSoneDB)",
+                    "output_name": "ITS OTU tables in JSON format (ITSoneDB)",
+                    "uuid": "13e54088-7391-4c8c-9fde-2dd63080fafd"
                 }
             ]
         },
@@ -11515,16 +11377,6 @@
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
-                    "label": null,
-                    "output_name": "2:output",
-                    "uuid": "ae453900-5f5b-481d-a562-710525d87ad8"
-                },
-                {
-                    "label": null,
-                    "output_name": "1:output",
-                    "uuid": "65a32ca3-7458-41d9-9605-378a45d6b63b"
-                },
-                {
                     "label": "SSU phylum level taxonomic abundance summary table",
                     "output_name": "phylum level taxonomic abundance summary table",
                     "uuid": "b8be6baa-41d2-4652-87dc-f1fb9abc07ee"
@@ -12188,24 +12040,14 @@
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
-                    "label": null,
-                    "output_name": "2:output",
-                    "uuid": "ecd7fcb5-84b5-4f4d-a8b6-953814167b6e"
-                },
-                {
-                    "label": "LSU phylum level taxonomic abundance summary table",
-                    "output_name": "phylum level taxonomic abundance summary table",
-                    "uuid": "e7425613-0d16-47f5-86c9-b881908ca21e"
-                },
-                {
                     "label": "LSU taxonomic abundance summary table",
                     "output_name": "Taxonomic abundance summary table",
                     "uuid": "203f7e9c-346a-44b3-82fb-c00beab8049f"
                 },
                 {
-                    "label": null,
-                    "output_name": "1:output",
-                    "uuid": "7ce321a3-9fa6-4d00-8dd6-09a09aef03c6"
+                    "label": "LSU phylum level taxonomic abundance summary table",
+                    "output_name": "phylum level taxonomic abundance summary table",
+                    "uuid": "e7425613-0d16-47f5-86c9-b881908ca21e"
                 }
             ]
         },
@@ -12866,24 +12708,14 @@
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
-                    "label": "ITSoneDB phylum level taxonomic abundance summary table",
-                    "output_name": "phylum level taxonomic abundance summary table",
-                    "uuid": "82dce358-6820-47c4-a1a1-6e02506e66be"
-                },
-                {
                     "label": "ITSoneDB taxonomic abundance summary table",
                     "output_name": "Taxonomic abundance summary table",
                     "uuid": "05613f35-22d4-4a32-8ddc-69d6a7281470"
                 },
                 {
-                    "label": null,
-                    "output_name": "1:output",
-                    "uuid": "e45fb38d-8b7a-419b-bb14-4c470fc934ef"
-                },
-                {
-                    "label": null,
-                    "output_name": "2:output",
-                    "uuid": "5e729547-0f7c-4b82-878f-2efe75794dab"
+                    "label": "ITSoneDB phylum level taxonomic abundance summary table",
+                    "output_name": "phylum level taxonomic abundance summary table",
+                    "uuid": "82dce358-6820-47c4-a1a1-6e02506e66be"
                 }
             ]
         },
@@ -13544,24 +13376,14 @@
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
-                    "label": null,
-                    "output_name": "1:output",
-                    "uuid": "74602444-fe5e-4bdb-8385-888b1c6015e8"
-                },
-                {
-                    "label": null,
-                    "output_name": "2:output",
-                    "uuid": "71a87ad9-6250-406c-81e7-6ecfe937ac03"
+                    "label": "ITS UNITE DB taxonomic abundance summary table",
+                    "output_name": "Taxonomic abundance summary table",
+                    "uuid": "a17b7e83-6e97-4923-a8ea-542838729f5d"
                 },
                 {
                     "label": "ITS UNITE DB phylum level taxonomic abundance summary table",
                     "output_name": "phylum level taxonomic abundance summary table",
                     "uuid": "1813a260-c36c-4b3d-862a-fb244ce8f4a9"
-                },
-                {
-                    "label": "ITS UNITE DB taxonomic abundance summary table",
-                    "output_name": "Taxonomic abundance summary table",
-                    "uuid": "a17b7e83-6e97-4923-a8ea-542838729f5d"
                 }
             ]
         }
@@ -13572,6 +13394,6 @@
         "amplicon",
         "name:microgalaxy"
     ],
-    "uuid": "e1106ef2-1922-4ad2-802f-44dd4482efa5",
-    "version": 153
+    "uuid": "fdbc9b75-5788-4346-a7c7-c41e42d4f61f",
+    "version": 154
 }

--- a/workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-paired-end/CHANGELOG.md
+++ b/workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-paired-end/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.2] - 2025-03-10
+
+- `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy3` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4`
+
 ## [0.1] - 2025-01-27
 
 - First release
+

--- a/workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-paired-end/mgnify-amplicon-pipeline-v5-quality-control-paired-end.ga
+++ b/workflows/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-paired-end/mgnify-amplicon-pipeline-v5-quality-control-paired-end.ga
@@ -24,7 +24,7 @@
     "format-version": "0.1",
     "license": "Apache-2.0",
     "name": "MGnify's amplicon pipeline v5.0 - Quality control PE",
-    "release": "0.1",
+    "release": "0.2",
     "report": {
         "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
     },
@@ -46,7 +46,7 @@
             "outputs": [],
             "position": {
                 "left": 0,
-                "top": 15.048431485651236
+                "top": 134.00843148565127
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list:paired\"}",
@@ -73,10 +73,10 @@
             "outputs": [],
             "position": {
                 "left": 67.94649253008049,
-                "top": 198.09430885853078
+                "top": 317.0543088585308
             },
             "tool_id": null,
-            "tool_state": "{\"default\": false, \"parameter_type\": \"boolean\", \"optional\": true}",
+            "tool_state": "{\"default\": false, \"validators\": [], \"parameter_type\": \"boolean\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "81367449-c0ca-41be-b69d-5bf1568e0361",
@@ -100,10 +100,10 @@
             "outputs": [],
             "position": {
                 "left": 309.2157898611554,
-                "top": 210.97762085193767
+                "top": 329.9376208519377
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 20, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 20, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "cb8a7bac-c007-45c6-814b-9aacae0e37b3",
@@ -127,10 +127,10 @@
             "outputs": [],
             "position": {
                 "left": 311.55821022359305,
-                "top": 301.16080480578603
+                "top": 420.12080480578607
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 20, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 20, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "26ed5910-22cf-4a8e-a144-edbb8d6b1d50",
@@ -154,10 +154,10 @@
             "outputs": [],
             "position": {
                 "left": 310.3870000423742,
-                "top": 387.830358215978
+                "top": 506.790358215978
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 70, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 70, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "6521e9f3-6d1b-4e95-8934-3345f858bcf8",
@@ -181,10 +181,10 @@
             "outputs": [],
             "position": {
                 "left": 310.8945435169014,
-                "top": 499.8566406435558
+                "top": 618.8166406435558
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 4, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 4, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "1b2652b0-235b-4120-9c82-e4d3210c9d2f",
@@ -208,10 +208,10 @@
             "outputs": [],
             "position": {
                 "left": 312.5205763417023,
-                "top": 632.1894950478717
+                "top": 751.1494950478717
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 15, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 15, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "53e87ca4-6745-4835-b25f-878705737f0d",
@@ -235,10 +235,10 @@
             "outputs": [],
             "position": {
                 "left": 315.85885539878177,
-                "top": 761.5628796617777
+                "top": 880.5228796617778
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 3, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 3, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "4e1cfaad-b067-4bf3-a6b8-33d3fd826285",
@@ -262,10 +262,10 @@
             "outputs": [],
             "position": {
                 "left": 330.0774689415621,
-                "top": 854.9611632212501
+                "top": 973.9211632212501
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 3, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 3, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "d48c0437-1ab6-4fd4-8dfa-29dd056acaec",
@@ -273,37 +273,10 @@
             "workflow_outputs": []
         },
         "9": {
-            "annotation": "Minimum length of reads to be kept.",
-            "content_id": null,
-            "errors": null,
-            "id": 9,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "Minimum length of reads to be kept.",
-                    "name": "Trimmomatic - MINLEN"
-                }
-            ],
-            "label": "Trimmomatic - MINLEN",
-            "name": "Input parameter",
-            "outputs": [],
-            "position": {
-                "left": 332.17940873206794,
-                "top": 943.1950248633116
-            },
-            "tool_id": null,
-            "tool_state": "{\"default\": 100, \"parameter_type\": \"integer\", \"optional\": true}",
-            "tool_version": null,
-            "type": "parameter_input",
-            "uuid": "c898eada-b136-40bf-a78d-240b8d02c660",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "10": {
             "annotation": "Minimum sequence length.",
             "content_id": null,
             "errors": null,
-            "id": 10,
+            "id": 9,
             "input_connections": {},
             "inputs": [
                 {
@@ -316,13 +289,40 @@
             "outputs": [],
             "position": {
                 "left": 993.3486541402174,
-                "top": 245.3668565107227
+                "top": 364.32685651072273
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 100, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 100, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "2957cfb6-b542-4354-b94f-fd171df4c9b1",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "10": {
+            "annotation": "Minimum length of reads to be kept.",
+            "content_id": null,
+            "errors": null,
+            "id": 10,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Minimum length of reads to be kept.",
+                    "name": "Trimmomatic - MINLEN"
+                }
+            ],
+            "label": "Trimmomatic - MINLEN",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 332.17940873206794,
+                "top": 1062.1550248633116
+            },
+            "tool_id": null,
+            "tool_state": "{\"default\": 100, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "c898eada-b136-40bf-a78d-240b8d02c660",
             "when": null,
             "workflow_outputs": []
         },
@@ -343,10 +343,10 @@
             "outputs": [],
             "position": {
                 "left": 1443.0933637282412,
-                "top": 118.73561171734482
+                "top": 237.69561171734486
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 10, \"parameter_type\": \"integer\", \"optional\": true}",
+            "tool_state": "{\"default\": 10, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "d8341e6e-1401-48ef-ac1a-68c98309d0e1",
@@ -355,13 +355,81 @@
         },
         "12": {
             "annotation": "",
-            "content_id": "__UNZIP_COLLECTION__",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4",
             "errors": null,
             "id": 12,
             "input_connections": {
-                "input": {
+                "filter_options|length_filtering_options|length_required": {
+                    "id": 4,
+                    "output_name": "output"
+                },
+                "filter_options|quality_filtering_options|qualified_quality_phred": {
+                    "id": 2,
+                    "output_name": "output"
+                },
+                "filter_options|quality_filtering_options|unqualified_percent_limit": {
+                    "id": 3,
+                    "output_name": "output"
+                },
+                "read_mod_options|base_correction_options|correction": {
+                    "id": 1,
+                    "output_name": "output"
+                },
+                "single_paired|paired_input": {
                     "id": 0,
                     "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool fastp",
+                    "name": "single_paired"
+                }
+            ],
+            "label": null,
+            "name": "fastp",
+            "outputs": [
+                {
+                    "name": "output_paired_coll",
+                    "type": "input"
+                },
+                {
+                    "name": "report_html",
+                    "type": "html"
+                },
+                {
+                    "name": "report_json",
+                    "type": "json"
+                }
+            ],
+            "position": {
+                "left": 331.5,
+                "top": 0.0
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4",
+            "tool_shed_repository": {
+                "changeset_revision": "10678d49d39e",
+                "name": "fastp",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": {\"__class__\": \"ConnectedValue\"}, \"unqualified_percent_limit\": {\"__class__\": \"ConnectedValue\"}, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": {\"__class__\": \"ConnectedValue\"}, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": null, \"umi_len\": null, \"umi_prefix\": null}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": {\"__class__\": \"ConnectedValue\"}}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 1, \"paired_input\": {\"__class__\": \"RuntimeValue\"}, \"merge_reads\": {\"merge\": \"\", \"__current_case__\": 1}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": null, \"adapter_sequence2\": null, \"detect_adapter_for_pe\": false}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.24.0+galaxy4",
+            "type": "tool",
+            "uuid": "9b7f1d2d-d39f-407d-a709-a5095fca62c2",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "13": {
+            "annotation": "",
+            "content_id": "__UNZIP_COLLECTION__",
+            "errors": null,
+            "id": 13,
+            "input_connections": {
+                "input": {
+                    "id": 12,
+                    "output_name": "output_paired_coll"
                 }
             },
             "inputs": [],
@@ -378,8 +446,8 @@
                 }
             ],
             "position": {
-                "left": 326.2817086942314,
-                "top": 0
+                "left": 610.2833251953125,
+                "top": 342.9666748046875
             },
             "post_job_actions": {
                 "ChangeDatatypeActionforward": {
@@ -415,107 +483,6 @@
             "when": null,
             "workflow_outputs": []
         },
-        "13": {
-            "annotation": "Filtering of forward and reverse paired-end reads.",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy3",
-            "errors": null,
-            "id": 13,
-            "input_connections": {
-                "filter_options|length_filtering_options|length_required": {
-                    "id": 4,
-                    "output_name": "output"
-                },
-                "filter_options|quality_filtering_options|qualified_quality_phred": {
-                    "id": 2,
-                    "output_name": "output"
-                },
-                "filter_options|quality_filtering_options|unqualified_percent_limit": {
-                    "id": 3,
-                    "output_name": "output"
-                },
-                "read_mod_options|base_correction_options|correction": {
-                    "id": 1,
-                    "output_name": "output"
-                },
-                "single_paired|in1": {
-                    "id": 12,
-                    "output_name": "forward"
-                },
-                "single_paired|in2": {
-                    "id": 12,
-                    "output_name": "reverse"
-                }
-            },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool fastp",
-                    "name": "single_paired"
-                },
-                {
-                    "description": "runtime parameter for tool fastp",
-                    "name": "single_paired"
-                }
-            ],
-            "label": "fastp filtering",
-            "name": "fastp",
-            "outputs": [
-                {
-                    "name": "out1",
-                    "type": "input"
-                },
-                {
-                    "name": "out2",
-                    "type": "input"
-                },
-                {
-                    "name": "report_html",
-                    "type": "html"
-                },
-                {
-                    "name": "report_json",
-                    "type": "json"
-                }
-            ],
-            "position": {
-                "left": 578.1256188749957,
-                "top": 186.01134288495575
-            },
-            "post_job_actions": {
-                "HideDatasetActionout1": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "out1"
-                },
-                "HideDatasetActionout2": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "out2"
-                },
-                "HideDatasetActionreport_html": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "report_html"
-                },
-                "HideDatasetActionreport_json": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "report_json"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy3",
-            "tool_shed_repository": {
-                "changeset_revision": "a626e8c0e1ba",
-                "name": "fastp",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": {\"__class__\": \"ConnectedValue\"}, \"unqualified_percent_limit\": {\"__class__\": \"ConnectedValue\"}, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": {\"__class__\": \"ConnectedValue\"}, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": null, \"umi_len\": null, \"umi_prefix\": null}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": {\"__class__\": \"ConnectedValue\"}}}, \"single_paired\": {\"single_paired_selector\": \"paired\", \"__current_case__\": 1, \"in1\": {\"__class__\": \"ConnectedValue\"}, \"in2\": {\"__class__\": \"ConnectedValue\"}, \"merge_reads\": {\"merge\": \"\", \"__current_case__\": 1}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": null, \"adapter_sequence2\": null, \"detect_adapter_for_pe\": false}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.24.0+galaxy3",
-            "type": "tool",
-            "uuid": "6d9e0ee3-cc0f-423e-8613-0ad0b5b3de0b",
-            "when": null,
-            "workflow_outputs": []
-        },
         "14": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/mgnify_seqprep/mgnify_seqprep/1.2+galaxy0",
@@ -524,11 +491,11 @@
             "input_connections": {
                 "input1": {
                     "id": 13,
-                    "output_name": "out1"
+                    "output_name": "forward"
                 },
                 "input2": {
                     "id": 13,
-                    "output_name": "out2"
+                    "output_name": "reverse"
                 }
             },
             "inputs": [],
@@ -550,7 +517,7 @@
             ],
             "position": {
                 "left": 788.0499877929688,
-                "top": 530.4190556311589
+                "top": 649.379055631159
             },
             "post_job_actions": {
                 "ChangeDatatypeActionmerged": {
@@ -613,7 +580,7 @@
                     "output_name": "output"
                 },
                 "operations_3|operation|minlen": {
-                    "id": 9,
+                    "id": 10,
                     "output_name": "output"
                 },
                 "readtype|fastq_in": {
@@ -637,7 +604,7 @@
             ],
             "position": {
                 "left": 1099.8073621070885,
-                "top": 359.9795420250569
+                "top": 478.93954202505694
             },
             "post_job_actions": {
                 "HideDatasetActionfastq_out": {
@@ -699,7 +666,7 @@
             ],
             "position": {
                 "left": 1250.6521000986795,
-                "top": 1081.9540694839034
+                "top": 1200.9140694839034
             },
             "post_job_actions": {
                 "HideDatasetActionhtml_file": {
@@ -745,7 +712,7 @@
                     "output_name": "fastq_out"
                 },
                 "min_size": {
-                    "id": 10,
+                    "id": 9,
                     "output_name": "output"
                 }
             },
@@ -760,7 +727,7 @@
             ],
             "position": {
                 "left": 1359,
-                "top": 321.40574133062194
+                "top": 440.365741330622
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_file": {
@@ -822,7 +789,7 @@
             ],
             "position": {
                 "left": 1546.9682759470388,
-                "top": 1080.7828593026848
+                "top": 1199.7428593026848
             },
             "post_job_actions": {
                 "HideDatasetActionhtml_file": {
@@ -879,7 +846,7 @@
             ],
             "position": {
                 "left": 1593.8207131348126,
-                "top": 1445.0234870611885
+                "top": 1563.9834870611885
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -904,9 +871,72 @@
         },
         "20": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.74+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/prinseq/prinseq/0.20.4+galaxy2",
             "errors": null,
             "id": 20,
+            "input_connections": {
+                "filter_treatments|base_content_filter_treatments|N_percentage_content_filter_treatments|N_percentage_content_filter_treatment_value": {
+                    "id": 11,
+                    "output_name": "output"
+                },
+                "seq_type|input_singles": {
+                    "id": 17,
+                    "output_name": "output_file"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool PRINSEQ",
+                    "name": "seq_type"
+                }
+            ],
+            "label": "Ambiguity filtering",
+            "name": "PRINSEQ",
+            "outputs": [
+                {
+                    "name": "good_sequence_file",
+                    "type": "input"
+                },
+                {
+                    "name": "rejected_sequence_file",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1646.903450664335,
+                "top": 523.0258360658718
+            },
+            "post_job_actions": {
+                "HideDatasetActiongood_sequence_file": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "good_sequence_file"
+                },
+                "HideDatasetActionrejected_sequence_file": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "rejected_sequence_file"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/prinseq/prinseq/0.20.4+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "1ee282794de3",
+                "name": "prinseq",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"filter_treatments\": {\"apply_filter_treatments\": \"true\", \"__current_case__\": 0, \"length_filter_treatments\": {\"apply_length_filter_treatments\": \"false\", \"__current_case__\": 1}, \"quality_filter_treatments\": {\"apply_quality_filter_treatments\": \"false\", \"__current_case__\": 1}, \"base_content_filter_treatments\": {\"apply_base_content_filter_treatments\": \"true\", \"__current_case__\": 0, \"GC_perc_content_filter_treatments\": {\"apply_GC_perc_content_filter_treatments\": \"false\", \"__current_case__\": 1}, \"N_number_content_filter_treatments\": {\"apply_N_number_content_filter_treatments\": \"false\", \"__current_case__\": 1}, \"N_percentage_content_filter_treatments\": {\"apply_N_percentage_content_filter_treatments\": \"true\", \"__current_case__\": 0, \"N_percentage_content_filter_treatment_value\": {\"__class__\": \"ConnectedValue\"}}, \"apply_other_base_content_filter_treatments\": true}, \"complexity_filter_treatments\": {\"apply_complexity_filter_treatments\": \"false\", \"__current_case__\": 1}}, \"seq_type\": {\"seq_type_opt\": \"single\", \"__current_case__\": 0, \"input_singles\": {\"__class__\": \"ConnectedValue\"}}, \"trimming_treatments\": {\"apply_trimming_treatments\": \"false\", \"__current_case__\": 1}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.20.4+galaxy2",
+            "type": "tool",
+            "uuid": "d65b0e38-5f52-425a-a3c3-9cb126ead9f7",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "21": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.74+galaxy1",
+            "errors": null,
+            "id": 21,
             "input_connections": {
                 "input_file": {
                     "id": 17,
@@ -941,7 +971,7 @@
             ],
             "position": {
                 "left": 1536.6496929362308,
-                "top": 699.2091488145751
+                "top": 818.1691488145751
             },
             "post_job_actions": {
                 "HideDatasetActionhtml_file": {
@@ -976,69 +1006,6 @@
             "when": null,
             "workflow_outputs": []
         },
-        "21": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/prinseq/prinseq/0.20.4+galaxy2",
-            "errors": null,
-            "id": 21,
-            "input_connections": {
-                "filter_treatments|base_content_filter_treatments|N_percentage_content_filter_treatments|N_percentage_content_filter_treatment_value": {
-                    "id": 11,
-                    "output_name": "output"
-                },
-                "seq_type|input_singles": {
-                    "id": 17,
-                    "output_name": "output_file"
-                }
-            },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool PRINSEQ",
-                    "name": "seq_type"
-                }
-            ],
-            "label": "Ambiguity filtering",
-            "name": "PRINSEQ",
-            "outputs": [
-                {
-                    "name": "good_sequence_file",
-                    "type": "input"
-                },
-                {
-                    "name": "rejected_sequence_file",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 1646.903450664335,
-                "top": 404.0658360658717
-            },
-            "post_job_actions": {
-                "HideDatasetActiongood_sequence_file": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "good_sequence_file"
-                },
-                "HideDatasetActionrejected_sequence_file": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "rejected_sequence_file"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/prinseq/prinseq/0.20.4+galaxy2",
-            "tool_shed_repository": {
-                "changeset_revision": "1ee282794de3",
-                "name": "prinseq",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"filter_treatments\": {\"apply_filter_treatments\": \"true\", \"__current_case__\": 0, \"length_filter_treatments\": {\"apply_length_filter_treatments\": \"false\", \"__current_case__\": 1}, \"quality_filter_treatments\": {\"apply_quality_filter_treatments\": \"false\", \"__current_case__\": 1}, \"base_content_filter_treatments\": {\"apply_base_content_filter_treatments\": \"true\", \"__current_case__\": 0, \"GC_perc_content_filter_treatments\": {\"apply_GC_perc_content_filter_treatments\": \"false\", \"__current_case__\": 1}, \"N_number_content_filter_treatments\": {\"apply_N_number_content_filter_treatments\": \"false\", \"__current_case__\": 1}, \"N_percentage_content_filter_treatments\": {\"apply_N_percentage_content_filter_treatments\": \"true\", \"__current_case__\": 0, \"N_percentage_content_filter_treatment_value\": {\"__class__\": \"ConnectedValue\"}}, \"apply_other_base_content_filter_treatments\": true}, \"complexity_filter_treatments\": {\"apply_complexity_filter_treatments\": \"false\", \"__current_case__\": 1}}, \"seq_type\": {\"seq_type_opt\": \"single\", \"__current_case__\": 0, \"input_singles\": {\"__class__\": \"ConnectedValue\"}}, \"trimming_treatments\": {\"apply_trimming_treatments\": \"false\", \"__current_case__\": 1}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.20.4+galaxy2",
-            "type": "tool",
-            "uuid": "d65b0e38-5f52-425a-a3c3-9cb126ead9f7",
-            "when": null,
-            "workflow_outputs": []
-        },
         "22": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
@@ -1061,7 +1028,7 @@
             ],
             "position": {
                 "left": 1919.413113574621,
-                "top": 1045.64655386612
+                "top": 1164.60655386612
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -1086,57 +1053,12 @@
         },
         "23": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqtofasta/fastq_to_fasta_python/1.1.5+galaxy2",
             "errors": null,
             "id": 23,
             "input_connections": {
-                "infile": {
-                    "id": 20,
-                    "output_name": "text_file"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Replace",
-            "outputs": [
-                {
-                    "name": "outfile",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 2169.018738976497,
-                "top": 877.5344763313531
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutfile": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "outfile"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
-            "tool_shed_repository": {
-                "changeset_revision": "86755160afbf",
-                "name": "text_processing",
-                "owner": "bgruening",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"\\\\t(.*?)\\\\.gz\", \"replace_pattern\": \"\\\\t$1_length_filtering\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "9.3+galaxy1",
-            "type": "tool",
-            "uuid": "8c5dc662-6bcc-4772-bc0e-d0b747113ef3",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "24": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqtofasta/fastq_to_fasta_python/1.1.5+galaxy2",
-            "errors": null,
-            "id": 24,
-            "input_connections": {
                 "input_file": {
-                    "id": 21,
+                    "id": 20,
                     "output_name": "good_sequence_file"
                 }
             },
@@ -1151,7 +1073,7 @@
             ],
             "position": {
                 "left": 1952.1162504932327,
-                "top": 422.9194796760812
+                "top": 541.8794796760812
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_file": {
@@ -1174,14 +1096,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "25": {
+        "24": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.74+galaxy1",
             "errors": null,
-            "id": 25,
+            "id": 24,
             "input_connections": {
                 "input_file": {
-                    "id": 21,
+                    "id": 20,
                     "output_name": "good_sequence_file"
                 }
             },
@@ -1213,7 +1135,7 @@
             ],
             "position": {
                 "left": 2282.6440047444867,
-                "top": 547.9029867716423
+                "top": 666.8629867716423
             },
             "post_job_actions": {
                 "HideDatasetActionhtml_file": {
@@ -1248,6 +1170,51 @@
             "when": null,
             "workflow_outputs": []
         },
+        "25": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "errors": null,
+            "id": 25,
+            "input_connections": {
+                "infile": {
+                    "id": 21,
+                    "output_name": "text_file"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Replace",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2169.018738976497,
+                "top": 996.4944763313531
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutfile": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "86755160afbf",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"\\\\t(.*?)\\\\.gz\", \"replace_pattern\": \"\\\\t$1_length_filtering\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "9.3+galaxy1",
+            "type": "tool",
+            "uuid": "8c5dc662-6bcc-4772-bc0e-d0b747113ef3",
+            "when": null,
+            "workflow_outputs": []
+        },
         "26": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_formatter/cshl_fasta_formatter/1.0.1+galaxy2",
@@ -1255,7 +1222,7 @@
             "id": 26,
             "input_connections": {
                 "input": {
-                    "id": 24,
+                    "id": 23,
                     "output_name": "output_file"
                 }
             },
@@ -1270,7 +1237,7 @@
             ],
             "position": {
                 "left": 2306.5295226390967,
-                "top": 283.3337627748787
+                "top": 402.29376277487876
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -1308,7 +1275,7 @@
             "id": 27,
             "input_connections": {
                 "infile": {
-                    "id": 25,
+                    "id": 24,
                     "output_name": "text_file"
                 }
             },
@@ -1323,7 +1290,7 @@
             ],
             "position": {
                 "left": 2529.1111984955273,
-                "top": 712.6491291601473
+                "top": 831.6091291601473
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -1361,7 +1328,7 @@
                     "output_name": "outfile"
                 },
                 "results_0|software_cond|output_2|input": {
-                    "id": 23,
+                    "id": 25,
                     "output_name": "outfile"
                 },
                 "results_0|software_cond|output_3|input": {
@@ -1384,7 +1351,7 @@
             ],
             "position": {
                 "left": 2884.8980879090345,
-                "top": 478.96236806163165
+                "top": 597.9223680616317
             },
             "post_job_actions": {
                 "RenameDatasetActionhtml_report": {
@@ -1409,21 +1376,21 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastqc\", \"__current_case__\": 8, \"output\": [{\"__index__\": 0, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 1, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 2, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 3, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}]}}], \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastqc\", \"__current_case__\": 8, \"output\": [{\"__index__\": 0, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 2, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 3, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}]}}], \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.27+galaxy0",
             "type": "tool",
             "uuid": "e04ee136-c52f-4d7e-85c5-3b3ed78b0cce",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Paired-end MultiQC report",
-                    "output_name": "html_report",
-                    "uuid": "1d870a5b-942b-4f61-b8fd-a68b121b7f8c"
-                },
-                {
                     "label": "Paired-end MultiQC statistics",
                     "output_name": "stats",
                     "uuid": "fc6047b2-201d-4e77-ab0d-9c8107897088"
+                },
+                {
+                    "label": "Paired-end MultiQC report",
+                    "output_name": "html_report",
+                    "uuid": "1d870a5b-942b-4f61-b8fd-a68b121b7f8c"
                 }
             ]
         }
@@ -1434,6 +1401,6 @@
         "metagenomics",
         "name:microgalaxy"
     ],
-    "uuid": "a9df547d-8f99-4740-b884-73d1e83a89b5",
-    "version": 20
+    "uuid": "3af45a28-126d-4c9d-9948-cabfe43566f3",
+    "version": 21
 }


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [x] License permits unrestricted use (educational + commercial)
* [x] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file

`toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy3` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4` in the Paired end sub-WF and in the complete WF.
