### PR TITLE
Overhaul Galaxy Instance Selector, add support for usegalay.org.au (and others?)

### DIFF
--- a/website/components/GalaxyInstanceSelector.vue
+++ b/website/components/GalaxyInstanceSelector.vue
@@ -13,6 +13,7 @@ const defaultInstances = [
     "https://usegalaxy.org",
     "https://usegalaxy.eu",
     "https://usegalaxy.org.au",
+    "https://usegalaxy.fr",
     "https://test.galaxyproject.org",
 ];
 

--- a/website/components/GalaxyInstanceSelector.vue
+++ b/website/components/GalaxyInstanceSelector.vue
@@ -127,7 +127,8 @@ const showCreateOption = computed(() => {
             :options="allInstances"
             :searchable="true"
             v-model:query="internalQuery"
-            placeholder="Select or enter a Galaxy instance URL"
+            searchable-placeholder="Select or enter a custom Galaxy instance URL"
+            show-create-option-when="always"
             by="value"
             creatable>
             <template #option-create="{ option }">

--- a/website/components/GalaxyInstanceSelector.vue
+++ b/website/components/GalaxyInstanceSelector.vue
@@ -1,42 +1,64 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, watch } from 'vue';
+import { useStorage } from '@vueuse/core';
+
+// Default instance list
+const defaultInstances = [
+  { value: "https://usegalaxy.org", label: "usegalaxy.org" },
+  { value: "https://usegalaxy.eu", label: "usegalaxy.eu" },
+  { value: "https://usegalaxy.org.au", label: "usegalaxy.org.au" },
+  { value: "https://test.galaxyproject.org", label: "test.galaxyproject.org" },
+];
 
 const props = defineProps({
   modelValue: {
     type: String,
     required: true
   },
-  instances: {
-    type: Array,
-    default: () => []
-  }
 });
 
 const emit = defineEmits(['update:modelValue', 'change']);
 
-const selectedInstance = ref(props.modelValue);
+// Use useStorage to persist the selected instance
+const selectedInstance = ref('');
+const selectedInstanceStorage = useStorage('galaxy-instance-preference', selectedInstance);
 const customMode = ref(false);
 const customInstanceUrl = ref('');
 
+// Watch for changes to modelValue from parent component.
+watch(
+  () => props.modelValue,
+  (newVal) => {
+    if (newVal !== selectedInstance.value) {
+      selectedInstance.value = newVal;
+    }
+  }
+);
+
+// Watch for changes to the selected instance.
+watch(selectedInstance, (newVal) => {
+  selectedInstanceStorage.value = newVal;
+  emit('update:modelValue', newVal);
+  emit('change', newVal);
+});
+
 onMounted(() => {
   // Check if current value is a predefined instance or custom
-  customMode.value = !props.instances.some(instance => instance.value === props.modelValue);
+  customMode.value = !defaultInstances.some(instance => instance.value === selectedInstance.value);
   if (customMode.value) {
-    customInstanceUrl.value = props.modelValue;
+    customInstanceUrl.value = selectedInstance.value;
   }
 });
 
 function selectInstance(instance) {
   selectedInstance.value = instance;
-  emit('update:modelValue', instance);
-  emit('change', instance);
 }
 
 function toggleCustomMode() {
   customMode.value = !customMode.value;
   if (!customMode.value) {
     // When switching back to predefined, select the first instance
-    selectInstance(props.instances[0].value);
+    selectInstance(defaultInstances[0].value);
   } else {
     // When switching to custom, pre-fill with current selection
     customInstanceUrl.value = selectedInstance.value;
@@ -65,26 +87,26 @@ function handleCustomInputBlur() {
   <div class="galaxy-instance-selector">
     <div class="flex items-center justify-between mb-2">
       <span class="text-sm font-medium">Galaxy Instance</span>
-      <UButton 
+      <UButton
         size="xs"
-        :color="customMode ? 'primary' : 'gray'" 
+        :color="customMode ? 'primary' : 'gray'"
         :variant="customMode ? 'solid' : 'ghost'"
         @click="toggleCustomMode"
       >
         {{ customMode ? 'Use Predefined' : 'Use Custom' }}
       </UButton>
     </div>
-    
+
     <div v-if="!customMode">
       <USelect
         v-model="selectedInstance"
-        :options="instances"
+        :options="defaultInstances"
         @change="selectInstance"
         placeholder="Select a Galaxy instance"
         class="w-full"
       />
     </div>
-    
+
     <div v-else class="custom-url-input">
       <UInput
         v-model="customInstanceUrl"

--- a/website/components/GalaxyInstanceSelector.vue
+++ b/website/components/GalaxyInstanceSelector.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+
+const props = defineProps({
+  modelValue: {
+    type: String,
+    required: true
+  },
+  instances: {
+    type: Array,
+    default: () => []
+  }
+});
+
+const emit = defineEmits(['update:modelValue', 'change']);
+
+const selectedInstance = ref(props.modelValue);
+const customMode = ref(false);
+const customInstanceUrl = ref('');
+
+onMounted(() => {
+  // Check if current value is a predefined instance or custom
+  customMode.value = !props.instances.some(instance => instance.value === props.modelValue);
+  if (customMode.value) {
+    customInstanceUrl.value = props.modelValue;
+  }
+});
+
+function selectInstance(instance) {
+  selectedInstance.value = instance;
+  emit('update:modelValue', instance);
+  emit('change', instance);
+}
+
+function toggleCustomMode() {
+  customMode.value = !customMode.value;
+  if (!customMode.value) {
+    // When switching back to predefined, select the first instance
+    selectInstance(props.instances[0].value);
+  } else {
+    // When switching to custom, pre-fill with current selection
+    customInstanceUrl.value = selectedInstance.value;
+  }
+}
+
+function applyCustomUrl() {
+  try {
+    // Basic validation
+    new URL(customInstanceUrl.value);
+    selectInstance(customInstanceUrl.value);
+  } catch (e) {
+    console.error("Invalid URL provided");
+    // You could add visual feedback here
+  }
+}
+
+function handleCustomInputBlur() {
+  if (customInstanceUrl.value) {
+    applyCustomUrl();
+  }
+}
+</script>
+
+<template>
+  <div class="galaxy-instance-selector">
+    <div class="flex items-center justify-between mb-2">
+      <span class="text-sm font-medium">Galaxy Instance</span>
+      <UButton 
+        size="xs"
+        :color="customMode ? 'primary' : 'gray'" 
+        :variant="customMode ? 'solid' : 'ghost'"
+        @click="toggleCustomMode"
+      >
+        {{ customMode ? 'Use Predefined' : 'Use Custom' }}
+      </UButton>
+    </div>
+    
+    <div v-if="!customMode">
+      <USelect
+        v-model="selectedInstance"
+        :options="instances"
+        @change="selectInstance"
+        placeholder="Select a Galaxy instance"
+        class="w-full"
+      />
+    </div>
+    
+    <div v-else class="custom-url-input">
+      <UInput
+        v-model="customInstanceUrl"
+        placeholder="Enter Galaxy Instance URL"
+        @blur="handleCustomInputBlur"
+        @keyup.enter="applyCustomUrl"
+        class="w-full"
+      >
+        <template #trailing>
+          <UButton
+            icon="i-heroicons-check"
+            color="primary"
+            variant="ghost"
+            size="xs"
+            @click="applyCustomUrl"
+          />
+        </template>
+      </UInput>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.galaxy-instance-selector {
+  width: 100%;
+}
+</style>

--- a/website/components/GalaxyInstanceSelector.vue
+++ b/website/components/GalaxyInstanceSelector.vue
@@ -1,90 +1,137 @@
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue';
-import { useStorage } from '@vueuse/core';
+import { ref, computed, onMounted, watch } from "vue";
+import { useStorage } from "@vueuse/core";
 
-// Default instance list
+// Default instance list - never modified
 const defaultInstances = [
-  { value: "https://usegalaxy.org", label: "usegalaxy.org" },
-  { value: "https://usegalaxy.eu", label: "usegalaxy.eu" },
-  { value: "https://usegalaxy.org.au", label: "usegalaxy.org.au" },
-  { value: "https://test.galaxyproject.org", label: "test.galaxyproject.org" },
+    { value: "https://usegalaxy.org", label: "usegalaxy.org" },
+    { value: "https://usegalaxy.eu", label: "usegalaxy.eu" },
+    { value: "https://usegalaxy.org.au", label: "usegalaxy.org.au" },
+    { value: "https://test.galaxyproject.org", label: "test.galaxyproject.org" },
 ];
 
 const props = defineProps({
-  modelValue: {
-    type: String,
-    required: true
-  },
+    modelValue: {
+        type: String,
+        required: true,
+    },
 });
 
-const emit = defineEmits(['update:modelValue', 'change']);
+const emit = defineEmits(["update:modelValue", "change"]);
 
-// Store available instances in local storage, starting with defaults
-const availableInstances = useStorage('galaxy-available-instances', defaultInstances);
-const selectedInstance = ref(props.modelValue);
+// Persist custom instances to localStorage
+const customInstances = useStorage<Array<{ value: string; label: string }>>("galaxy-custom-instances", []);
+
+// Persist last selected instance URL
+const lastSelectedInstance = useStorage<string>("galaxy-selected-instance", defaultInstances[0].value);
+
+// Combine default and custom instances for display
+const allInstances = computed(() => {
+    // Start with all default instances
+    const combined = [...defaultInstances];
+
+    // Add custom instances that don't overlap with defaults
+    if (customInstances.value) {
+        customInstances.value.forEach((custom) => {
+            if (!combined.some((item) => item.value === custom.value)) {
+                combined.push(custom);
+            }
+        });
+    }
+
+    return combined;
+});
+
+// Initialize selected instance
+const selectedInstance = ref(props.modelValue || lastSelectedInstance.value);
+
+onMounted(() => {
+    // Check if the current model value exists in our instances
+    const instanceExists = allInstances.value.some((instance) => instance.value === props.modelValue);
+
+    if (props.modelValue && !instanceExists) {
+        // If model value is provided but not in our lists, try to add it as custom
+        try {
+            const url = new URL(props.modelValue);
+            onCreateInstance(props.modelValue);
+        } catch (e) {
+            // If not a valid URL, select the last known instance
+            selectedInstance.value = lastSelectedInstance.value;
+        }
+    } else if (!props.modelValue) {
+        // If no model value provided, use the last selected instance
+        selectedInstance.value = lastSelectedInstance.value;
+    }
+});
 
 // Watch for changes to modelValue from parent component
 watch(
-  () => props.modelValue,
-  (newVal) => {
-    if (newVal !== selectedInstance.value) {
-      selectedInstance.value = newVal;
-    }
-  }
+    () => props.modelValue,
+    (newVal) => {
+        if (newVal && newVal !== selectedInstance.value) {
+            selectedInstance.value = newVal;
+        }
+    },
 );
 
 // Watch for changes to the selected instance
 watch(selectedInstance, (newVal) => {
-  emit('update:modelValue', newVal);
-  emit('change', newVal);
+    if (newVal) {
+        // Update the last selected instance in storage
+        lastSelectedInstance.value = newVal;
+        // Emit the changes
+        emit("update:modelValue", newVal);
+        emit("change", newVal);
+    }
 });
 
 // Function to create a new instance
 function onCreateInstance(url: string) {
-  try {
-    // Basic validation
-    const parsedUrl = new URL(url);
-    
-    // Create a label from the URL
-    const label = parsedUrl.hostname;
-    
-    // Check if this URL already exists
-    if (!availableInstances.value.some(instance => instance.value === url)) {
-      // Add to available instances
-      availableInstances.value.push({ value: url, label });
+    try {
+        // Basic validation
+        const parsedUrl = new URL(url);
+
+        // Create a label from the URL
+        const label = parsedUrl.hostname;
+
+        const newInstance = { value: url, label };
+
+        // Only add to custom instances if it's not already there and not a default
+        const isDefault = defaultInstances.some((def) => def.value === url);
+        const isExistingCustom = customInstances.value.some((custom) => custom.value === url);
+
+        if (!isDefault && !isExistingCustom) {
+            customInstances.value.push(newInstance);
+        }
+
+        // Set as selected
+        selectedInstance.value = url;
+    } catch (e) {
+        console.error("Invalid URL provided:", e);
     }
-    
-    // Set as selected
-    selectedInstance.value = url;
-  } catch (e) {
-    console.error("Invalid URL provided:", e);
-    // You could add visual feedback here
-  }
 }
 </script>
 
 <template>
-  <div class="galaxy-instance-selector">
-    <div class="mb-2">
-      <span class="text-sm font-medium">Galaxy Instance</span>
+    <div class="galaxy-instance-selector">
+        <div class="mb-2">
+            <span class="text-sm font-medium">Run this workflow at a Galaxy Instance</span>
+        </div>
+
+        <USelectMenu
+            create-item
+            create-text="Use custom Galaxy instance:"
+            :items="allInstances"
+            placeholder="Select or enter a Galaxy instance URL"
+            by="value"
+            option-attribute="label"
+            class="w-full"
+            @create="onCreateInstance" />
     </div>
-    
-    <USelectMenu
-      v-model="selectedInstance"
-      create-item
-      create-text="Use custom Galaxy instance:"
-      :items="availableInstances"
-      placeholder="Select or enter a Galaxy instance URL"
-      by="value"
-      option-attribute="label"
-      class="w-full"
-      @create="onCreateInstance"
-    />
-  </div>
 </template>
 
 <style scoped>
 .galaxy-instance-selector {
-  width: 100%;
+    width: 100%;
 }
 </style>

--- a/website/components/GalaxyInstanceSelector.vue
+++ b/website/components/GalaxyInstanceSelector.vue
@@ -52,21 +52,11 @@ const selectedInstance = ref(props.modelValue || lastSelectedInstance.value);
 const internalQuery = ref("");
 
 onMounted(() => {
-    // Check if the current model value exists in our instances
-    const instanceExists = allInstances.value.some((instance) => instance === props.modelValue);
-
-    if (props.modelValue && !instanceExists) {
-        // If model value is provided but not in our lists, try to add it as custom
-        try {
-            const url = new URL(props.modelValue);
-            onCreateInstance(props.modelValue);
-        } catch (e) {
-            // If not a valid URL, select the last known instance
-            selectedInstance.value = lastSelectedInstance.value;
-        }
-    } else if (!props.modelValue) {
+    if (!props.modelValue) {
         // If no model value provided, use the last selected instance
         selectedInstance.value = lastSelectedInstance.value;
+        emit("update:modelValue", selectedInstance.value);
+        emit("change", selectedInstance.value);
     }
 });
 
@@ -95,7 +85,6 @@ watch(selectedInstance, (newVal, oldVal) => {
         }
         // Update the last selected instance in storage
         lastSelectedInstance.value = instanceUrl;
-
         // Emit the changes
         emit("update:modelValue", instanceUrl);
         emit("change", instanceUrl);

--- a/website/components/GalaxyInstanceSelector.vue
+++ b/website/components/GalaxyInstanceSelector.vue
@@ -55,6 +55,8 @@ onMounted(() => {
     if (!props.modelValue) {
         // If no model value provided, use the last selected instance
         selectedInstance.value = lastSelectedInstance.value;
+        // TODO -- the watch should do this but is not?  Is it because of the string handling?
+        // No harm in kicking it out here, though.
         emit("update:modelValue", selectedInstance.value);
         emit("change", selectedInstance.value);
     }
@@ -90,18 +92,6 @@ watch(selectedInstance, (newVal, oldVal) => {
         emit("change", instanceUrl);
     }
 });
-
-const filteredOptions = computed(() => {
-    if (!internalQuery.value) {
-        return allInstances.value;
-    }
-    const query = internalQuery.value.toLowerCase();
-    return allInstances.value.filter((instance) => instance.toLowerCase().includes(query));
-});
-
-const showCreateOption = computed(() => {
-    return internalQuery.value && !filteredOptions.value.some((item) => item === internalQuery.value);
-});
 </script>
 
 <template>
@@ -113,12 +103,11 @@ const showCreateOption = computed(() => {
         </div>
         <USelectMenu
             v-model="selectedInstance"
+            v-model:query="internalQuery"
             :options="allInstances"
             :searchable="true"
-            v-model:query="internalQuery"
             searchable-placeholder="Select or enter a custom Galaxy instance URL"
             show-create-option-when="always"
-            by="value"
             creatable>
             <template #option-create="{ option }">
                 <span>Create "{{ internalQuery }}"</span>

--- a/website/components/GalaxyInstanceSelector.vue
+++ b/website/components/GalaxyInstanceSelector.vue
@@ -118,10 +118,9 @@ const showCreateOption = computed(() => {
 <template>
     <div class="galaxy-instance-selector">
         <div class="my-2">
-            <span class="text-sm font-medium"
-                >Select or enter a Galaxy instance URL in the field below to launch this workflow on that
-                instance.</span
-            >
+            <p class="text-sm font-medium">
+                Select or enter a Galaxy instance URL in the field below to launch this workflow on that instance.
+            </p>
         </div>
         <USelectMenu
             v-model="selectedInstance"

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,6 +10,7 @@
         "@nuxt/icon": "^1.10.3",
         "@nuxt/ui": "^2.21.0",
         "@pinia/nuxt": "^0.10.1",
+        "@vueuse/core": "^13.0.0",
         "marked": "^15.0.7",
         "mermaid": "^11.4.1",
         "nuxt": "^3.15.4",
@@ -3669,6 +3670,27 @@
       "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
       "license": "MIT"
     },
+    "node_modules/@vueuse/core": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.0.0.tgz",
+      "integrity": "sha512-rkgb4a8/0b234lMGCT29WkCjPfsX0oxrIRR7FDndRoW3FsaC9NBzefXg/9TLhAgwM11f49XnutshM4LzJBrQ5g==",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "13.0.0",
+        "@vueuse/shared": "13.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/core/node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="
+    },
     "node_modules/@vueuse/integrations": {
       "version": "12.5.0",
       "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.5.0.tgz",
@@ -3794,6 +3816,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.0.0.tgz",
+      "integrity": "sha512-TRNksqmvtvqsuHf7bbgH9OSXEV2b6+M3BSN4LR5oxWKykOFT9gV78+C2/0++Pq9KCp9KQ1OQDPvGlWNQpOb2Mw==",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.0.0.tgz",
+      "integrity": "sha512-9MiHhAPw+sqCF/RLo8V6HsjRqEdNEWVpDLm2WBRW2G/kSQjb8X901sozXpSCaeLG0f7TEfMrT4XNaA5m1ez7Dg==",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
       }
     },
     "node_modules/abbrev": {

--- a/website/package.json
+++ b/website/package.json
@@ -14,6 +14,7 @@
     "@nuxt/icon": "^1.10.3",
     "@nuxt/ui": "^2.21.0",
     "@pinia/nuxt": "^0.10.1",
+    "@vueuse/core": "^13.0.0",
     "marked": "^15.0.7",
     "mermaid": "^11.4.1",
     "nuxt": "^3.15.4",

--- a/website/pages/workflow/[id].vue
+++ b/website/pages/workflow/[id].vue
@@ -5,7 +5,7 @@ import MarkdownRenderer from "~/components/MarkdownRenderer.vue";
 import Author from "~/components/Author.vue";
 import { useWorkflowStore } from "~/stores/workflows";
 import { formatDate } from "~/utils/";
-import GalaxyInstanceSelector from '~/components/GalaxyInstanceSelector.vue';
+import GalaxyInstanceSelector from "~/components/GalaxyInstanceSelector.vue";
 
 const route = useRoute();
 const workflowStore = useWorkflowStore();
@@ -134,10 +134,8 @@ onBeforeMount(async () => {
                         </ULink>
                     </li>
                 </ul>
+                <GalaxyInstanceSelector v-model="selectedInstance" />
                 <UButtonGroup class="mt-4" size="sm" orientation="vertical">
-                  <GalaxyInstanceSelector
-                    v-model="selectedInstance"
-                  />
                     <UButton
                         :to="launchUrl"
                         target="_blank"

--- a/website/pages/workflow/[id].vue
+++ b/website/pages/workflow/[id].vue
@@ -134,17 +134,20 @@ onBeforeMount(async () => {
                         </ULink>
                     </li>
                 </ul>
+                <h3 class="font-bold text-l mt-4">Running this workflow</h3>
                 <GalaxyInstanceSelector v-model="selectedInstance" />
-                <UButtonGroup class="mt-4" size="sm" orientation="vertical">
+                <p class="my-2 text-sm font-medium">
+                    You can choose to run the workflow with sample data prefilled, or with your own data.
+                </p>
+                <UButtonGroup class="mt-4" size="sm">
                     <UButton
                         :to="launchUrl"
                         target="_blank"
                         icon="i-heroicons-rocket-launch"
                         color="primary"
                         variant="solid"
-                        label="Launch at" />
+                        label="Run Workflow" />
                     <UButton
-                        class="mt-4"
                         @click="createLandingPage"
                         target="_blank"
                         icon="i-heroicons-rocket-launch"

--- a/website/pages/workflow/[id].vue
+++ b/website/pages/workflow/[id].vue
@@ -27,15 +27,6 @@ const links = [
     },
 ];
 
-// Instance Selector -- defined in the component now
-const instances = [
-    { value: "https://usegalaxy.org", label: "usegalaxy.org" },
-    { value: "https://usegalaxy.eu", label: "usegalaxy.eu" },
-    { value: "https://usegalaxy.org.au", label: "usegalaxy.org.au" },
-    { value: "https://test.galaxyproject.org", label: "test.galaxyproject.org" },
-    { value: "http://localhost:8081", label: "local dev instance" },
-];
-
 const selectedInstance = ref("");
 
 const launchUrl = computed(() => {
@@ -113,10 +104,6 @@ onBeforeMount(async () => {
     await workflowStore.setWorkflow();
     loading.value = false;
 });
-
-const onInstanceChange = (value: string) => {
-    selectedInstance.value = value
-};
 </script>
 
 <template>
@@ -150,9 +137,7 @@ const onInstanceChange = (value: string) => {
                 <UButtonGroup class="mt-4" size="sm" orientation="vertical">
                   <GalaxyInstanceSelector
                     v-model="selectedInstance"
-                    :instances="instances"
-                    @change="onInstanceChange"
-                    />
+                  />
                     <UButton
                         :to="launchUrl"
                         target="_blank"

--- a/website/pages/workflow/[id].vue
+++ b/website/pages/workflow/[id].vue
@@ -101,6 +101,7 @@ const selectedInstance = ref("");
 const instances = reactive([
     { value: "https://usegalaxy.org", label: "usegalaxy.org" },
     { value: "https://usegalaxy.eu", label: "usegalaxy.eu" },
+    { value: "https://usegalaxy.org.au", label: "usegalaxy.org.au" },
     { value: "https://test.galaxyproject.org", label: "test.galaxyproject.org" },
     { value: "http://localhost:8081", label: "local dev instance" },
 ]);

--- a/website/pages/workflow/[id].vue
+++ b/website/pages/workflow/[id].vue
@@ -5,12 +5,12 @@ import MarkdownRenderer from "~/components/MarkdownRenderer.vue";
 import Author from "~/components/Author.vue";
 import { useWorkflowStore } from "~/stores/workflows";
 import { formatDate } from "~/utils/";
+import GalaxyInstanceSelector from '~/components/GalaxyInstanceSelector.vue';
 
 const route = useRoute();
 const workflowStore = useWorkflowStore();
 const workflow = computed(() => workflowStore.workflow);
 
-// TODO: Add a component for authors.  For now, just have a computed that grabs names and joins them
 const authors = computed(() => {
     let authorLine = "";
     if (workflow.value?.authors) {
@@ -26,6 +26,17 @@ const links = [
         to: "/",
     },
 ];
+
+// Instance Selector -- defined in the component now
+const instances = [
+    { value: "https://usegalaxy.org", label: "usegalaxy.org" },
+    { value: "https://usegalaxy.eu", label: "usegalaxy.eu" },
+    { value: "https://usegalaxy.org.au", label: "usegalaxy.org.au" },
+    { value: "https://test.galaxyproject.org", label: "test.galaxyproject.org" },
+    { value: "http://localhost:8081", label: "local dev instance" },
+];
+
+const selectedInstance = ref("");
 
 const launchUrl = computed(() => {
     if (!workflow.value || !selectedInstance.value) return "";
@@ -96,32 +107,15 @@ const tabs = computed(() => [
     },
 ]);
 
-/* Instance Selector -- factor out to a component */
-const selectedInstance = ref("");
-const instances = reactive([
-    { value: "https://usegalaxy.org", label: "usegalaxy.org" },
-    { value: "https://usegalaxy.eu", label: "usegalaxy.eu" },
-    { value: "https://usegalaxy.org.au", label: "usegalaxy.org.au" },
-    { value: "https://test.galaxyproject.org", label: "test.galaxyproject.org" },
-    { value: "http://localhost:8081", label: "local dev instance" },
-]);
-
 const loading = ref(true);
 
 onBeforeMount(async () => {
-    // Shift to a store to handle this, as it breaks nuxt to use localStorage in setup but this is a quick hack
     await workflowStore.setWorkflow();
-    const savedInstance = localStorage.getItem("selectedInstance");
-    if (savedInstance) {
-        selectedInstance.value = savedInstance;
-    } else {
-        selectedInstance.value = instances[0].value;
-    }
     loading.value = false;
 });
 
 const onInstanceChange = (value: string) => {
-    localStorage.setItem("selectedInstance", value);
+    selectedInstance.value = value
 };
 </script>
 
@@ -154,11 +148,11 @@ const onInstanceChange = (value: string) => {
                     </li>
                 </ul>
                 <UButtonGroup class="mt-4" size="sm" orientation="vertical">
-                    <USelect
-                        v-model="selectedInstance"
-                        :options="instances"
-                        label="Select Galaxy Instance"
-                        @change="onInstanceChange" />
+                  <GalaxyInstanceSelector
+                    v-model="selectedInstance"
+                    :instances="instances"
+                    @change="onInstanceChange"
+                    />
                     <UButton
                         :to="launchUrl"
                         target="_blank"
@@ -178,7 +172,6 @@ const onInstanceChange = (value: string) => {
             </div>
         </template>
 
-        <!-- Right side workflow cards -->
         <template #content>
             <div v-if="workflow" class="mx-auto">
                 <div class="p-4 mb-6">
@@ -207,7 +200,6 @@ const onInstanceChange = (value: string) => {
                                 </div>
                             </div>
                             <div v-else-if="item.preview" class="mt-6">
-                                <!-- placeholder, we need to add the linkage to construct this, and we need to handle security?-->
                                 <iframe
                                     title="Galaxy Workflow Embed"
                                     style="width: 100%; height: 700px; border: none"


### PR DESCRIPTION
Presents the default list of instances but now also allows custom entry, which is persisted in localstorage.

Also adds the rest of usegalaxy.* servers - usegalaxy.fr, usegalaxy.org.au to the default instances list.


![image](https://github.com/user-attachments/assets/6aa9d723-8530-43f7-9c12-38199bac14b9)

![image](https://github.com/user-attachments/assets/99096695-b0a9-4516-8202-863ca496e22d)



FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
