### PR TITLE
Updating workflows/bacterial_genomics/bacterial_genome_annotation from 1.1.7 to 1.1.8

### DIFF
--- a/workflows/bacterial_genomics/bacterial_genome_annotation/CHANGELOG.md
+++ b/workflows/bacterial_genomics/bacterial_genome_annotation/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.8] - 2025-04-14
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta/1.9.4+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta/1.9.4+galaxy1`
+- `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0`
+
 ## [1.1.7] - 2024-10-21
 
 ### Automatic update

--- a/workflows/bacterial_genomics/bacterial_genome_annotation/CHANGELOG.md
+++ b/workflows/bacterial_genomics/bacterial_genome_annotation/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
-## [1.1.8] - 2025-04-14
+## [1.1.8] - 2025-04-15
 
 ### Automatic update
 - `toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta/1.9.4+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta/1.9.4+galaxy1`
 - `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0`
 - `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0`
+
+### Manual update
+- Changes output name/tag for Tooldistillator
+- Fixes syntax and parameter errors
 
 ## [1.1.7] - 2024-10-21
 

--- a/workflows/bacterial_genomics/bacterial_genome_annotation/README.md
+++ b/workflows/bacterial_genomics/bacterial_genome_annotation/README.md
@@ -1,4 +1,4 @@
-# Bacterial genome annotation workflow (v1.0)
+# Bacterial genome annotation workflow (v1.1.8)
 
 This workflow uses assembled bacterial genome fasta files (but can be any fasta file) and executes the following steps:
 1. Genomic annotation

--- a/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation-tests.yml
+++ b/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation-tests.yml
@@ -51,7 +51,7 @@
       asserts:
         has_n_columns:
           n: 8
-    tooldistillator_summarize:
+    tooldistillator_summarize_annotation:
       asserts:
         - that: "has_text"
           text: "CDS12738(DOp1)"

--- a/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation.ga
+++ b/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation.ga
@@ -1183,7 +1183,7 @@
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0",
             "tool_shed_repository": {
                 "changeset_revision": "07d093aaf3b4",
-                "name": "tooldistillator_summarize_annotation",
+                "name": "tooldistillator_summarize",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },

--- a/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation.ga
+++ b/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation.ga
@@ -1,6 +1,7 @@
 {
     "a_galaxy_workflow": "true",
     "annotation": "Annotation of an assembled bacterial genomes to detect genes, potential plasmids, integrons and Insertion sequence (IS) elements.",
+    "comments": [],
     "creator": [
         {
             "class": "Person",
@@ -27,7 +28,6 @@
     ],
     "format-version": "0.1",
     "license": "GPL-3.0-or-later",
-    "release": "1.1.7",
     "name": "bacterial_genome_annotation",
     "steps": {
         "0": {
@@ -77,7 +77,7 @@
                 "top": 734.3939210886799
             },
             "tool_id": null,
-            "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
+            "tool_state": "{\"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "66c11ad1-7cd5-40b7-b97f-8d15cc097dd9",
@@ -110,7 +110,7 @@
                 "top": 859.5166625976562
             },
             "tool_id": null,
-            "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
+            "tool_state": "{\"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "4de1f52c-078c-4112-86ad-e4e8f3b62e3a",
@@ -143,7 +143,7 @@
                 "top": 995.2631409484753
             },
             "tool_id": null,
-            "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
+            "tool_state": "{\"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "aec02a2c-6bf7-476d-91aa-3f1ce49083c7",
@@ -632,7 +632,7 @@
         },
         "7": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta/1.9.4+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta/1.9.4+galaxy1",
             "errors": null,
             "id": 7,
             "input_connections": {
@@ -905,15 +905,15 @@
                     "output_name": "summary_txt"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta/1.9.4+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta/1.9.4+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "d77802fe76f7",
+                "changeset_revision": "1942e86e2ee1",
                 "name": "bakta",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"annotation\": {\"complete\": false, \"prodigal\": {\"__class__\": \"RuntimeValue\"}, \"translation_table\": \"11\", \"keep_contig_headers\": false, \"replicons\": {\"__class__\": \"RuntimeValue\"}, \"compliant\": false, \"proteins\": {\"__class__\": \"RuntimeValue\"}, \"meta\": false, \"regions\": {\"__class__\": \"RuntimeValue\"}}, \"input_option\": {\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"min_contig_length\": null, \"bakta_db_select\": {\"__class__\": \"ConnectedValue\"}, \"amrfinder_db_select\": {\"__class__\": \"ConnectedValue\"}}, \"organism\": {\"genus\": null, \"species\": null, \"strain\": null, \"plasmid\": null}, \"output_files\": {\"output_selection\": [\"file_tsv\", \"file_gff3\", \"file_ffn\", \"file_plot\", \"file_gbff\", \"file_embl\", \"file_fna\", \"file_faa\", \"hypo_tsv\", \"hypo_fa\", \"file_json\", \"sum_txt\"]}, \"workflow\": {\"skip_analysis\": null}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.9.4+galaxy0",
+            "tool_version": "1.9.4+galaxy1",
             "type": "tool",
             "uuid": "0a32dcad-f456-460e-9e6f-9e306a8fd515",
             "when": null,
@@ -982,7 +982,7 @@
         },
         "8": {
             "annotation": "ToolDistillator extracts results from tools and creates a JSON file for each tool",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0",
             "errors": null,
             "id": 8,
             "input_connections": {
@@ -1120,15 +1120,15 @@
                     "output_name": "output_json"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "ea93df4b3df2",
+                "changeset_revision": "66617be450bd",
                 "name": "tooldistillator",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"log\": false, \"tool_section\": {\"tools\": [{\"__index__\": 0, \"select_tool\": {\"tool_list\": \"plasmidfinder\", \"__current_case__\": 14, \"input\": {\"__class__\": \"ConnectedValue\"}, \"plasmid_result_tabular_path\": {\"__class__\": \"ConnectedValue\"}, \"genome_hit_path\": {\"__class__\": \"ConnectedValue\"}, \"plasmid_hit_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"select_tool\": {\"tool_list\": \"isescan\", \"__current_case__\": 11, \"input\": {\"__class__\": \"ConnectedValue\"}, \"summary_path\": {\"__class__\": \"ConnectedValue\"}, \"annotation_path\": {\"__class__\": \"ConnectedValue\"}, \"orf_fna_path\": {\"__class__\": \"ConnectedValue\"}, \"orf_faa_path\": {\"__class__\": \"ConnectedValue\"}, \"is_fna_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 2, \"select_tool\": {\"tool_list\": \"integronfinder2\", \"__current_case__\": 10, \"input\": {\"__class__\": \"ConnectedValue\"}, \"summary_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 3, \"select_tool\": {\"tool_list\": \"bakta\", \"__current_case__\": 2, \"input\": {\"__class__\": \"ConnectedValue\"}, \"annotation_tabular_path\": {\"__class__\": \"ConnectedValue\"}, \"annotation_genbank_path\": {\"__class__\": \"ConnectedValue\"}, \"annotation_embl_path\": {\"__class__\": \"ConnectedValue\"}, \"contig_sequences_path\": {\"__class__\": \"ConnectedValue\"}, \"hypothetical_protein_path\": {\"__class__\": \"ConnectedValue\"}, \"hypothetical_tabular_path\": {\"__class__\": \"ConnectedValue\"}, \"plot_file_path\": {\"__class__\": \"ConnectedValue\"}, \"summary_result_path\": {\"__class__\": \"ConnectedValue\"}, \"nucleotide_annotation_path\": {\"__class__\": \"ConnectedValue\"}, \"amino_acid_annotation_path\": {\"__class__\": \"ConnectedValue\"}, \"gff_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.9.1+galaxy1",
+            "tool_state": "{\"log\": false, \"tool_section\": {\"tools\": [{\"__index__\": 0, \"select_tool\": {\"tool_list\": \"plasmidfinder\", \"__current_case__\": 15, \"input\": {\"__class__\": \"ConnectedValue\"}, \"plasmid_result_tabular_path\": {\"__class__\": \"ConnectedValue\"}, \"genome_hit_path\": {\"__class__\": \"ConnectedValue\"}, \"plasmid_hit_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"select_tool\": {\"tool_list\": \"isescan\", \"__current_case__\": 12, \"input\": {\"__class__\": \"ConnectedValue\"}, \"summary_path\": {\"__class__\": \"ConnectedValue\"}, \"annotation_path\": {\"__class__\": \"ConnectedValue\"}, \"orf_fna_path\": {\"__class__\": \"ConnectedValue\"}, \"orf_faa_path\": {\"__class__\": \"ConnectedValue\"}, \"is_fna_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 2, \"select_tool\": {\"tool_list\": \"integronfinder2\", \"__current_case__\": 11, \"input\": {\"__class__\": \"ConnectedValue\"}, \"summary_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 3, \"select_tool\": {\"tool_list\": \"bakta\", \"__current_case__\": 2, \"input\": {\"__class__\": \"ConnectedValue\"}, \"annotation_tabular_path\": {\"__class__\": \"ConnectedValue\"}, \"annotation_genbank_path\": {\"__class__\": \"ConnectedValue\"}, \"annotation_embl_path\": {\"__class__\": \"ConnectedValue\"}, \"contig_sequences_path\": {\"__class__\": \"ConnectedValue\"}, \"hypothetical_protein_path\": {\"__class__\": \"ConnectedValue\"}, \"hypothetical_tabular_path\": {\"__class__\": \"ConnectedValue\"}, \"plot_file_path\": {\"__class__\": \"ConnectedValue\"}, \"summary_result_path\": {\"__class__\": \"ConnectedValue\"}, \"nucleotide_annotation_path\": {\"__class__\": \"ConnectedValue\"}, \"amino_acid_annotation_path\": {\"__class__\": \"ConnectedValue\"}, \"gff_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.9.2+galaxy0",
             "type": "tool",
             "uuid": "678bdbfe-7a3a-4a91-8ea7-1cb17f53daa6",
             "when": null,
@@ -1142,7 +1142,7 @@
         },
         "9": {
             "annotation": "ToolDistillator summarize groups all JSON file into a unique JSON file",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0",
             "errors": null,
             "id": 9,
             "input_connections": {
@@ -1180,15 +1180,15 @@
                     "output_name": "summary_json"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "24eec94e6dfc",
+                "changeset_revision": "07d093aaf3b4",
                 "name": "tooldistillator_summarize",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"summarize_data\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.9.1+galaxy1",
+            "tool_version": "0.9.2+galaxy0",
             "type": "tool",
             "uuid": "3427b1f1-79ce-4ade-a350-baf15ac250c2",
             "when": null,
@@ -1209,6 +1209,7 @@
         "Annotation",
         "genome-annotation"
     ],
-    "uuid": "d55a9e46-a205-4143-b92f-3783499063ed",
-    "version": 1
+    "uuid": "4ac5a4ec-8a7c-4b88-af7c-f5f9d9ba0d4e",
+    "version": 1,
+    "release": "1.1.8"
 }

--- a/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation.ga
+++ b/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation.ga
@@ -1107,14 +1107,14 @@
             "post_job_actions": {
                 "RenameDatasetActionoutput_json": {
                     "action_arguments": {
-                        "newname": "tooldistillator_results"
+                        "newname": "tooldistillator_results_annotation"
                     },
                     "action_type": "RenameDatasetAction",
                     "output_name": "output_json"
                 },
                 "TagDatasetActionoutput_json": {
                     "action_arguments": {
-                        "tags": "tooldistillator_results"
+                        "tags": "tooldistillator_results_annotation"
                     },
                     "action_type": "TagDatasetAction",
                     "output_name": "output_json"
@@ -1127,14 +1127,14 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"log\": false, \"tool_section\": {\"tools\": [{\"__index__\": 0, \"select_tool\": {\"tool_list\": \"plasmidfinder\", \"__current_case__\": 15, \"input\": {\"__class__\": \"ConnectedValue\"}, \"plasmid_result_tabular_path\": {\"__class__\": \"ConnectedValue\"}, \"genome_hit_path\": {\"__class__\": \"ConnectedValue\"}, \"plasmid_hit_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"select_tool\": {\"tool_list\": \"isescan\", \"__current_case__\": 12, \"input\": {\"__class__\": \"ConnectedValue\"}, \"summary_path\": {\"__class__\": \"ConnectedValue\"}, \"annotation_path\": {\"__class__\": \"ConnectedValue\"}, \"orf_fna_path\": {\"__class__\": \"ConnectedValue\"}, \"orf_faa_path\": {\"__class__\": \"ConnectedValue\"}, \"is_fna_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 2, \"select_tool\": {\"tool_list\": \"integronfinder2\", \"__current_case__\": 11, \"input\": {\"__class__\": \"ConnectedValue\"}, \"summary_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 3, \"select_tool\": {\"tool_list\": \"bakta\", \"__current_case__\": 2, \"input\": {\"__class__\": \"ConnectedValue\"}, \"annotation_tabular_path\": {\"__class__\": \"ConnectedValue\"}, \"annotation_genbank_path\": {\"__class__\": \"ConnectedValue\"}, \"annotation_embl_path\": {\"__class__\": \"ConnectedValue\"}, \"contig_sequences_path\": {\"__class__\": \"ConnectedValue\"}, \"hypothetical_protein_path\": {\"__class__\": \"ConnectedValue\"}, \"hypothetical_tabular_path\": {\"__class__\": \"ConnectedValue\"}, \"plot_file_path\": {\"__class__\": \"ConnectedValue\"}, \"summary_result_path\": {\"__class__\": \"ConnectedValue\"}, \"nucleotide_annotation_path\": {\"__class__\": \"ConnectedValue\"}, \"amino_acid_annotation_path\": {\"__class__\": \"ConnectedValue\"}, \"gff_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"log\": false, \"tool_section\": {\"tools\": [{\"__index__\": 0, \"select_tool\": {\"tool_list\": \"plasmidfinder\", \"__current_case__\": 15, \"input\": {\"__class__\": \"RuntimeValue\"}, \"plasmid_result_tabular_path\": {\"__class__\": \"RuntimeValue\"}, \"genome_hit_path\": {\"__class__\": \"RuntimeValue\"}, \"plasmid_hit_path\": {\"__class__\": \"RuntimeValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"select_tool\": {\"tool_list\": \"isescan\", \"__current_case__\": 12, \"input\": {\"__class__\": \"RuntimeValue\"}, \"summary_path\": {\"__class__\": \"RuntimeValue\"}, \"annotation_path\": {\"__class__\": \"RuntimeValue\"}, \"orf_fna_path\": {\"__class__\": \"RuntimeValue\"}, \"orf_faa_path\": {\"__class__\": \"RuntimeValue\"}, \"is_fna_path\": {\"__class__\": \"RuntimeValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": null}}, {\"__index__\": 2, \"select_tool\": {\"tool_list\": \"integronfinder2\", \"__current_case__\": 11, \"input\": {\"__class__\": \"RuntimeValue\"}, \"summary_file_path\": {\"__class__\": \"RuntimeValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": null}}, {\"__index__\": 3, \"select_tool\": {\"tool_list\": \"bakta\", \"__current_case__\": 2, \"input\": {\"__class__\": \"RuntimeValue\"}, \"annotation_tabular_path\": {\"__class__\": \"RuntimeValue\"}, \"annotation_genbank_path\": {\"__class__\": \"RuntimeValue\"}, \"annotation_embl_path\": {\"__class__\": \"RuntimeValue\"}, \"contig_sequences_path\": {\"__class__\": \"RuntimeValue\"}, \"hypothetical_protein_path\": {\"__class__\": \"RuntimeValue\"}, \"hypothetical_tabular_path\": {\"__class__\": \"RuntimeValue\"}, \"plot_file_path\": {\"__class__\": \"RuntimeValue\"}, \"summary_result_path\": {\"__class__\": \"RuntimeValue\"}, \"nucleotide_annotation_path\": {\"__class__\": \"RuntimeValue\"}, \"amino_acid_annotation_path\": {\"__class__\": \"RuntimeValue\"}, \"gff_file_path\": {\"__class__\": \"RuntimeValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}]}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.9.2+galaxy0",
             "type": "tool",
             "uuid": "678bdbfe-7a3a-4a91-8ea7-1cb17f53daa6",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "tooldistillator_results",
+                    "label": "tooldistillator_results_annotation",
                     "output_name": "output_json",
                     "uuid": "a8db4b4d-8573-45bf-990c-304868ad5150"
                 }
@@ -1167,14 +1167,14 @@
             "post_job_actions": {
                 "RenameDatasetActionsummary_json": {
                     "action_arguments": {
-                        "newname": "tooldistillator_summarize"
+                        "newname": "tooldistillator_summarize_annotation"
                     },
                     "action_type": "RenameDatasetAction",
                     "output_name": "summary_json"
                 },
                 "TagDatasetActionsummary_json": {
                     "action_arguments": {
-                        "tags": "tooldistillator_summarize"
+                        "tags": "tooldistillator_summarize_annotation"
                     },
                     "action_type": "TagDatasetAction",
                     "output_name": "summary_json"
@@ -1183,7 +1183,7 @@
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0",
             "tool_shed_repository": {
                 "changeset_revision": "07d093aaf3b4",
-                "name": "tooldistillator_summarize",
+                "name": "tooldistillator_summarize_annotation",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
@@ -1194,7 +1194,7 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "tooldistillator_summarize",
+                    "label": "tooldistillator_summarize_annotation",
                     "output_name": "summary_json",
                     "uuid": "96d63721-4cb5-4879-8984-4eeba8dec36b"
                 }


### PR DESCRIPTION
Hello, 

This code (close #795 ):
- Changes Bakta version: `toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta/1.9.4+galaxy0` to `toolshed.g2.bx.psu.edu/repos/iuc/bakta/bakta/1.9.4+galaxy1`
- Changes the ToolDistillator wrapper version: 
    - `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy1`  to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0`
    - `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy1` to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0`
- Changes the output name/tag of Tooldistillator to `tooldistillator_[results|summarize]_annotation`
- Fixes syntax and parameter errors

This workflow uses databases available on http://datacache.galaxyproject.org/.

Thanks :smiley: 