### PR TITLE
Updating workflows/genome-assembly/quality-and-contamination-control from 1.1.6 to 1.1.7

### DIFF
--- a/workflows/genome-assembly/quality-and-contamination-control/CHANGELOG.md
+++ b/workflows/genome-assembly/quality-and-contamination-control/CHANGELOG.md
@@ -9,6 +9,11 @@
 - `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0`
 - `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0`
 
+### Manual update
+- Changes output name/tag for Tooldistillator
+- Fixes syntax and parameter errors
+- With Fastp 0.24.0 we can now only select the input Paired Collection: so the Zip and Unzip collection tools have been added to the workflow
+
 ## [1.1.6] - 2024-11-18
 
 ### Automatic update

--- a/workflows/genome-assembly/quality-and-contamination-control/CHANGELOG.md
+++ b/workflows/genome-assembly/quality-and-contamination-control/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.1.7] - 2025-04-14
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy3` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4`
+- `toolshed.g2.bx.psu.edu/repos/iuc/bracken/est_abundance/3.0+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/bracken/est_abundance/3.1+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/recentrifuge/recentrifuge/1.15.0+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/recentrifuge/recentrifuge/1.16.0+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0`
+
 ## [1.1.6] - 2024-11-18
 
 ### Automatic update

--- a/workflows/genome-assembly/quality-and-contamination-control/README.md
+++ b/workflows/genome-assembly/quality-and-contamination-control/README.md
@@ -1,4 +1,4 @@
-# Quality and Contamination control workflow for paired end data (v1.0)
+# Quality and Contamination control workflow for paired end data (v1.1.7)
 
 This workflow uses paired-end illumina fastq(.gz) files and executes the following steps:
 1. Quality control and trimming

--- a/workflows/genome-assembly/quality-and-contamination-control/quality_and_contamination_control-tests.yml
+++ b/workflows/genome-assembly/quality-and-contamination-control/quality_and_contamination_control-tests.yml
@@ -53,7 +53,7 @@
           text: "input_dir/kraken_report_reads"
         has_n_columns:
           n: 2
-    tooldistillator_summarize:
+    tooldistillator_summarize_control:
       asserts:
         - that: has_text
           text: "fastp_report"

--- a/workflows/genome-assembly/quality-and-contamination-control/quality_and_contamination_control.ga
+++ b/workflows/genome-assembly/quality-and-contamination-control/quality_and_contamination_control.ga
@@ -46,7 +46,7 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 21.02195459971947,
+                "left": 0,
                 "top": 0
             },
             "tool_id": null,
@@ -73,8 +73,8 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 17.95353354143969,
-                "top": 108.04692569668924
+                "left": 0.60009765625,
+                "top": 143.79998779296875
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"format\": [\"fastq\", \"fastq.gz\", \"fastqsanger\", \"fastqsanger.gz\"], \"tag\": \"\"}",
@@ -100,8 +100,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 0,
-                "top": 307.433349609375
+                "left": 345.65008544921875,
+                "top": 464.183349609375
             },
             "tool_id": null,
             "tool_state": "{\"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
@@ -109,13 +109,7 @@
             "type": "parameter_input",
             "uuid": "1a56b57e-8893-4cbc-a984-329e0b815cbd",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "62ded62a-d0c4-49ba-b3ef-c97ff39c6c5e"
-                }
-            ]
+            "workflow_outputs": []
         },
         "3": {
             "annotation": "Select the ncbi taxonomy database for Recentrifuge.",
@@ -133,8 +127,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 5.9666748046875,
-                "top": 454.91066885428484
+                "left": 351.61676025390625,
+                "top": 611.6606688542848
             },
             "tool_id": null,
             "tool_state": "{\"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
@@ -142,22 +136,67 @@
             "type": "parameter_input",
             "uuid": "daac0634-bcf4-4fdd-bcd2-67247f5afdd0",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "9b99164e-0a87-4bba-8838-ec4f428cf4d5"
-                }
-            ]
+            "workflow_outputs": []
         },
         "4": {
-            "annotation": "fastp_triming, quality analaysis and read cleaning",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4",
+            "annotation": "",
+            "content_id": "__ZIP_COLLECTION__",
             "errors": null,
             "id": 4,
             "input_connections": {
-                "single_paired|in1": {
+                "input_forward": {
                     "id": 0,
+                    "output_name": "output"
+                },
+                "input_reverse": {
+                    "id": 1,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Zip collections",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 245.7000732421875,
+                "top": 55.78334045410156
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "paired_coll"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__ZIP_COLLECTION__",
+            "tool_state": "{\"input_forward\": {\"__class__\": \"ConnectedValue\"}, \"input_reverse\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "757d6fe1-a4fd-40b6-8009-c4f80e9ef496",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "paired_coll",
+                    "output_name": "output",
+                    "uuid": "422f0a96-5a57-47c3-9a09-1f48dd7b57d4"
+                }
+            ]
+        },
+        "5": {
+            "annotation": "fastp_triming, quality analaysis and read cleaning",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4",
+            "errors": null,
+            "id": 5,
+            "input_connections": {
+                "single_paired|paired_input": {
+                    "id": 4,
                     "output_name": "output"
                 }
             },
@@ -171,7 +210,7 @@
             "name": "fastp",
             "outputs": [
                 {
-                    "name": "out1",
+                    "name": "output_paired_coll",
                     "type": "input"
                 },
                 {
@@ -184,8 +223,8 @@
                 }
             ],
             "position": {
-                "left": 256.3279681321078,
-                "top": 11.29864083194758
+                "left": 462.6500244140625,
+                "top": 162.54998779296875
             },
             "post_job_actions": {
                 "ChangeDatatypeActionout1": {
@@ -216,6 +255,13 @@
                     "action_type": "RenameDatasetAction",
                     "output_name": "out2"
                 },
+                "RenameDatasetActionoutput_paired_coll": {
+                    "action_arguments": {
+                        "newname": "fastp_trim_coll"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output_paired_coll"
+                },
                 "RenameDatasetActionreport_html": {
                     "action_arguments": {
                         "newname": "fastp_report_html"
@@ -244,6 +290,13 @@
                     "action_type": "TagDatasetAction",
                     "output_name": "out2"
                 },
+                "TagDatasetActionoutput_paired_coll": {
+                    "action_arguments": {
+                        "tags": "fastp"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "output_paired_coll"
+                },
                 "TagDatasetActionreport_html": {
                     "action_arguments": {
                         "tags": "fastp,html"
@@ -266,26 +319,21 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": null, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": null, \"umi_len\": null, \"umi_prefix\": null}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": false}}, \"single_paired\": {\"single_paired_selector\": \"single\", \"__current_case__\": 0, \"in1\": {\"__class__\": \"RuntimeValue\"}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": null}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": null, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": null, \"umi_len\": null, \"umi_prefix\": null}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": false}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 1, \"paired_input\": {\"__class__\": \"ConnectedValue\"}, \"merge_reads\": {\"merge\": \"\", \"__current_case__\": 1}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": null, \"adapter_sequence2\": null, \"detect_adapter_for_pe\": false}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.24.0+galaxy4",
             "type": "tool",
             "uuid": "7f405009-2491-4633-b4e1-ca0fdbd8360d",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "fastp_trimmed_R1",
-                    "output_name": "out1",
-                    "uuid": "d596e01c-9180-4482-9326-cc8289427fa1"
-                },
-                {
-                    "label": "fastp_trimmed_R2",
-                    "output_name": "out2",
-                    "uuid": "44c14c4e-40af-4045-856c-f2429af36b98"
-                },
-                {
                     "label": "fastp_report_html",
                     "output_name": "report_html",
                     "uuid": "f6b7db2c-fdd8-4d7c-81c0-6d4a9dd76ff7"
+                },
+                {
+                    "label": "fastp_trim_coll",
+                    "output_name": "output_paired_coll",
+                    "uuid": "c6dc7069-cf54-4cf3-976b-e2241d353ee7"
                 },
                 {
                     "label": "fastp_report_json",
@@ -294,19 +342,114 @@
                 }
             ]
         },
-        "5": {
+        "6": {
+            "annotation": "",
+            "content_id": "__UNZIP_COLLECTION__",
+            "errors": null,
+            "id": 6,
+            "input_connections": {
+                "input": {
+                    "id": 5,
+                    "output_name": "output_paired_coll"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Unzip collection",
+            "outputs": [
+                {
+                    "name": "forward",
+                    "type": "input"
+                },
+                {
+                    "name": "reverse",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 686.5332641601562,
+                "top": 105.69998168945312
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionforward": {
+                    "action_arguments": {
+                        "newtype": "fastqsanger.gz"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "forward"
+                },
+                "ChangeDatatypeActionreverse": {
+                    "action_arguments": {
+                        "newtype": "fastqsanger.gz"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "reverse"
+                },
+                "RenameDatasetActionforward": {
+                    "action_arguments": {
+                        "newname": "fastp_trimmed_R1"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "forward"
+                },
+                "RenameDatasetActionreverse": {
+                    "action_arguments": {
+                        "newname": "fastp_trimmed_R2"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "reverse"
+                },
+                "TagDatasetActionforward": {
+                    "action_arguments": {
+                        "tags": "R1"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "forward"
+                },
+                "TagDatasetActionreverse": {
+                    "action_arguments": {
+                        "tags": "R2"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "reverse"
+                }
+            },
+            "tool_id": "__UNZIP_COLLECTION__",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "8ca0e1a9-a5be-4060-b31a-075494aa5970",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "fastp_trimmed_R2",
+                    "output_name": "reverse",
+                    "uuid": "aa4f6317-6827-4a51-88a5-a2eb5e03745a"
+                },
+                {
+                    "label": "fastp_trimmed_R1",
+                    "output_name": "forward",
+                    "uuid": "40638bdf-08c5-4a57-9288-9803dcbee719"
+                }
+            ]
+        },
+        "7": {
             "annotation": "kraken_taxonomy_assignation",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/kraken2/kraken2/2.1.3+galaxy1",
             "errors": null,
-            "id": 5,
+            "id": 7,
             "input_connections": {
                 "kraken2_database": {
                     "id": 2,
                     "output_name": "output"
                 },
                 "single_paired|forward_input": {
-                    "id": 4,
-                    "output_name": "out1"
+                    "id": 6,
+                    "output_name": "forward"
+                },
+                "single_paired|reverse_input": {
+                    "id": 6,
+                    "output_name": "reverse"
                 }
             },
             "inputs": [
@@ -332,8 +475,8 @@
                 }
             ],
             "position": {
-                "left": 563.3447180137721,
-                "top": 148.60919325423987
+                "left": 908.9948034629908,
+                "top": 305.35919325423987
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -379,25 +522,25 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "kraken_report_tabular",
-                    "output_name": "report_output",
-                    "uuid": "68f9f0c0-375c-43ba-8687-9e2a1e602e8e"
-                },
-                {
                     "label": "kraken_report_reads",
                     "output_name": "output",
                     "uuid": "267ff8a0-b6bc-4fcf-97b9-bbf5a3d0c05f"
+                },
+                {
+                    "label": "kraken_report_tabular",
+                    "output_name": "report_output",
+                    "uuid": "68f9f0c0-375c-43ba-8687-9e2a1e602e8e"
                 }
             ]
         },
-        "6": {
+        "8": {
             "annotation": "bracken_abundance_estimation",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bracken/est_abundance/3.1+galaxy0",
             "errors": null,
-            "id": 6,
+            "id": 8,
             "input_connections": {
                 "input": {
-                    "id": 5,
+                    "id": 7,
                     "output_name": "report_output"
                 },
                 "kmer_distr": {
@@ -419,8 +562,8 @@
                 }
             ],
             "position": {
-                "left": 810.7535213344084,
-                "top": 77.49065954589844
+                "left": 1156.4036067836273,
+                "top": 234.24065954589844
             },
             "post_job_actions": {
                 "RenameDatasetActionkraken_report": {
@@ -477,18 +620,18 @@
                 }
             ]
         },
-        "7": {
+        "9": {
             "annotation": "recentrifuge_taxonomy_visualization",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/recentrifuge/recentrifuge/1.16.0+galaxy0",
             "errors": null,
-            "id": 7,
+            "id": 9,
             "input_connections": {
                 "database|database_name": {
                     "id": 3,
                     "output_name": "output"
                 },
                 "input_file": {
-                    "id": 5,
+                    "id": 7,
                     "output_name": "output"
                 }
             },
@@ -519,8 +662,8 @@
                 }
             ],
             "position": {
-                "left": 809.9535335414397,
-                "top": 405.274
+                "left": 1155.6036189906586,
+                "top": 562.024
             },
             "post_job_actions": {
                 "RenameDatasetActiondata_tsv": {
@@ -594,6 +737,16 @@
             "when": null,
             "workflow_outputs": [
                 {
+                    "label": "recentrifuge_logfile",
+                    "output_name": "logfile",
+                    "uuid": "f09996c8-a1be-484c-9b0d-3d96a68ae8c7"
+                },
+                {
+                    "label": "recentrifuge_data_tabular",
+                    "output_name": "data_tsv",
+                    "uuid": "2c9ca7c0-6fd8-4324-8684-94e4d1fa24ba"
+                },
+                {
                     "label": "recentrifuge_report_html",
                     "output_name": "html_report",
                     "uuid": "1cb280ed-a5dc-4d26-8ce4-833b3c3ffe47"
@@ -602,39 +755,33 @@
                     "label": "recentrifuge_stats_tabular",
                     "output_name": "stat_tsv",
                     "uuid": "62543f1b-765b-4022-bf57-ce2a7f6d3845"
-                },
-                {
-                    "label": "recentrifuge_data_tabular",
-                    "output_name": "data_tsv",
-                    "uuid": "2c9ca7c0-6fd8-4324-8684-94e4d1fa24ba"
-                },
-                {
-                    "label": "recentrifuge_logfile",
-                    "output_name": "logfile",
-                    "uuid": "f09996c8-a1be-484c-9b0d-3d96a68ae8c7"
                 }
             ]
         },
-        "8": {
+        "10": {
             "annotation": "ToolDistillator extracts results from tools and creates a JSON file for each tool",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0",
             "errors": null,
-            "id": 8,
+            "id": 10,
             "input_connections": {
                 "tool_section|tools_0|select_tool|html_report_path": {
-                    "id": 4,
+                    "id": 5,
                     "output_name": "report_html"
                 },
                 "tool_section|tools_0|select_tool|input": {
-                    "id": 4,
+                    "id": 5,
                     "output_name": "report_json"
                 },
                 "tool_section|tools_0|select_tool|trimmed_forward_R1_path": {
-                    "id": 4,
-                    "output_name": "out1"
+                    "id": 6,
+                    "output_name": "forward"
+                },
+                "tool_section|tools_0|select_tool|trimmed_reverse_R2_path": {
+                    "id": 6,
+                    "output_name": "reverse"
                 },
                 "tool_section|tools_1|select_tool|input": {
-                    "id": 5,
+                    "id": 7,
                     "output_name": "report_output"
                 },
                 "tool_section|tools_1|select_tool|reference_database_version": {
@@ -642,15 +789,15 @@
                     "output_name": "output"
                 },
                 "tool_section|tools_1|select_tool|seq_classification_file_path": {
-                    "id": 5,
+                    "id": 7,
                     "output_name": "output"
                 },
                 "tool_section|tools_2|select_tool|input": {
-                    "id": 6,
+                    "id": 8,
                     "output_name": "report"
                 },
                 "tool_section|tools_2|select_tool|kraken_report_path": {
-                    "id": 6,
+                    "id": 8,
                     "output_name": "kraken_report"
                 },
                 "tool_section|tools_2|select_tool|reference_database_version": {
@@ -658,15 +805,15 @@
                     "output_name": "output"
                 },
                 "tool_section|tools_3|select_tool|input": {
-                    "id": 7,
+                    "id": 9,
                     "output_name": "data_tsv"
                 },
                 "tool_section|tools_3|select_tool|rcf_html_path": {
-                    "id": 7,
+                    "id": 9,
                     "output_name": "html_report"
                 },
                 "tool_section|tools_3|select_tool|rcf_stat_path": {
-                    "id": 7,
+                    "id": 9,
                     "output_name": "stat_tsv"
                 },
                 "tool_section|tools_3|select_tool|reference_database_version": {
@@ -684,20 +831,20 @@
                 }
             ],
             "position": {
-                "left": 1208.036907564877,
-                "top": 47.093340454101565
+                "left": 1553.6869930140958,
+                "top": 203.84334045410156
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput_json": {
                     "action_arguments": {
-                        "newname": "tooldistillator_results"
+                        "newname": "tooldistillator_results_control"
                     },
                     "action_type": "RenameDatasetAction",
                     "output_name": "output_json"
                 },
                 "TagDatasetActionoutput_json": {
                     "action_arguments": {
-                        "tags": "tooldistillator_results"
+                        "tags": "tooldistillator_results_control"
                     },
                     "action_type": "TagDatasetAction",
                     "output_name": "output_json"
@@ -710,27 +857,27 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"log\": false, \"tool_section\": {\"tools\": [{\"__index__\": 0, \"select_tool\": {\"tool_list\": \"fastp\", \"__current_case__\": 7, \"input\": {\"__class__\": \"ConnectedValue\"}, \"trimmed_forward_R1_path\": {\"__class__\": \"ConnectedValue\"}, \"trimmed_reverse_R2_path\": {\"__class__\": \"ConnectedValue\"}, \"html_report_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 1, \"select_tool\": {\"tool_list\": \"kraken2\", \"__current_case__\": 13, \"input\": {\"__class__\": \"ConnectedValue\"}, \"seq_classification_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"select_tool\": {\"tool_list\": \"bracken\", \"__current_case__\": 4, \"input\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}, \"kraken_report_path\": {\"__class__\": \"ConnectedValue\"}, \"threshold\": null, \"read_len\": \"100\", \"level\": \"S\"}}, {\"__index__\": 3, \"select_tool\": {\"tool_list\": \"recentrifuge\", \"__current_case__\": 18, \"input\": {\"__class__\": \"ConnectedValue\"}, \"rcf_stat_path\": {\"__class__\": \"ConnectedValue\"}, \"rcf_html_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"log\": false, \"tool_section\": {\"tools\": [{\"__index__\": 0, \"select_tool\": {\"tool_list\": \"fastp\", \"__current_case__\": 7, \"input\": {\"__class__\": \"ConnectedValue\"}, \"trimmed_forward_R1_path\": {\"__class__\": \"ConnectedValue\"}, \"trimmed_reverse_R2_path\": {\"__class__\": \"ConnectedValue\"}, \"html_report_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": null}}, {\"__index__\": 1, \"select_tool\": {\"tool_list\": \"kraken2\", \"__current_case__\": 13, \"input\": {\"__class__\": \"ConnectedValue\"}, \"seq_classification_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"select_tool\": {\"tool_list\": \"bracken\", \"__current_case__\": 4, \"input\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}, \"kraken_report_path\": {\"__class__\": \"ConnectedValue\"}, \"threshold\": null, \"read_len\": \"100\", \"level\": \"S\"}}, {\"__index__\": 3, \"select_tool\": {\"tool_list\": \"recentrifuge\", \"__current_case__\": 18, \"input\": {\"__class__\": \"ConnectedValue\"}, \"rcf_stat_path\": {\"__class__\": \"ConnectedValue\"}, \"rcf_html_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}]}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.9.2+galaxy0",
             "type": "tool",
             "uuid": "b88b0ffe-f660-43ea-b00a-40ca0087f83f",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "tooldistillator_results",
+                    "label": "tooldistillator_results_control",
                     "output_name": "output_json",
                     "uuid": "d0ad8d88-a27f-439a-8523-6e0626401c58"
                 }
             ]
         },
-        "9": {
+        "11": {
             "annotation": "ToolDistillator summarize groups all JSON file into a unique JSON file",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0",
             "errors": null,
-            "id": 9,
+            "id": 11,
             "input_connections": {
                 "summarize_data": {
-                    "id": 8,
+                    "id": 10,
                     "output_name": "output_json"
                 }
             },
@@ -744,20 +891,20 @@
                 }
             ],
             "position": {
-                "left": 1509.353557955502,
-                "top": 342.8073251953125
+                "left": 1855.0036434047208,
+                "top": 499.5573251953125
             },
             "post_job_actions": {
                 "RenameDatasetActionsummary_json": {
                     "action_arguments": {
-                        "newname": "tooldistillator_summarize"
+                        "newname": "tooldistillator_summarize_control"
                     },
                     "action_type": "RenameDatasetAction",
                     "output_name": "summary_json"
                 },
                 "TagDatasetActionsummary_json": {
                     "action_arguments": {
-                        "tags": "tooldistillator_summarize"
+                        "tags": "tooldistillator_summarize_control"
                     },
                     "action_type": "TagDatasetAction",
                     "output_name": "summary_json"
@@ -777,7 +924,7 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "tooldistillator_summarize",
+                    "label": "tooldistillator_summarize_control",
                     "output_name": "summary_json",
                     "uuid": "2db8147f-05b9-4ddc-a3db-bd31fb57c690"
                 }

--- a/workflows/genome-assembly/quality-and-contamination-control/quality_and_contamination_control.ga
+++ b/workflows/genome-assembly/quality-and-contamination-control/quality_and_contamination_control.ga
@@ -1,6 +1,7 @@
 {
     "a_galaxy_workflow": "true",
     "annotation": "Short paired-end read analysis to provide quality analysis, read cleaning and taxonomy assignation",
+    "comments": [],
     "creator": [
         {
             "class": "Person",
@@ -27,7 +28,6 @@
     ],
     "format-version": "0.1",
     "license": "GPL-3.0-or-later",
-    "release": "1.1.6",
     "name": "Quality and Contamination Control For Genome Assembly",
     "steps": {
         "0": {
@@ -104,7 +104,7 @@
                 "top": 307.433349609375
             },
             "tool_id": null,
-            "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
+            "tool_state": "{\"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "1a56b57e-8893-4cbc-a984-329e0b815cbd",
@@ -137,7 +137,7 @@
                 "top": 454.91066885428484
             },
             "tool_id": null,
-            "tool_state": "{\"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
+            "tool_state": "{\"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "daac0634-bcf4-4fdd-bcd2-67247f5afdd0",
@@ -152,24 +152,16 @@
         },
         "4": {
             "annotation": "fastp_triming, quality analaysis and read cleaning",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy3",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4",
             "errors": null,
             "id": 4,
             "input_connections": {
                 "single_paired|in1": {
                     "id": 0,
                     "output_name": "output"
-                },
-                "single_paired|in2": {
-                    "id": 1,
-                    "output_name": "output"
                 }
             },
             "inputs": [
-                {
-                    "description": "runtime parameter for tool fastp",
-                    "name": "single_paired"
-                },
                 {
                     "description": "runtime parameter for tool fastp",
                     "name": "single_paired"
@@ -180,10 +172,6 @@
             "outputs": [
                 {
                     "name": "out1",
-                    "type": "input"
-                },
-                {
-                    "name": "out2",
                     "type": "input"
                 },
                 {
@@ -271,15 +259,15 @@
                     "output_name": "report_json"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy3",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4",
             "tool_shed_repository": {
-                "changeset_revision": "a626e8c0e1ba",
+                "changeset_revision": "10678d49d39e",
                 "name": "fastp",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": null, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": null, \"umi_len\": null, \"umi_prefix\": null}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": false}}, \"single_paired\": {\"single_paired_selector\": \"paired\", \"__current_case__\": 1, \"in1\": {\"__class__\": \"ConnectedValue\"}, \"in2\": {\"__class__\": \"ConnectedValue\"}, \"merge_reads\": {\"merge\": \"\", \"__current_case__\": 1}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": null, \"adapter_sequence2\": null, \"detect_adapter_for_pe\": false}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.24.0+galaxy3",
+            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": null, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": null, \"umi_len\": null, \"umi_prefix\": null}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": false}}, \"single_paired\": {\"single_paired_selector\": \"single\", \"__current_case__\": 0, \"in1\": {\"__class__\": \"RuntimeValue\"}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": null}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.24.0+galaxy4",
             "type": "tool",
             "uuid": "7f405009-2491-4633-b4e1-ca0fdbd8360d",
             "when": null,
@@ -319,10 +307,6 @@
                 "single_paired|forward_input": {
                     "id": 4,
                     "output_name": "out1"
-                },
-                "single_paired|reverse_input": {
-                    "id": 4,
-                    "output_name": "out2"
                 }
             },
             "inputs": [
@@ -408,7 +392,7 @@
         },
         "6": {
             "annotation": "bracken_abundance_estimation",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bracken/est_abundance/3.0+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bracken/est_abundance/3.1+galaxy0",
             "errors": null,
             "id": 6,
             "input_connections": {
@@ -468,15 +452,15 @@
                     "output_name": "report"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bracken/est_abundance/3.0+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bracken/est_abundance/3.1+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "0c7b6eb7e752",
+                "changeset_revision": "4d350ac5148e",
                 "name": "bracken",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"kmer_distr\": {\"__class__\": \"ConnectedValue\"}, \"level\": \"S\", \"logfile_output\": false, \"out_report\": true, \"threshold\": \"10\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "3.0+galaxy0",
+            "tool_version": "3.1+galaxy0",
             "type": "tool",
             "uuid": "e088cdc6-d79b-453c-8787-6d4b7004312a",
             "when": null,
@@ -495,7 +479,7 @@
         },
         "7": {
             "annotation": "recentrifuge_taxonomy_visualization",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/recentrifuge/recentrifuge/1.15.0+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/recentrifuge/recentrifuge/1.16.0+galaxy0",
             "errors": null,
             "id": 7,
             "input_connections": {
@@ -596,15 +580,15 @@
                     "output_name": "stat_tsv"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/recentrifuge/recentrifuge/1.15.0+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/recentrifuge/recentrifuge/1.16.0+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "591175c0f051",
+                "changeset_revision": "cfb53a01abc5",
                 "name": "recentrifuge",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"advanced_option\": {\"controls\": \"0\", \"scoring\": null, \"minscore_value\": \"0\", \"mintaxa\": \"0\", \"exclude_taxa_name\": null, \"include_taxa_name\": null, \"avoidcross\": false}, \"database\": {\"database_name\": {\"__class__\": \"ConnectedValue\"}}, \"file_type\": {\"filetype\": \"kraken\", \"__current_case__\": 3}, \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"more_advanced_option\": {\"ctrlminscore\": \"0\", \"ctrlmintaxa\": \"0\", \"summary\": \"ADD\", \"takeoutroot\": false, \"nokollapse\": false, \"strain\": true, \"sequential\": false}, \"output_option\": {\"extra\": \"TSV\", \"nohtml\": false, \"no_logfile\": false}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.15.0+galaxy0",
+            "tool_version": "1.16.0+galaxy0",
             "type": "tool",
             "uuid": "2db5d20e-62c7-43ad-b21f-e9992c77faa1",
             "when": null,
@@ -633,7 +617,7 @@
         },
         "8": {
             "annotation": "ToolDistillator extracts results from tools and creates a JSON file for each tool",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0",
             "errors": null,
             "id": 8,
             "input_connections": {
@@ -648,10 +632,6 @@
                 "tool_section|tools_0|select_tool|trimmed_forward_R1_path": {
                     "id": 4,
                     "output_name": "out1"
-                },
-                "tool_section|tools_0|select_tool|trimmed_reverse_R2_path": {
-                    "id": 4,
-                    "output_name": "out2"
                 },
                 "tool_section|tools_1|select_tool|input": {
                     "id": 5,
@@ -723,15 +703,15 @@
                     "output_name": "output_json"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "ea93df4b3df2",
+                "changeset_revision": "66617be450bd",
                 "name": "tooldistillator",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"log\": false, \"tool_section\": {\"tools\": [{\"__index__\": 0, \"select_tool\": {\"tool_list\": \"fastp\", \"__current_case__\": 6, \"input\": {\"__class__\": \"ConnectedValue\"}, \"trimmed_forward_R1_path\": {\"__class__\": \"ConnectedValue\"}, \"trimmed_reverse_R2_path\": {\"__class__\": \"ConnectedValue\"}, \"html_report_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 1, \"select_tool\": {\"tool_list\": \"kraken2\", \"__current_case__\": 12, \"input\": {\"__class__\": \"ConnectedValue\"}, \"seq_classification_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"select_tool\": {\"tool_list\": \"bracken\", \"__current_case__\": 4, \"input\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}, \"kraken_report_path\": {\"__class__\": \"ConnectedValue\"}, \"threshold\": null, \"read_len\": \"100\", \"level\": \"S\"}}, {\"__index__\": 3, \"select_tool\": {\"tool_list\": \"recentrifuge\", \"__current_case__\": 17, \"input\": {\"__class__\": \"ConnectedValue\"}, \"rcf_stat_path\": {\"__class__\": \"ConnectedValue\"}, \"rcf_html_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.9.1+galaxy1",
+            "tool_state": "{\"log\": false, \"tool_section\": {\"tools\": [{\"__index__\": 0, \"select_tool\": {\"tool_list\": \"fastp\", \"__current_case__\": 7, \"input\": {\"__class__\": \"ConnectedValue\"}, \"trimmed_forward_R1_path\": {\"__class__\": \"ConnectedValue\"}, \"trimmed_reverse_R2_path\": {\"__class__\": \"ConnectedValue\"}, \"html_report_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 1, \"select_tool\": {\"tool_list\": \"kraken2\", \"__current_case__\": 13, \"input\": {\"__class__\": \"ConnectedValue\"}, \"seq_classification_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"select_tool\": {\"tool_list\": \"bracken\", \"__current_case__\": 4, \"input\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}, \"kraken_report_path\": {\"__class__\": \"ConnectedValue\"}, \"threshold\": null, \"read_len\": \"100\", \"level\": \"S\"}}, {\"__index__\": 3, \"select_tool\": {\"tool_list\": \"recentrifuge\", \"__current_case__\": 18, \"input\": {\"__class__\": \"ConnectedValue\"}, \"rcf_stat_path\": {\"__class__\": \"ConnectedValue\"}, \"rcf_html_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.9.2+galaxy0",
             "type": "tool",
             "uuid": "b88b0ffe-f660-43ea-b00a-40ca0087f83f",
             "when": null,
@@ -745,7 +725,7 @@
         },
         "9": {
             "annotation": "ToolDistillator summarize groups all JSON file into a unique JSON file",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0",
             "errors": null,
             "id": 9,
             "input_connections": {
@@ -783,15 +763,15 @@
                     "output_name": "summary_json"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "24eec94e6dfc",
+                "changeset_revision": "07d093aaf3b4",
                 "name": "tooldistillator_summarize",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"summarize_data\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.9.1+galaxy1",
+            "tool_version": "0.9.2+galaxy0",
             "type": "tool",
             "uuid": "fbc8d552-c0b1-426c-b26f-8bfe8371b05e",
             "when": null,
@@ -814,6 +794,7 @@
         "ABRomics",
         "trimming"
     ],
-    "uuid": "eb1c667d-639d-4403-a2b4-1cb6683e0fa5",
-    "version": 1
+    "uuid": "83b60d78-8d6e-4bc0-9691-51c011bcc7ee",
+    "version": 1,
+    "release": "1.1.7"
 }


### PR DESCRIPTION
Hello, 

This code (close #678  ):
- Changes tools version: 
  - `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy3` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4`
  - `toolshed.g2.bx.psu.edu/repos/iuc/bracken/est_abundance/3.0+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/bracken/est_abundance/3.1+galaxy0`
  - `toolshed.g2.bx.psu.edu/repos/iuc/recentrifuge/recentrifuge/1.15.0+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/recentrifuge/recentrifuge/1.16.0+galaxy0`
  - `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0`
  - `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0`
- Changes the output name/tag of Tooldistillator to `tooldistillator_[results|summarize]_control`
- Fixes syntax and parameter errors
- With Fastp 0.24.0 we can now only select the input Paired Collection: so the Zip and Unzip collection tools have been added to the workflow


This workflow uses databases available on http://datacache.galaxyproject.org/.

Thanks :smiley: 