### PR TITLE
Accessibility score improvements: adding Title header element to Home Page

### DIFF
--- a/website/app.config.ts
+++ b/website/app.config.ts
@@ -1,4 +1,9 @@
 export default defineAppConfig({
+    site: {
+        name: "Galaxy IWC",
+        defaultDescription: "Scientific workflows by the Intergalactic Workflow Comission (IWC).",
+        keywords: ["Galaxy Project", "Workflow", "Intergalactic Workflow Comission", "Bioinformatics"]
+      },
     ui: {
         primary: "hokey-pokey",
         gray: "ebony-clay",

--- a/website/components/IWCHeader.vue
+++ b/website/components/IWCHeader.vue
@@ -1,7 +1,19 @@
 <script setup>
-const pageName = "Galaxy IWC - Workflow Library";
+const appConfig = useAppConfig();
+const pageName = `${appConfig.site.name} - Workflow Library`;
+
 useHead({
     title: pageName,
+    meta: [
+        {
+            name: "description",
+            content: pageName,
+        },
+        {
+            name: "keywords",
+            content: appConfig.site.keywords.join(', '),
+        },
+    ],
 });
 </script>
 

--- a/website/components/IWCHeader.vue
+++ b/website/components/IWCHeader.vue
@@ -1,10 +1,17 @@
+<script setup>
+const pageName = "Galaxy IWC - Workflow Library";
+useHead({
+    title: pageName,
+});
+</script>
+
 <template>
     <header class="py-2 px-6 bg-ebony-clay text-white">
         <div class="flex">
             <div class="flex flex-grow space-x-2">
                 <NuxtLink to="/" class="flex items-center space-x-2 hover:text-hokey-pokey">
                     <img src="/iwc_logo_white.png" alt="IWC Logo" width="64" height="64" />
-                    <span class="text-xl font-semibold px-4"> Galaxy IWC - Workflow Library </span>
+                    <span class="text-xl font-semibold px-4"> {{ pageName }} </span>
                 </NuxtLink>
             </div>
             <div class="flex items-center space-x-8">

--- a/website/nuxt.config.ts
+++ b/website/nuxt.config.ts
@@ -17,6 +17,9 @@ export default defineNuxtConfig({
     app: {
         head: {
             link: [{ rel: "icon", type: "image/png", href: "/iwc_logo_white.png" }],
+            htmlAttrs: {
+                lang: "en",
+            },
         },
     },
 

--- a/website/pages/workflow/[id].vue
+++ b/website/pages/workflow/[id].vue
@@ -8,6 +8,7 @@ import { formatDate } from "~/utils/";
 import GalaxyInstanceSelector from "~/components/GalaxyInstanceSelector.vue";
 
 const route = useRoute();
+const appConfig = useAppConfig();
 const workflowStore = useWorkflowStore();
 const workflow = computed(() => workflowStore.workflow);
 
@@ -145,6 +146,27 @@ onBeforeMount(async () => {
     nextTick(() => {
         setActiveTabFromHash();
     });
+});
+
+function getFirstLine(markdown: string) {
+    if (typeof markdown !== 'string') return '';
+    /* Normalize line endings and split */
+    const lines = markdown.replace(/\r\n/g, '\n').split('\n');
+    /* Remove Markdownn's Header syntax */
+    if (lines[0].substring(0, 2) === '# ') {
+        lines[0] = lines[0].substring(2);
+    }
+    return lines[0].trim();
+}
+
+useHead({
+    title: `${getFirstLine(tabs.value[currentTabIndex.value].content)} | ${appConfig.site.name}`,
+    meta: [
+        {
+            name: "description",
+            content: `Workflow ${getFirstLine(tabs.value[currentTabIndex.value].content)}`,
+        },
+    ],
 });
 </script>
 

--- a/website/pages/workflow/[id].vue
+++ b/website/pages/workflow/[id].vue
@@ -68,6 +68,10 @@ const tools = computed(() => {
     return Array.from(new Set(toolIds));
 });
 
+const workflowName = computed(() => {
+    return workflow.value?.definition?.name || "Workflow Details";
+});
+
 // Define interface for tab items
 interface TabItem {
     label: string;
@@ -148,23 +152,12 @@ onBeforeMount(async () => {
     });
 });
 
-function getFirstLine(markdown: string) {
-    if (typeof markdown !== 'string') return '';
-    /* Normalize line endings and split */
-    const lines = markdown.replace(/\r\n/g, '\n').split('\n');
-    /* Remove Markdownn's Header syntax */
-    if (lines[0].substring(0, 2) === '# ') {
-        lines[0] = lines[0].substring(2);
-    }
-    return lines[0].trim();
-}
-
 useHead({
-    title: `${getFirstLine(tabs.value[currentTabIndex.value].content)} | ${appConfig.site.name}`,
+    title: computed(() => `${workflowName.value} | ${appConfig.site.name}`),
     meta: [
         {
             name: "description",
-            content: `Workflow ${getFirstLine(tabs.value[currentTabIndex.value].content)}`,
+            content: `Workflow ${workflowName.value}`,
         },
     ],
 });


### PR DESCRIPTION
Addresses issue [#805](https://github.com/galaxyproject/iwc/issues/805)

FOR CONTRIBUTOR:
* [x] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [x] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
