### PR TITLE
Update MGnify WFs

### DIFF
--- a/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/CHANGELOG.md
+++ b/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.3] - 2025-05-05
+
+- `toolshed.g2.bx.psu.edu/repos/iuc/fastq_dl/fastq_dl/3.0.0+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/fastq_dl/fastq_dl/3.0.1+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.3+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy3`
+- `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.1+galaxy0`
+- `CONVERTER_gz_to_uncompressed` output format was updated to `fastqsanger`
+- `CONVERTER_uncompressed_to_gz` output format was updated to `fastqsanger.gz`
+
 ## [0.2] - 2025-03-10
 
 - `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy3` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4`

--- a/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.ga
+++ b/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete.ga
@@ -24,7 +24,7 @@
     "format-version": "0.1",
     "license": "Apache-2.0",
     "name": "MGnify's amplicon pipeline v5.0",
-    "release": "0.2",
+    "release": "0.3",
     "report": {
         "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
     },
@@ -52,7 +52,7 @@
             "tool_state": "{\"optional\": false, \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "830c700a-be07-46b4-b64e-83e7c75e53ca",
+            "uuid": "c947828b-6ce8-485d-954d-7a552e8ad2be",
             "when": null,
             "workflow_outputs": []
         },
@@ -79,7 +79,7 @@
             "tool_state": "{\"optional\": false, \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "fd16b9ce-b602-4535-9fa0-4218666c2290",
+            "uuid": "dce27280-0a9a-48e8-bfc3-812be9c5c954",
             "when": null,
             "workflow_outputs": []
         },
@@ -106,9 +106,15 @@
             "tool_state": "{\"default\": 4, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "39e0bbb8-def5-4cbe-875d-0e75d5e37495",
+            "uuid": "016f5b29-e1b2-41ca-a689-d14f13bd38e9",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "71a7e481-9ad4-4899-8fad-57eabba73c24"
+                }
+            ]
         },
         "3": {
             "annotation": "Average quality required.",
@@ -133,9 +139,15 @@
             "tool_state": "{\"default\": 15, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "21106922-bb34-4647-9bee-446710c7d8d5",
+            "uuid": "ffc28b10-754c-46df-8a4f-8945a3a713c7",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "c0cddee1-d28c-4f14-af73-408683eb0db4"
+                }
+            ]
         },
         "4": {
             "annotation": "Enable base correction in overlapped regions. (Paired-end)",
@@ -160,9 +172,15 @@
             "tool_state": "{\"default\": false, \"validators\": [], \"parameter_type\": \"boolean\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "90776758-eb1e-494a-9c34-d891fb22552b",
+            "uuid": "7fd036bd-c64b-4292-b1d7-0eb8a8784ca8",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "e48af52d-e6c4-4afc-8918-24b6a9f66898"
+                }
+            ]
         },
         "5": {
             "annotation": "Cut bases off the start of a read, if below a threshold quality.",
@@ -187,9 +205,15 @@
             "tool_state": "{\"default\": 3, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "869e3248-10ca-44f5-98bb-5e520658b9bd",
+            "uuid": "00f4e247-5ffa-425b-a124-9a646b07a12b",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "cc3664a6-9bb4-4568-aa5f-6c7402bf76e9"
+                }
+            ]
         },
         "6": {
             "annotation": "The quality value that a base is qualified. (Paired-end)",
@@ -214,9 +238,15 @@
             "tool_state": "{\"default\": 20, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "9d0bfec9-8ab2-4d46-af38-65e8d9f38445",
+            "uuid": "d8db65e1-4923-4398-9e6c-c672e45a06ff",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "15f4e0d3-96ab-4f5a-afb3-a488b2ff61fb"
+                }
+            ]
         },
         "7": {
             "annotation": "Cut bases off the end of a read, if below a threshold quality.",
@@ -241,9 +271,15 @@
             "tool_state": "{\"default\": 3, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "a5f602ee-06ac-4c40-a5db-2bac77112f97",
+            "uuid": "615d5b43-92ae-4896-bd03-02840a903a1d",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "3e480bec-78d8-447a-af03-c2a20e27897d"
+                }
+            ]
         },
         "8": {
             "annotation": "How many percents of bases are allowed to be unqualified (0~100). (Paired-end)",
@@ -268,9 +304,15 @@
             "tool_state": "{\"default\": 20, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "3ccea377-db95-4eea-83d8-864f942e3347",
+            "uuid": "6d8aa77e-0d6f-4902-9f0d-bb65b067245a",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "359c7014-7bee-417c-9547-372d5a7c7c4a"
+                }
+            ]
         },
         "9": {
             "annotation": "Minimum length of reads to be kept.",
@@ -295,9 +337,15 @@
             "tool_state": "{\"default\": 100, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "183a6499-b9e0-4844-a4cd-f5de8804f1e1",
+            "uuid": "aa9b3035-c91e-4414-b5a5-d34661605d62",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "104edb3c-2364-4b6d-b8d3-7d3928a1b755"
+                }
+            ]
         },
         "10": {
             "annotation": "Reads shorter than this value will be discarded. (Paired-end)",
@@ -322,9 +370,15 @@
             "tool_state": "{\"default\": 70, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "4c9fd5af-fd9b-45f2-8fe5-31852d05cab1",
+            "uuid": "b55b68aa-bc68-4ca7-a4fd-abaaf40c1f20",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "ef84a2c9-58d5-4543-9eb3-77e39c59bf13"
+                }
+            ]
         },
         "11": {
             "annotation": "Minimum sequence length.",
@@ -349,9 +403,15 @@
             "tool_state": "{\"default\": 100, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "d5361c5a-2500-4dbd-bbc2-907d0b067fc4",
+            "uuid": "5a5f7e28-ea70-44d3-97fa-6d0847d3f2b4",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "e6171779-6a5c-4572-b891-4a6133a48f71"
+                }
+            ]
         },
         "12": {
             "annotation": "Maximal N percentage threshold to conserve sequences.",
@@ -376,9 +436,15 @@
             "tool_state": "{\"default\": 10, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "1503e81e-64d4-473c-bde9-751ba2bb9143",
+            "uuid": "7ddc1d8a-98b8-4a73-a53e-dd0c549c3b60",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "43bce969-fc38-4317-a2cd-6922b7481543"
+                }
+            ]
         },
         "13": {
             "annotation": "",
@@ -403,9 +469,15 @@
             "tool_state": "{\"default\": \"SSU taxonomic abundance summary table\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "44cdc1f5-5482-4843-915c-3eeec13e63ff",
+            "uuid": "abc41a3e-36b1-40bb-a258-a220eab1c7de",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "782d8d78-14a6-4ef8-9bd9-3a1de2e8cb27"
+                }
+            ]
         },
         "14": {
             "annotation": "",
@@ -430,9 +502,15 @@
             "tool_state": "{\"default\": \"SSU phylum level taxonomic abundance summary table\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "7a186613-22f7-406c-a464-566889fba9b6",
+            "uuid": "945fe916-1ba6-4d73-b25e-5d02ab1fedc1",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "b513c98b-6447-44c2-b08f-ff6b5ee8fc54"
+                }
+            ]
         },
         "15": {
             "annotation": "",
@@ -457,9 +535,15 @@
             "tool_state": "{\"default\": \"LSU taxonomic abundance summary table\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "c5976795-446d-465b-a17b-89f88cd36609",
+            "uuid": "fd6f9bef-727b-46fe-8d98-76b6931eed2e",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "88208ba1-f108-4cd0-a9c9-63f31e84c81c"
+                }
+            ]
         },
         "16": {
             "annotation": "",
@@ -484,9 +568,15 @@
             "tool_state": "{\"default\": \"LSU phylum level taxonomic abundance summary table\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "0d031f24-2524-4111-8199-fde1fed46abd",
+            "uuid": "0f87b11d-2664-40b3-a6bc-c19095160bd5",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "f4959b29-a2a7-4279-9a6b-f055aa6fe3ca"
+                }
+            ]
         },
         "17": {
             "annotation": "",
@@ -511,9 +601,15 @@
             "tool_state": "{\"default\": \"ITSoneDB taxonomic abundance summary table\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "78990ece-405a-4a82-8a7c-87c4efbe396f",
+            "uuid": "a320b3d6-de5f-44c7-82cf-9ceb1b7bf090",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "a86de307-117c-4bdc-8187-cbab848b2726"
+                }
+            ]
         },
         "18": {
             "annotation": "",
@@ -538,9 +634,15 @@
             "tool_state": "{\"default\": \"ITSoneDB phylum level taxonomic abundance summary table\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "25b414b3-afe1-48b1-81cd-37059285b496",
+            "uuid": "9f1cef7d-774d-4202-8e57-8d79cd44f023",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "76d6156a-aec3-4037-a1c9-a343a0ab69e6"
+                }
+            ]
         },
         "19": {
             "annotation": "",
@@ -565,9 +667,15 @@
             "tool_state": "{\"default\": \"ITS UNITE DB taxonomic abundance summary table\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "d6da448e-070a-423e-9f7e-182b7d20340c",
+            "uuid": "4c883ed6-ca06-4dd5-b1b0-06d48e9f86b8",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "9105b670-f6ef-45af-bc7f-d83be538c85b"
+                }
+            ]
         },
         "20": {
             "annotation": "",
@@ -592,13 +700,19 @@
             "tool_state": "{\"default\": \"ITS UNITE DB phylum level taxonomic abundance summary table\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "2f17ad42-aebe-4069-9907-ca85aec8df82",
+            "uuid": "c6a4cf18-a1cf-4b9e-bd49-fc13136adc2e",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "3f8a349a-79eb-4140-ae14-9648bb8aa768"
+                }
+            ]
         },
         "21": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastq_dl/fastq_dl/3.0.0+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastq_dl/fastq_dl/3.0.1+galaxy0",
             "errors": null,
             "id": 21,
             "input_connections": {
@@ -650,17 +764,17 @@
                     "output_name": "single_end_collection"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastq_dl/fastq_dl/3.0.0+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastq_dl/fastq_dl/3.0.1+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "5e7401777990",
+                "changeset_revision": "3f1ee30e39e9",
                 "name": "fastq_dl",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"group_by_experiment\": false, \"group_by_sample\": false, \"input_type\": {\"select_input_type\": \"accessions_list\", \"__current_case__\": 1, \"accessions_file\": {\"__class__\": \"ConnectedValue\"}}, \"only_download_metadata\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "3.0.0+galaxy0",
+            "tool_state": "{\"group_by_experiment\": false, \"group_by_sample\": false, \"input_type\": {\"select_input_type\": \"accessions_list\", \"__current_case__\": 1, \"accessions_file\": {\"__class__\": \"ConnectedValue\"}}, \"only_download_metadata\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "3.0.1+galaxy0",
             "type": "tool",
-            "uuid": "f0deb7f2-7d87-4b03-ba36-9aa0c697fb71",
+            "uuid": "1c899d51-3fdf-4191-a301-2fe8c2f8e65b",
             "when": null,
             "workflow_outputs": []
         },
@@ -691,7 +805,7 @@
             "post_job_actions": {
                 "ChangeDatatypeActionoutput1": {
                     "action_arguments": {
-                        "newtype": "fastq"
+                        "newtype": "fastqsanger"
                     },
                     "action_type": "ChangeDatatypeAction",
                     "output_name": "output1"
@@ -706,7 +820,7 @@
             "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "d08c592b-f96d-466a-955f-79f94d7c6583",
+            "uuid": "117cc28f-3dbf-484c-889b-d3d9e8836d7e",
             "when": null,
             "workflow_outputs": []
         },
@@ -737,7 +851,7 @@
             "post_job_actions": {
                 "ChangeDatatypeActionoutput1": {
                     "action_arguments": {
-                        "newtype": "fastq"
+                        "newtype": "fastqsanger"
                     },
                     "action_type": "ChangeDatatypeAction",
                     "output_name": "output1"
@@ -752,13 +866,13 @@
             "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "846a5e86-bb32-4a51-aead-67e885c47626",
+            "uuid": "3b742137-c248-49c8-b369-691547509b35",
             "when": null,
             "workflow_outputs": []
         },
         "24": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.3+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy0",
             "errors": null,
             "id": 24,
             "input_connections": {
@@ -787,23 +901,23 @@
                     "output_name": "outfile"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.3+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "86755160afbf",
+                "changeset_revision": "6073bb457ec0",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"code\": \"NR % 4 == 1 { gsub(/[ \\\\/]/, \\\"-\\\", $0) } { print }\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "9.3+galaxy1",
+            "tool_version": "9.5+galaxy0",
             "type": "tool",
-            "uuid": "55dc8c71-6a78-42b3-ac88-1908de9386e0",
+            "uuid": "e48f8f18-a9ea-4de0-aeaa-62607b8a3d1c",
             "when": null,
             "workflow_outputs": []
         },
         "25": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.3+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy0",
             "errors": null,
             "id": 25,
             "input_connections": {
@@ -832,17 +946,17 @@
                     "output_name": "outfile"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.3+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "86755160afbf",
+                "changeset_revision": "6073bb457ec0",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"code\": \"NR % 4 == 1 { gsub(/[ \\\\/]/, \\\"-\\\", $0) } { print }\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "9.3+galaxy1",
+            "tool_version": "9.5+galaxy0",
             "type": "tool",
-            "uuid": "e69435e0-8589-4010-af09-52d505b5408c",
+            "uuid": "b005ff23-5590-4b25-a2c6-3ac6ef2a3c5c",
             "when": null,
             "workflow_outputs": []
         },
@@ -888,7 +1002,7 @@
             "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.16+galaxy0",
             "type": "tool",
-            "uuid": "f88f472c-f9e4-4693-b47d-ac2938f4fd47",
+            "uuid": "c3ae73e9-296e-488b-91f1-f2df270b829c",
             "when": null,
             "workflow_outputs": []
         },
@@ -934,7 +1048,7 @@
             "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.16+galaxy0",
             "type": "tool",
-            "uuid": "146869a3-e9f7-4f0b-a6a9-e33532825c61",
+            "uuid": "2d88cfc6-db91-4c8d-ab71-712a446c46ad",
             "when": null,
             "workflow_outputs": []
         },
@@ -1022,14 +1136,14 @@
                 },
                 "steps": {
                     "0": {
-                        "annotation": "Single-end reads collection.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 0,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Single-end reads collection.",
+                                "description": "",
                                 "name": "Single-end reads"
                             }
                         ],
@@ -1049,14 +1163,14 @@
                         "workflow_outputs": []
                     },
                     "1": {
-                        "annotation": "Average quality required.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 1,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Average quality required.",
+                                "description": "",
                                 "name": "Trimmomatic - SLIDING WINDOW - Average quality required"
                             }
                         ],
@@ -1073,23 +1187,17 @@
                         "type": "parameter_input",
                         "uuid": "7b3ec08b-9dd4-4215-8901-c0eb6f0be3e7",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "dc036460-5da1-4fd8-bc90-39f026ed738f"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "2": {
-                        "annotation": "Cut bases off the start of a read, if below a threshold quality.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 2,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Cut bases off the start of a read, if below a threshold quality.",
+                                "description": "",
                                 "name": "Trimmomatic - LEADING"
                             }
                         ],
@@ -1106,23 +1214,17 @@
                         "type": "parameter_input",
                         "uuid": "2f3fe5f1-44e3-4117-9417-d68b8a90aa23",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "cbc31256-f1f7-40f6-a21d-1e2dc968bc64"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "3": {
-                        "annotation": "Number of bases to average across.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 3,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Number of bases to average across.",
+                                "description": "",
                                 "name": "Trimmomatic - SLIDING WINDOW - Number of bases to average across"
                             }
                         ],
@@ -1139,23 +1241,17 @@
                         "type": "parameter_input",
                         "uuid": "5b70e0b8-0631-4059-aa36-d1ce896e45b1",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "225ef644-f8cf-489a-8de3-95e7c67d471d"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "4": {
-                        "annotation": "Cut bases off the end of a read, if below a threshold quality.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 4,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Cut bases off the end of a read, if below a threshold quality.",
+                                "description": "",
                                 "name": "Trimmomatic - TRAILING"
                             }
                         ],
@@ -1172,23 +1268,17 @@
                         "type": "parameter_input",
                         "uuid": "eed3e996-2baf-4908-ba47-449254adc3cb",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "87a0516a-a12b-44ca-b4a4-bc3e3f9ae30b"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "5": {
-                        "annotation": "Minimum length of reads to be kept.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 5,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Minimum length of reads to be kept.",
+                                "description": "",
                                 "name": "Trimmomatic - MINLEN"
                             }
                         ],
@@ -1205,23 +1295,17 @@
                         "type": "parameter_input",
                         "uuid": "08f7f8d1-ad75-42cf-91e0-bb549c8edd14",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "4cf4eeb3-bc3f-4134-bc0b-dc5f31e061c5"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "6": {
-                        "annotation": "Minimum sequence length.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 6,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Minimum sequence length.",
+                                "description": "",
                                 "name": "Length filtering - Minimum size"
                             }
                         ],
@@ -1238,23 +1322,17 @@
                         "type": "parameter_input",
                         "uuid": "5db2e477-4d58-4380-bc0d-e02a2249045c",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "62b85a60-f703-47d4-9e73-6e11cedd4b7b"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "7": {
-                        "annotation": "Maximal N percentage threshold to conserve sequences.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 7,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Maximal N percentage threshold to conserve sequences.",
+                                "description": "",
                                 "name": "Ambiguity filtering - Maximal N percentage threshold to conserve sequences"
                             }
                         ],
@@ -1271,13 +1349,7 @@
                         "type": "parameter_input",
                         "uuid": "1d6681c7-d75f-49ce-a21b-e5779b0cadca",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "d1f7d15b-61fb-425b-81f7-b7345dcebb1d"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "8": {
                         "annotation": "",
@@ -1951,7 +2023,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_formatter/cshl_fasta_formatter/1.0.1+galaxy2",
                         "tool_shed_repository": {
-                            "changeset_revision": "516b97a23d7e",
+                            "changeset_revision": "e773f1eb16cf",
                             "name": "fasta_formatter",
                             "owner": "devteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2016,7 +2088,7 @@
                     },
                     "21": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy0",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy3",
                         "errors": null,
                         "id": 21,
                         "input_connections": {
@@ -2037,7 +2109,12 @@
                                 "output_name": "outfile"
                             }
                         },
-                        "inputs": [],
+                        "inputs": [
+                            {
+                                "description": "runtime parameter for tool MultiQC",
+                                "name": "image_content_input"
+                            }
+                        ],
                         "label": null,
                         "name": "MultiQC",
                         "outputs": [
@@ -2070,15 +2147,15 @@
                                 "output_name": "stats"
                             }
                         },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy0",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy3",
                         "tool_shed_repository": {
-                            "changeset_revision": "a7e081ceb76a",
+                            "changeset_revision": "31c42a2c02d3",
                             "name": "multiqc",
                             "owner": "iuc",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastqc\", \"__current_case__\": 8, \"output\": [{\"__index__\": 0, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 1, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 2, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 3, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}]}}], \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "1.27+galaxy0",
+                        "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"image_content_input\": {\"__class__\": \"RuntimeValue\"}, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastqc\", \"__current_case__\": 8, \"output\": [{\"__index__\": 0, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 1, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 2, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}, {\"__index__\": 3, \"type\": \"data\", \"input\": {\"__class__\": \"RuntimeValue\"}}]}}], \"title\": \"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "1.27+galaxy3",
                         "type": "tool",
                         "uuid": "640f4f45-c12a-47e0-846b-9b150ed8beca",
                         "when": null,
@@ -2097,27 +2174,62 @@
                     }
                 },
                 "tags": [],
-                "uuid": "68bf2a73-d68a-4e25-ba52-5586c057df77"
+                "uuid": "a5fe9508-fb55-4c08-a605-9682abe0b67a"
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "147188ec-4e08-448a-be45-c8eec144d9f2",
+            "uuid": "b30531eb-7fa8-4d9f-902b-64c78de0de97",
             "when": null,
             "workflow_outputs": [
                 {
+                    "label": null,
+                    "output_name": "7:output",
+                    "uuid": "14c4a5ed-1058-4fa1-8356-552ab1c41db4"
+                },
+                {
+                    "label": null,
+                    "output_name": "5:output",
+                    "uuid": "07b2dc15-a276-4d90-9194-ca8b4a1eb45e"
+                },
+                {
+                    "label": null,
+                    "output_name": "3:output",
+                    "uuid": "dd64ed6c-b4de-410c-a2c3-e6c29a658b49"
+                },
+                {
+                    "label": null,
+                    "output_name": "6:output",
+                    "uuid": "5e928cf6-df3a-4d9f-86b9-4d76a9915d0f"
+                },
+                {
+                    "label": null,
+                    "output_name": "4:output",
+                    "uuid": "4421b16d-a3ff-4441-9923-b23718c43729"
+                },
+                {
                     "label": "Single-end MultiQC report",
                     "output_name": "Single-end MultiQC report",
-                    "uuid": "524978e4-ce01-4152-95e5-4e1ef5d48c3a"
+                    "uuid": "6f6ecd17-f506-4c5e-b872-a1b79620e44c"
                 },
                 {
                     "label": "Single-end post quality control FASTA files",
                     "output_name": "Single-end post quality control FASTA files",
-                    "uuid": "306311fc-4935-4aae-b9ad-ade3901e134d"
+                    "uuid": "8cf887ba-467f-4192-9eba-29cb8c7a5a1a"
+                },
+                {
+                    "label": null,
+                    "output_name": "2:output",
+                    "uuid": "b9838d8b-6d48-47de-98b9-e97f59203506"
                 },
                 {
                     "label": "Single-end MultiQC statistics",
                     "output_name": "Single-end MultiQC statistics",
-                    "uuid": "90e90edf-c318-42bf-a359-02d7d2bab053"
+                    "uuid": "91c6c565-ca5b-4f23-ba15-40ab9378837d"
+                },
+                {
+                    "label": null,
+                    "output_name": "1:output",
+                    "uuid": "4594767e-ae34-4368-a864-64e3dd6cf134"
                 }
             ]
         },
@@ -2225,14 +2337,14 @@
                 },
                 "steps": {
                     "0": {
-                        "annotation": "Paired-end reads collection.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 0,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Paired-end reads collection.",
+                                "description": "",
                                 "name": "Paired-end reads"
                             }
                         ],
@@ -2252,14 +2364,14 @@
                         "workflow_outputs": []
                     },
                     "1": {
-                        "annotation": " Enable base correction in overlapped regions.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 1,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": " Enable base correction in overlapped regions.",
+                                "description": "",
                                 "name": "fastp - Enable base correction"
                             }
                         ],
@@ -2276,23 +2388,17 @@
                         "type": "parameter_input",
                         "uuid": "81367449-c0ca-41be-b69d-5bf1568e0361",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "2cc2526b-c51d-42bd-94ac-540d45cce0aa"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "2": {
-                        "annotation": "The quality value that a base is qualified.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 2,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "The quality value that a base is qualified.",
+                                "description": "",
                                 "name": "fastp - Qualified quality phred"
                             }
                         ],
@@ -2309,23 +2415,17 @@
                         "type": "parameter_input",
                         "uuid": "cb8a7bac-c007-45c6-814b-9aacae0e37b3",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "8ed6f5eb-5fa9-4d25-8e8b-5f1252c4cf59"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "3": {
-                        "annotation": "How many percents of bases are allowed to be unqualified (0~100).",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 3,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "How many percents of bases are allowed to be unqualified (0~100).",
+                                "description": "",
                                 "name": "fastp - Unqualified percent limit "
                             }
                         ],
@@ -2342,23 +2442,17 @@
                         "type": "parameter_input",
                         "uuid": "26ed5910-22cf-4a8e-a144-edbb8d6b1d50",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "c24e8e77-678b-4fa3-9436-8f0d6592ed7e"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "4": {
-                        "annotation": "Reads shorter than this value will be discarded.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 4,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Reads shorter than this value will be discarded.",
+                                "description": "",
                                 "name": "fastp - Length required"
                             }
                         ],
@@ -2375,23 +2469,17 @@
                         "type": "parameter_input",
                         "uuid": "6521e9f3-6d1b-4e95-8934-3345f858bcf8",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "3221d128-de9e-489e-8497-e357f686112f"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "5": {
-                        "annotation": "Number of bases to average across.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 5,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Number of bases to average across.",
+                                "description": "",
                                 "name": "Trimmomatic - SLIDINGWINDOW - Number of bases to average across"
                             }
                         ],
@@ -2408,23 +2496,17 @@
                         "type": "parameter_input",
                         "uuid": "1b2652b0-235b-4120-9c82-e4d3210c9d2f",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "77bf0209-c48a-4422-8478-722a924ee1f3"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "6": {
-                        "annotation": "Average quality required.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 6,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Average quality required.",
+                                "description": "",
                                 "name": "Trimmomatic - SLIDINGWINDOW - Average quality required"
                             }
                         ],
@@ -2441,23 +2523,17 @@
                         "type": "parameter_input",
                         "uuid": "53e87ca4-6745-4835-b25f-878705737f0d",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "d4ea0915-89cf-4a64-8c27-3e0a1443168d"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "7": {
-                        "annotation": "Minimum quality required to keep a base.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 7,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Minimum quality required to keep a base.",
+                                "description": "",
                                 "name": "Trimmomatic - LEADING"
                             }
                         ],
@@ -2474,23 +2550,17 @@
                         "type": "parameter_input",
                         "uuid": "4e1cfaad-b067-4bf3-a6b8-33d3fd826285",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "fe7fcea9-5651-491a-b079-db434960e968"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "8": {
-                        "annotation": "Minimum quality required to keep a base.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 8,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Minimum quality required to keep a base.",
+                                "description": "",
                                 "name": "Trimmomatic - TRAILING"
                             }
                         ],
@@ -2507,23 +2577,17 @@
                         "type": "parameter_input",
                         "uuid": "d48c0437-1ab6-4fd4-8dfa-29dd056acaec",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "5f620484-e1bf-4bc5-a227-1b40d783eadd"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "9": {
-                        "annotation": "Minimum sequence length.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 9,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Minimum sequence length.",
+                                "description": "",
                                 "name": "Length filtering - Minimum size"
                             }
                         ],
@@ -2540,23 +2604,17 @@
                         "type": "parameter_input",
                         "uuid": "2957cfb6-b542-4354-b94f-fd171df4c9b1",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "4792bf14-48e1-43da-b086-5e137cd9c2a0"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "10": {
-                        "annotation": "Minimum length of reads to be kept.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 10,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Minimum length of reads to be kept.",
+                                "description": "",
                                 "name": "Trimmomatic - MINLEN"
                             }
                         ],
@@ -2573,23 +2631,17 @@
                         "type": "parameter_input",
                         "uuid": "c898eada-b136-40bf-a78d-240b8d02c660",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "b5501135-286f-410f-8aaa-ce79dfa52b38"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "11": {
-                        "annotation": "Maximal N percentage threshold to conserve sequences.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 11,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Maximal N percentage threshold to conserve sequences.",
+                                "description": "",
                                 "name": "Ambiguity filtering - Maximal N percentage threshold to conserve sequences"
                             }
                         ],
@@ -2606,17 +2658,11 @@
                         "type": "parameter_input",
                         "uuid": "d8341e6e-1401-48ef-ac1a-68c98309d0e1",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "f55c448d-f67e-4e0f-bede-c7937f2eb298"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "12": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.1+galaxy0",
                         "errors": null,
                         "id": 12,
                         "input_connections": {
@@ -2665,18 +2711,18 @@
                         ],
                         "position": {
                             "left": 331.5,
-                            "top": 0.0
+                            "top": 0
                         },
                         "post_job_actions": {},
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.1+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "10678d49d39e",
+                            "changeset_revision": "25c59c0ceb55",
                             "name": "fastp",
                             "owner": "iuc",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": {\"__class__\": \"ConnectedValue\"}, \"unqualified_percent_limit\": {\"__class__\": \"ConnectedValue\"}, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": {\"__class__\": \"ConnectedValue\"}, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": null, \"umi_len\": null, \"umi_prefix\": null}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": {\"__class__\": \"ConnectedValue\"}}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 1, \"paired_input\": {\"__class__\": \"RuntimeValue\"}, \"merge_reads\": {\"merge\": \"\", \"__current_case__\": 1}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": null, \"adapter_sequence2\": null, \"detect_adapter_for_pe\": false}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "0.24.0+galaxy4",
+                        "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": {\"__class__\": \"ConnectedValue\"}, \"unqualified_percent_limit\": {\"__class__\": \"ConnectedValue\"}, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": {\"__class__\": \"ConnectedValue\"}, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": null, \"umi_len\": null, \"umi_prefix\": null}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": {\"__class__\": \"ConnectedValue\"}}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 1, \"paired_input\": {\"__class__\": \"ConnectedValue\"}, \"merge_reads\": {\"merge\": \"\", \"__current_case__\": 1}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": null, \"adapter_sequence2\": null, \"detect_adapter_for_pe\": false}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "0.24.1+galaxy0",
                         "type": "tool",
                         "uuid": "9b7f1d2d-d39f-407d-a709-a5095fca62c2",
                         "when": null,
@@ -3087,7 +3133,7 @@
                     },
                     "19": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
                         "errors": null,
                         "id": 19,
                         "input_connections": {
@@ -3116,15 +3162,15 @@
                                 "output_name": "outfile"
                             }
                         },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "86755160afbf",
+                            "changeset_revision": "6073bb457ec0",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
                         "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"\\\\t(.*?)\\\\.gz\", \"replace_pattern\": \"\\\\t$1_initial_reads\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "9.3+galaxy1",
+                        "tool_version": "9.5+galaxy0",
                         "type": "tool",
                         "uuid": "680b293b-0b1e-4b95-9dc9-233354651b61",
                         "when": null,
@@ -3269,7 +3315,7 @@
                     },
                     "22": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
                         "errors": null,
                         "id": 22,
                         "input_connections": {
@@ -3298,15 +3344,15 @@
                                 "output_name": "outfile"
                             }
                         },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "86755160afbf",
+                            "changeset_revision": "6073bb457ec0",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
                         "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"\\\\t(.*?)\\\\.gz\", \"replace_pattern\": \"\\\\t$1_trimming\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "9.3+galaxy1",
+                        "tool_version": "9.5+galaxy0",
                         "type": "tool",
                         "uuid": "2bb5af38-51bd-4828-bc34-7b4c7273c9e2",
                         "when": null,
@@ -3433,7 +3479,7 @@
                     },
                     "25": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
                         "errors": null,
                         "id": 25,
                         "input_connections": {
@@ -3462,15 +3508,15 @@
                                 "output_name": "outfile"
                             }
                         },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "86755160afbf",
+                            "changeset_revision": "6073bb457ec0",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
                         "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"\\\\t(.*?)\\\\.gz\", \"replace_pattern\": \"\\\\t$1_length_filtering\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "9.3+galaxy1",
+                        "tool_version": "9.5+galaxy0",
                         "type": "tool",
                         "uuid": "8c5dc662-6bcc-4772-bc0e-d0b747113ef3",
                         "when": null,
@@ -3511,7 +3557,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_formatter/cshl_fasta_formatter/1.0.1+galaxy2",
                         "tool_shed_repository": {
-                            "changeset_revision": "516b97a23d7e",
+                            "changeset_revision": "e773f1eb16cf",
                             "name": "fasta_formatter",
                             "owner": "devteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -3531,7 +3577,7 @@
                     },
                     "27": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
                         "errors": null,
                         "id": 27,
                         "input_connections": {
@@ -3560,15 +3606,15 @@
                                 "output_name": "outfile"
                             }
                         },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "86755160afbf",
+                            "changeset_revision": "6073bb457ec0",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
                         "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"\\\\t(.*?)\\\\.gz\", \"replace_pattern\": \"\\\\t$1_ambiguous_base_filtering\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "9.3+galaxy1",
+                        "tool_version": "9.5+galaxy0",
                         "type": "tool",
                         "uuid": "aacb9221-34de-46f7-91ec-ff796e98db10",
                         "when": null,
@@ -3576,7 +3622,7 @@
                     },
                     "28": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy0",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy3",
                         "errors": null,
                         "id": 28,
                         "input_connections": {
@@ -3597,7 +3643,12 @@
                                 "output_name": "outfile"
                             }
                         },
-                        "inputs": [],
+                        "inputs": [
+                            {
+                                "description": "runtime parameter for tool MultiQC",
+                                "name": "image_content_input"
+                            }
+                        ],
                         "label": null,
                         "name": "MultiQC",
                         "outputs": [
@@ -3630,15 +3681,15 @@
                                 "output_name": "stats"
                             }
                         },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy0",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy3",
                         "tool_shed_repository": {
-                            "changeset_revision": "a7e081ceb76a",
+                            "changeset_revision": "31c42a2c02d3",
                             "name": "multiqc",
                             "owner": "iuc",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastqc\", \"__current_case__\": 8, \"output\": [{\"__index__\": 0, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 2, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 3, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}]}}], \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "1.27+galaxy0",
+                        "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"image_content_input\": {\"__class__\": \"RuntimeValue\"}, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastqc\", \"__current_case__\": 8, \"output\": [{\"__index__\": 0, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 2, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 3, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}]}}], \"title\": \"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "1.27+galaxy3",
                         "type": "tool",
                         "uuid": "e04ee136-c52f-4d7e-85c5-3b3ed78b0cce",
                         "when": null,
@@ -3657,27 +3708,82 @@
                     }
                 },
                 "tags": [],
-                "uuid": "3af45a28-126d-4c9d-9948-cabfe43566f3"
+                "uuid": "970d8230-91d9-41c0-93e1-16673cdfd9b7"
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "a6cb4bbc-057a-4326-b5c8-2c2a17514a62",
+            "uuid": "507e047e-5fe6-4056-adff-fd6f04f50c12",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Paired-end MultiQC statistics",
-                    "output_name": "Paired-end MultiQC statistics",
-                    "uuid": "9f83bbc4-916e-4379-a018-cef375aa6abb"
+                    "label": null,
+                    "output_name": "4:output",
+                    "uuid": "03651ca4-cc3b-493c-bd79-19cae87ae555"
                 },
                 {
-                    "label": "Paired-end post quality control FASTA files",
-                    "output_name": "Paired-end post quality control FASTA files",
-                    "uuid": "6b08b8f6-8f53-4a23-92a1-40a064674f17"
+                    "label": null,
+                    "output_name": "5:output",
+                    "uuid": "d96f1fc1-62e8-4ec2-afef-5c11cf6e9e4a"
+                },
+                {
+                    "label": null,
+                    "output_name": "7:output",
+                    "uuid": "8ec4dd54-b518-42a5-b20d-88e024286071"
+                },
+                {
+                    "label": null,
+                    "output_name": "8:output",
+                    "uuid": "b653fde2-6f9d-4361-9242-011262333c00"
                 },
                 {
                     "label": "Paired-end MultiQC report",
                     "output_name": "Paired-end MultiQC report",
-                    "uuid": "ec044dec-9f20-447f-8108-6040204f6054"
+                    "uuid": "fd1bad4c-912f-4fb3-9dbf-44abf4fad5d6"
+                },
+                {
+                    "label": null,
+                    "output_name": "11:output",
+                    "uuid": "0ca47869-b8d2-4138-8d3f-b552d2907fdd"
+                },
+                {
+                    "label": null,
+                    "output_name": "3:output",
+                    "uuid": "16d61dce-d6f9-4fcd-a801-759422a97051"
+                },
+                {
+                    "label": "Paired-end post quality control FASTA files",
+                    "output_name": "Paired-end post quality control FASTA files",
+                    "uuid": "2c08c132-f9c7-49b2-b4f3-1ecc424e1254"
+                },
+                {
+                    "label": "Paired-end MultiQC statistics",
+                    "output_name": "Paired-end MultiQC statistics",
+                    "uuid": "64f4d25d-2f9c-41d2-9a05-d31e010307f4"
+                },
+                {
+                    "label": null,
+                    "output_name": "1:output",
+                    "uuid": "04b07390-6c8c-4b8f-9bac-ca48a38da8f1"
+                },
+                {
+                    "label": null,
+                    "output_name": "9:output",
+                    "uuid": "841b6856-c7f7-4f63-aaae-9dc91868d3ac"
+                },
+                {
+                    "label": null,
+                    "output_name": "2:output",
+                    "uuid": "4f23ff34-1550-4835-81e6-b38516f38b93"
+                },
+                {
+                    "label": null,
+                    "output_name": "10:output",
+                    "uuid": "9a3cf51b-5f11-46fc-8e23-8327ac42e738"
+                },
+                {
+                    "label": null,
+                    "output_name": "6:output",
+                    "uuid": "06f3d63a-40ab-4bdb-98c7-dcb674f7c307"
                 }
             ]
         },
@@ -3720,7 +3826,7 @@
             "tool_state": "{\"advanced\": {\"conflict\": {\"duplicate_options\": \"keep_first\", \"__current_case__\": 3}}, \"inputs\": [{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "7ae8f68b-ebaf-4d46-af2b-804c8983dd7d",
+            "uuid": "0049e454-adf0-4456-b3e0-7f8156a8b477",
             "when": null,
             "workflow_outputs": []
         },
@@ -3778,14 +3884,14 @@
                 },
                 "steps": {
                     "0": {
-                        "annotation": "Post quality control.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 0,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Post quality control.",
+                                "description": "",
                                 "name": "Processed sequences"
                             }
                         ],
@@ -3805,14 +3911,14 @@
                         "workflow_outputs": []
                     },
                     "1": {
-                        "annotation": "This file lists which models belong to the same clan.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 1,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "This file lists which models belong to the same clan.",
+                                "description": "",
                                 "name": "Clan information file"
                             }
                         ],
@@ -4843,7 +4949,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_formatter/cshl_fasta_formatter/1.0.1+galaxy2",
                         "tool_shed_repository": {
-                            "changeset_revision": "516b97a23d7e",
+                            "changeset_revision": "e773f1eb16cf",
                             "name": "fasta_formatter",
                             "owner": "devteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -4896,7 +5002,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_formatter/cshl_fasta_formatter/1.0.1+galaxy2",
                         "tool_shed_repository": {
-                            "changeset_revision": "516b97a23d7e",
+                            "changeset_revision": "e773f1eb16cf",
                             "name": "fasta_formatter",
                             "owner": "devteam",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -5629,14 +5735,14 @@
                             "name": "Map empty/not empty collection to boolean ",
                             "steps": {
                                 "0": {
-                                    "annotation": "Collection to map to boolean parameter.",
+                                    "annotation": "",
                                     "content_id": null,
                                     "errors": null,
                                     "id": 0,
                                     "input_connections": {},
                                     "inputs": [
                                         {
-                                            "description": "Collection to map to boolean parameter.",
+                                            "description": "",
                                             "name": "Input collection"
                                         }
                                     ],
@@ -6006,14 +6112,14 @@
                             "name": "Map empty/not empty collection to boolean ",
                             "steps": {
                                 "0": {
-                                    "annotation": "Collection to map to boolean parameter.",
+                                    "annotation": "",
                                     "content_id": null,
                                     "errors": null,
                                     "id": 0,
                                     "input_connections": {},
                                     "inputs": [
                                         {
-                                            "description": "Collection to map to boolean parameter.",
+                                            "description": "",
                                             "name": "Input collection"
                                         }
                                     ],
@@ -6250,14 +6356,14 @@
                             "name": "Map empty/not empty collection to boolean ",
                             "steps": {
                                 "0": {
-                                    "annotation": "Collection to map to boolean parameter.",
+                                    "annotation": "",
                                     "content_id": null,
                                     "errors": null,
                                     "id": 0,
                                     "input_connections": {},
                                     "inputs": [
                                         {
-                                            "description": "Collection to map to boolean parameter.",
+                                            "description": "",
                                             "name": "Input collection"
                                         }
                                     ],
@@ -6556,14 +6662,14 @@
                             "name": "Map empty/not empty collection to boolean ",
                             "steps": {
                                 "0": {
-                                    "annotation": "Collection to map to boolean parameter.",
+                                    "annotation": "",
                                     "content_id": null,
                                     "errors": null,
                                     "id": 0,
                                     "input_connections": {},
                                     "inputs": [
                                         {
-                                            "description": "Collection to map to boolean parameter.",
+                                            "description": "",
                                             "name": "Input collection"
                                         }
                                     ],
@@ -7114,73 +7220,73 @@
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "ce11d4ec-e858-4aa8-a6f3-fe7c8d31be7d",
+            "uuid": "f70b66c5-aecd-435c-87b7-2fafc39fd5c9",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "LSU and SSU BED regions",
-                    "output_name": "LSU and SSU BED regions",
-                    "uuid": "2c0868a6-e45b-4738-9f2e-8395c49f6af1"
-                },
-                {
-                    "label": "LSU OTU tables (SILVA DB)",
-                    "output_name": "LSU OTU tables (SILVA DB)",
-                    "uuid": "6b36b9af-d003-4cc2-a179-a2a6c05090ad"
-                },
-                {
-                    "label": "SSU taxonomic classifications using SILVA DB",
-                    "output_name": "SSU taxonomic classifications using SILVA DB",
-                    "uuid": "3d7739ed-d444-4dbd-b686-b27e1aa1b7d0"
+                    "label": "SSU FASTA files",
+                    "output_name": "SSU FASTA files",
+                    "uuid": "d1088f04-9e2f-416d-9dfc-87ab5c3d8652"
                 },
                 {
                     "label": "SSU OTU tables in HDF5 format (SILVA DB)",
                     "output_name": "SSU OTU tables in HDF5 format (SILVA DB)",
-                    "uuid": "6028cb8e-cb14-4447-a619-f848d39c4f57"
-                },
-                {
-                    "label": "SSU OTU tables (SILVA DB)",
-                    "output_name": "SSU OTU tables (SILVA DB)",
-                    "uuid": "7f21d964-f8bc-47b6-972d-7b39eb4b7b02"
-                },
-                {
-                    "label": "LSU taxonomic classifications using SILVA DB",
-                    "output_name": "LSU taxonomic classifications using SILVA DB",
-                    "uuid": "09f8843c-6250-4c8a-a2b3-3ceee8915d23"
-                },
-                {
-                    "label": "LSU OTU tables in JSON format (SILVA DB)",
-                    "output_name": "LSU OTU tables in JSON format (SILVA DB)",
-                    "uuid": "800565e9-4663-4b11-869a-d68fd09152ea"
-                },
-                {
-                    "label": "LSU OTU tables in HDF5 format (SILVA DB)",
-                    "output_name": "LSU OTU tables in HDF5 format (SILVA DB)",
-                    "uuid": "42c9e089-6d5b-4af5-9c7e-23165c8569eb"
-                },
-                {
-                    "label": "SSU OTU tables in JSON format (SILVA DB)",
-                    "output_name": "SSU OTU tables in JSON format (SILVA DB)",
-                    "uuid": "480b5147-b6f0-404b-838c-36f2818100f8"
-                },
-                {
-                    "label": "LSU taxonomic abundance pie charts (SILVA DB)",
-                    "output_name": "LSU taxonomic abundance pie charts (SILVA DB)",
-                    "uuid": "45a9891a-b535-4f6b-9a66-e86c53ee154b"
-                },
-                {
-                    "label": "SSU FASTA files",
-                    "output_name": "SSU FASTA files",
-                    "uuid": "ee71d9de-28d9-4177-acb6-9ef170d2ce25"
-                },
-                {
-                    "label": "LSU FASTA files",
-                    "output_name": "LSU FASTA files",
-                    "uuid": "a4371314-8837-4670-a6b2-1e528264ebd4"
+                    "uuid": "8af9c378-2a91-4339-93eb-743376bceb78"
                 },
                 {
                     "label": "SSU taxonomic abundance pie charts (SILVA DB)",
                     "output_name": "SSU taxonomic abundance pie charts (SILVA DB)",
-                    "uuid": "c57d0bc6-d624-4be5-a10b-74c3ad15ab17"
+                    "uuid": "46ede89c-7a3c-423d-9dbb-3b75b7faf55d"
+                },
+                {
+                    "label": "SSU OTU tables in JSON format (SILVA DB)",
+                    "output_name": "SSU OTU tables in JSON format (SILVA DB)",
+                    "uuid": "36d3f861-4728-409f-9980-fd0d3cbe0361"
+                },
+                {
+                    "label": "LSU taxonomic abundance pie charts (SILVA DB)",
+                    "output_name": "LSU taxonomic abundance pie charts (SILVA DB)",
+                    "uuid": "c321a9ab-fc6a-47b7-96a2-5e169d55012e"
+                },
+                {
+                    "label": "LSU OTU tables in HDF5 format (SILVA DB)",
+                    "output_name": "LSU OTU tables in HDF5 format (SILVA DB)",
+                    "uuid": "51d11ea0-8014-4488-a037-5430f62714ba"
+                },
+                {
+                    "label": "LSU FASTA files",
+                    "output_name": "LSU FASTA files",
+                    "uuid": "0c0f64de-8be5-4517-8566-e3b1fda38458"
+                },
+                {
+                    "label": "LSU OTU tables in JSON format (SILVA DB)",
+                    "output_name": "LSU OTU tables in JSON format (SILVA DB)",
+                    "uuid": "89e4f49b-1e0a-4bdf-98d7-5a3b99204d3a"
+                },
+                {
+                    "label": "LSU taxonomic classifications using SILVA DB",
+                    "output_name": "LSU taxonomic classifications using SILVA DB",
+                    "uuid": "73b814b6-9da1-47d8-85ed-72d10b2a4314"
+                },
+                {
+                    "label": "LSU and SSU BED regions",
+                    "output_name": "LSU and SSU BED regions",
+                    "uuid": "2ce160a6-8d19-4b83-a68d-1975f60d42fe"
+                },
+                {
+                    "label": "SSU OTU tables (SILVA DB)",
+                    "output_name": "SSU OTU tables (SILVA DB)",
+                    "uuid": "9f6eeabf-d2de-4c91-bf1c-167221e0d233"
+                },
+                {
+                    "label": "SSU taxonomic classifications using SILVA DB",
+                    "output_name": "SSU taxonomic classifications using SILVA DB",
+                    "uuid": "5f1081b1-9df2-422b-9ba9-48b4f219f892"
+                },
+                {
+                    "label": "LSU OTU tables (SILVA DB)",
+                    "output_name": "LSU OTU tables (SILVA DB)",
+                    "uuid": "ef19d94e-c4da-4ede-842e-54104811ac2e"
                 }
             ]
         },
@@ -7238,14 +7344,14 @@
                 },
                 "steps": {
                     "0": {
-                        "annotation": "A BED file containing the LSU and SSU coordinates.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 0,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "A BED file containing the LSU and SSU coordinates.",
+                                "description": "",
                                 "name": "LSU and SSU BED"
                             }
                         ],
@@ -7265,14 +7371,14 @@
                         "workflow_outputs": []
                     },
                     "1": {
-                        "annotation": "Processed sequences.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 1,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Processed sequences.",
+                                "description": "",
                                 "name": "Processed sequences"
                             }
                         ],
@@ -8204,14 +8310,14 @@
                             "name": "Map empty/not empty collection to boolean ",
                             "steps": {
                                 "0": {
-                                    "annotation": "Collection to map to boolean parameter.",
+                                    "annotation": "",
                                     "content_id": null,
                                     "errors": null,
                                     "id": 0,
                                     "input_connections": {},
                                     "inputs": [
                                         {
-                                            "description": "Collection to map to boolean parameter.",
+                                            "description": "",
                                             "name": "Input collection"
                                         }
                                     ],
@@ -8581,14 +8687,14 @@
                             "name": "Map empty/not empty collection to boolean ",
                             "steps": {
                                 "0": {
-                                    "annotation": "Collection to map to boolean parameter.",
+                                    "annotation": "",
                                     "content_id": null,
                                     "errors": null,
                                     "id": 0,
                                     "input_connections": {},
                                     "inputs": [
                                         {
-                                            "description": "Collection to map to boolean parameter.",
+                                            "description": "",
                                             "name": "Input collection"
                                         }
                                     ],
@@ -8825,14 +8931,14 @@
                             "name": "Map empty/not empty collection to boolean ",
                             "steps": {
                                 "0": {
-                                    "annotation": "Collection to map to boolean parameter.",
+                                    "annotation": "",
                                     "content_id": null,
                                     "errors": null,
                                     "id": 0,
                                     "input_connections": {},
                                     "inputs": [
                                         {
-                                            "description": "Collection to map to boolean parameter.",
+                                            "description": "",
                                             "name": "Input collection"
                                         }
                                     ],
@@ -9131,14 +9237,14 @@
                             "name": "Map empty/not empty collection to boolean ",
                             "steps": {
                                 "0": {
-                                    "annotation": "Collection to map to boolean parameter.",
+                                    "annotation": "",
                                     "content_id": null,
                                     "errors": null,
                                     "id": 0,
                                     "input_connections": {},
                                     "inputs": [
                                         {
-                                            "description": "Collection to map to boolean parameter.",
+                                            "description": "",
                                             "name": "Input collection"
                                         }
                                     ],
@@ -9689,63 +9795,63 @@
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "169871f2-1966-4600-a8f9-4c5d4d40435d",
+            "uuid": "433ce74e-e99f-4cdf-8df5-32b194d0e787",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "ITS OTU tables in HDF5 format (ITSoneDB)",
                     "output_name": "ITS OTU tables in HDF5 format (ITSoneDB)",
-                    "uuid": "d7b793f8-f828-44e3-9af5-798158bd11d6"
-                },
-                {
-                    "label": "ITS FASTA files",
-                    "output_name": "ITS FASTA files",
-                    "uuid": "b7a20037-e419-4d1d-9e05-b96c6a9efca5"
-                },
-                {
-                    "label": "ITS OTU tables (ITSoneDB)",
-                    "output_name": "ITS OTU tables (ITSoneDB)",
-                    "uuid": "9d7fe164-5af7-4ef2-a439-a163705abfbb"
-                },
-                {
-                    "label": "ITS OTU tables in JSON format (UNITE DB)",
-                    "output_name": "ITS OTU tables in JSON format (UNITE DB)",
-                    "uuid": "6ef5a97b-63a2-4308-90a2-08a0f81057ea"
-                },
-                {
-                    "label": "ITS OTU tables in HDF5 format (UNITE DB)",
-                    "output_name": "ITS OTU tables in HDF5 format (UNITE DB)",
-                    "uuid": "a92dea0e-4bcc-4eb6-8052-cc897908e605"
-                },
-                {
-                    "label": "ITS taxonomic classifications using ITSoneDB",
-                    "output_name": "ITS taxonomic classifications using ITSoneDB",
-                    "uuid": "2aa27435-9a26-4f50-8d2a-9e07cfda66ba"
+                    "uuid": "39a4794a-5298-4206-b06d-c79b2fb4c423"
                 },
                 {
                     "label": "ITS taxonomic abundance pie charts (UNITE DB)",
                     "output_name": "ITS taxonomic abundance pie charts (UNITE DB)",
-                    "uuid": "f9c37e34-a124-4a1f-b9df-e834efbe0e53"
+                    "uuid": "167efccc-7370-40ef-b9c2-356c637259cd"
                 },
                 {
-                    "label": "ITS taxonomic classifications using UNITE DB",
-                    "output_name": "ITS taxonomic classifications using UNITE DB",
-                    "uuid": "384bb22d-6926-4833-89ed-1c9ec309aa7f"
-                },
-                {
-                    "label": "ITS taxonomic abundance pie charts (ITSoneDB)",
-                    "output_name": "ITS taxonomic abundance pie charts (ITSoneDB)",
-                    "uuid": "db0a8042-4964-4619-93e1-0d6a4ffdc5f1"
+                    "label": "ITS taxonomic classifications using ITSoneDB",
+                    "output_name": "ITS taxonomic classifications using ITSoneDB",
+                    "uuid": "22b09e00-6c88-4894-8000-d8ecebe51cb9"
                 },
                 {
                     "label": "ITS OTU tables in JSON format (ITSoneDB)",
                     "output_name": "ITS OTU tables in JSON format (ITSoneDB)",
-                    "uuid": "13e54088-7391-4c8c-9fde-2dd63080fafd"
+                    "uuid": "825fc92e-513e-4672-9b03-8a509b753189"
+                },
+                {
+                    "label": "ITS OTU tables in HDF5 format (UNITE DB)",
+                    "output_name": "ITS OTU tables in HDF5 format (UNITE DB)",
+                    "uuid": "a5342c91-63e9-4aa8-88ef-9ad9ddc0ac05"
+                },
+                {
+                    "label": "ITS OTU tables in JSON format (UNITE DB)",
+                    "output_name": "ITS OTU tables in JSON format (UNITE DB)",
+                    "uuid": "3e8e45f5-c8b9-4cc0-b759-d5911e4b0a1f"
                 },
                 {
                     "label": "ITS OTU tables (UNITE DB)",
                     "output_name": "ITS OTU tables (UNITE DB)",
-                    "uuid": "582f0478-2a6b-4158-bd78-8144fc3a47bc"
+                    "uuid": "ce1cc3a7-d9f1-43e9-9a29-bf323538f003"
+                },
+                {
+                    "label": "ITS FASTA files",
+                    "output_name": "ITS FASTA files",
+                    "uuid": "6d44ec4c-ddc1-4d8f-a4e6-e7da84fca0d0"
+                },
+                {
+                    "label": "ITS taxonomic abundance pie charts (ITSoneDB)",
+                    "output_name": "ITS taxonomic abundance pie charts (ITSoneDB)",
+                    "uuid": "624858b8-dde6-4d8e-894e-3a32732ce588"
+                },
+                {
+                    "label": "ITS OTU tables (ITSoneDB)",
+                    "output_name": "ITS OTU tables (ITSoneDB)",
+                    "uuid": "9cdce277-457d-4c19-823a-108876f42463"
+                },
+                {
+                    "label": "ITS taxonomic classifications using UNITE DB",
+                    "output_name": "ITS taxonomic classifications using UNITE DB",
+                    "uuid": "332b291c-1b05-4762-b021-47cb65ba7673"
                 }
             ]
         },
@@ -9783,14 +9889,14 @@
                 "name": "Map empty/not empty collection to boolean ",
                 "steps": {
                     "0": {
-                        "annotation": "Collection to map to boolean parameter.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 0,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Collection to map to boolean parameter.",
+                                "description": "",
                                 "name": "Input collection"
                             }
                         ],
@@ -9989,7 +10095,7 @@
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "04b6be05-c23d-45af-9510-af8c948db3b9",
+            "uuid": "8f17f7df-7c4d-4b0a-92f0-8f713bcd2615",
             "when": null,
             "workflow_outputs": []
         },
@@ -10027,14 +10133,14 @@
                 "name": "Map empty/not empty collection to boolean ",
                 "steps": {
                     "0": {
-                        "annotation": "Collection to map to boolean parameter.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 0,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Collection to map to boolean parameter.",
+                                "description": "",
                                 "name": "Input collection"
                             }
                         ],
@@ -10233,7 +10339,7 @@
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "cfba285b-8cbc-49b9-81fb-4045df5da94a",
+            "uuid": "4eb6087c-2417-429a-b946-a2b5fd1b84fe",
             "when": null,
             "workflow_outputs": []
         },
@@ -10271,14 +10377,14 @@
                 "name": "Map empty/not empty collection to boolean ",
                 "steps": {
                     "0": {
-                        "annotation": "Collection to map to boolean parameter.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 0,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Collection to map to boolean parameter.",
+                                "description": "",
                                 "name": "Input collection"
                             }
                         ],
@@ -10477,7 +10583,7 @@
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "2d700305-0a7f-42fd-8abe-70af6993966b",
+            "uuid": "c05d9a57-8319-46d2-91d8-26bc7d79cdf8",
             "when": null,
             "workflow_outputs": []
         },
@@ -10515,14 +10621,14 @@
                 "name": "Map empty/not empty collection to boolean ",
                 "steps": {
                     "0": {
-                        "annotation": "Collection to map to boolean parameter.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 0,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "Collection to map to boolean parameter.",
+                                "description": "",
                                 "name": "Input collection"
                             }
                         ],
@@ -10721,7 +10827,7 @@
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "f63abbc2-d1c8-48fe-8e9f-99a70e9b541b",
+            "uuid": "0bfd394f-8dc6-4084-b3bf-bb05a534b0e2",
             "when": null,
             "workflow_outputs": []
         },
@@ -10810,14 +10916,14 @@
                 },
                 "steps": {
                     "0": {
-                        "annotation": "OTU tables.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 0,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "OTU tables.",
+                                "description": "",
                                 "name": "OTU tables"
                             }
                         ],
@@ -10837,14 +10943,14 @@
                         "workflow_outputs": []
                     },
                     "1": {
-                        "annotation": "specifies the name of taxonomic summary file.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 1,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "specifies the name of taxonomic summary file.",
+                                "description": "",
                                 "name": "Taxonomic abundance summary table name"
                             }
                         ],
@@ -10870,14 +10976,14 @@
                         ]
                     },
                     "2": {
-                        "annotation": "specifies the name of taxonomic summary file, for phylum level.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 2,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "specifies the name of taxonomic summary file, for phylum level.",
+                                "description": "",
                                 "name": "Phylum level taxonomic abundance summary table name"
                             }
                         ],
@@ -11373,18 +11479,28 @@
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "4ddff127-ed1a-4eab-bcfe-8715f2284618",
+            "uuid": "05472564-a4fe-4e08-a669-0e0c8f98669e",
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
-                    "label": "SSU taxonomic abundance summary table",
-                    "output_name": "Taxonomic abundance summary table",
-                    "uuid": "4efd5e53-32f9-4e1b-b850-ed9c6e96cbb3"
-                },
-                {
                     "label": "SSU phylum level taxonomic abundance summary table",
                     "output_name": "phylum level taxonomic abundance summary table",
-                    "uuid": "b8be6baa-41d2-4652-87dc-f1fb9abc07ee"
+                    "uuid": "627a3fc8-2a61-4096-892d-fcebc1a788b4"
+                },
+                {
+                    "label": null,
+                    "output_name": "2:output",
+                    "uuid": "9241baa9-2cad-4cb3-87a1-7218c6130b61"
+                },
+                {
+                    "label": null,
+                    "output_name": "1:output",
+                    "uuid": "c7042e1f-7c62-42ec-9abc-1e63350bb668"
+                },
+                {
+                    "label": "SSU taxonomic abundance summary table",
+                    "output_name": "Taxonomic abundance summary table",
+                    "uuid": "8b025e65-0071-4994-ab77-2c10252ba471"
                 }
             ]
         },
@@ -11473,14 +11589,14 @@
                 },
                 "steps": {
                     "0": {
-                        "annotation": "OTU tables.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 0,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "OTU tables.",
+                                "description": "",
                                 "name": "OTU tables"
                             }
                         ],
@@ -11500,14 +11616,14 @@
                         "workflow_outputs": []
                     },
                     "1": {
-                        "annotation": "specifies the name of taxonomic summary file.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 1,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "specifies the name of taxonomic summary file.",
+                                "description": "",
                                 "name": "Taxonomic abundance summary table name"
                             }
                         ],
@@ -11533,14 +11649,14 @@
                         ]
                     },
                     "2": {
-                        "annotation": "specifies the name of taxonomic summary file, for phylum level.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 2,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "specifies the name of taxonomic summary file, for phylum level.",
+                                "description": "",
                                 "name": "Phylum level taxonomic abundance summary table name"
                             }
                         ],
@@ -12036,18 +12152,28 @@
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "048da8ae-fbf7-4afe-ad77-85428df7b486",
+            "uuid": "70627541-d2f1-4085-99ee-a4f6fb225e83",
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
                     "label": "LSU phylum level taxonomic abundance summary table",
                     "output_name": "phylum level taxonomic abundance summary table",
-                    "uuid": "e7425613-0d16-47f5-86c9-b881908ca21e"
+                    "uuid": "11d82afa-e60a-4da2-9745-39b19e3d653a"
+                },
+                {
+                    "label": null,
+                    "output_name": "1:output",
+                    "uuid": "07d11d14-af41-4f7d-a1de-5d0b3de08026"
+                },
+                {
+                    "label": null,
+                    "output_name": "2:output",
+                    "uuid": "a328c834-0b0e-4395-9d04-f9f65f6c61a1"
                 },
                 {
                     "label": "LSU taxonomic abundance summary table",
                     "output_name": "Taxonomic abundance summary table",
-                    "uuid": "203f7e9c-346a-44b3-82fb-c00beab8049f"
+                    "uuid": "99c9ae4c-f816-4569-9a44-7884c9c5550e"
                 }
             ]
         },
@@ -12141,14 +12267,14 @@
                 },
                 "steps": {
                     "0": {
-                        "annotation": "OTU tables.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 0,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "OTU tables.",
+                                "description": "",
                                 "name": "OTU tables"
                             }
                         ],
@@ -12168,14 +12294,14 @@
                         "workflow_outputs": []
                     },
                     "1": {
-                        "annotation": "specifies the name of taxonomic summary file.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 1,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "specifies the name of taxonomic summary file.",
+                                "description": "",
                                 "name": "Taxonomic abundance summary table name"
                             }
                         ],
@@ -12201,14 +12327,14 @@
                         ]
                     },
                     "2": {
-                        "annotation": "specifies the name of taxonomic summary file, for phylum level.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 2,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "specifies the name of taxonomic summary file, for phylum level.",
+                                "description": "",
                                 "name": "Phylum level taxonomic abundance summary table name"
                             }
                         ],
@@ -12704,18 +12830,28 @@
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "7c750ebc-941e-4173-9684-23f98f9ec758",
+            "uuid": "022b83bf-0c26-44dd-9069-7044d507b201",
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
+                    "label": null,
+                    "output_name": "1:output",
+                    "uuid": "d9722daf-101c-4912-b561-ae3c583e9a75"
+                },
+                {
+                    "label": null,
+                    "output_name": "2:output",
+                    "uuid": "9824ef28-249f-4f08-9ed4-4ab60599cfcb"
+                },
+                {
                     "label": "ITSoneDB taxonomic abundance summary table",
                     "output_name": "Taxonomic abundance summary table",
-                    "uuid": "05613f35-22d4-4a32-8ddc-69d6a7281470"
+                    "uuid": "5b61f997-1cd1-496b-b0fd-d3a98e130e66"
                 },
                 {
                     "label": "ITSoneDB phylum level taxonomic abundance summary table",
                     "output_name": "phylum level taxonomic abundance summary table",
-                    "uuid": "82dce358-6820-47c4-a1a1-6e02506e66be"
+                    "uuid": "f3080e71-83a2-4cad-9ddf-9b0f806af898"
                 }
             ]
         },
@@ -12809,14 +12945,14 @@
                 },
                 "steps": {
                     "0": {
-                        "annotation": "OTU tables.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 0,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "OTU tables.",
+                                "description": "",
                                 "name": "OTU tables"
                             }
                         ],
@@ -12836,14 +12972,14 @@
                         "workflow_outputs": []
                     },
                     "1": {
-                        "annotation": "specifies the name of taxonomic summary file.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 1,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "specifies the name of taxonomic summary file.",
+                                "description": "",
                                 "name": "Taxonomic abundance summary table name"
                             }
                         ],
@@ -12869,14 +13005,14 @@
                         ]
                     },
                     "2": {
-                        "annotation": "specifies the name of taxonomic summary file, for phylum level.",
+                        "annotation": "",
                         "content_id": null,
                         "errors": null,
                         "id": 2,
                         "input_connections": {},
                         "inputs": [
                             {
-                                "description": "specifies the name of taxonomic summary file, for phylum level.",
+                                "description": "",
                                 "name": "Phylum level taxonomic abundance summary table name"
                             }
                         ],
@@ -13372,18 +13508,28 @@
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "a1fbce13-d09f-4106-be36-b2034451af81",
+            "uuid": "92ebccf3-7a53-4c86-93c9-33b8d65d3814",
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
-                    "label": "ITS UNITE DB taxonomic abundance summary table",
-                    "output_name": "Taxonomic abundance summary table",
-                    "uuid": "a17b7e83-6e97-4923-a8ea-542838729f5d"
-                },
-                {
                     "label": "ITS UNITE DB phylum level taxonomic abundance summary table",
                     "output_name": "phylum level taxonomic abundance summary table",
-                    "uuid": "1813a260-c36c-4b3d-862a-fb244ce8f4a9"
+                    "uuid": "5d0937ff-5bb2-458d-9cf6-85096119c089"
+                },
+                {
+                    "label": "ITS UNITE DB taxonomic abundance summary table",
+                    "output_name": "Taxonomic abundance summary table",
+                    "uuid": "84ee23b4-9c6c-4ee2-b71a-6412be55c1e3"
+                },
+                {
+                    "label": null,
+                    "output_name": "2:output",
+                    "uuid": "f4da6512-f386-4e2a-be5a-d16cfcf78849"
+                },
+                {
+                    "label": null,
+                    "output_name": "1:output",
+                    "uuid": "4f43c991-f0e7-446b-a29c-cc2762f75334"
                 }
             ]
         }
@@ -13394,6 +13540,6 @@
         "amplicon",
         "name:microgalaxy"
     ],
-    "uuid": "5d06fcca-ca23-4a0b-9361-89812a67f9e9",
-    "version": 155
+    "uuid": "fad227f2-8b1e-4782-a7a5-a1743b9643bf",
+    "version": 19
 }

--- a/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-paired-end/CHANGELOG.md
+++ b/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-paired-end/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3] - 2025-05-05
+
+- `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.1+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy3`
+
 ## [0.2] - 2025-03-10
 
 - `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy3` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4`

--- a/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-paired-end/mgnify-amplicon-pipeline-v5-quality-control-paired-end.ga
+++ b/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-paired-end/mgnify-amplicon-pipeline-v5-quality-control-paired-end.ga
@@ -24,7 +24,7 @@
     "format-version": "0.1",
     "license": "Apache-2.0",
     "name": "MGnify's amplicon pipeline v5.0 - Quality control PE",
-    "release": "0.2",
+    "release": "0.3",
     "report": {
         "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
     },
@@ -52,7 +52,7 @@
             "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list:paired\"}",
             "tool_version": null,
             "type": "data_collection_input",
-            "uuid": "4a419fd7-0b26-4f9d-83ec-2471f862c610",
+            "uuid": "99f591e7-8ec2-4848-9344-17bfaeb421b5",
             "when": null,
             "workflow_outputs": []
         },
@@ -79,7 +79,7 @@
             "tool_state": "{\"default\": false, \"validators\": [], \"parameter_type\": \"boolean\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "81367449-c0ca-41be-b69d-5bf1568e0361",
+            "uuid": "1a531eb6-3ffe-4e6f-93ec-630c7d216198",
             "when": null,
             "workflow_outputs": []
         },
@@ -106,7 +106,7 @@
             "tool_state": "{\"default\": 20, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "cb8a7bac-c007-45c6-814b-9aacae0e37b3",
+            "uuid": "0a062661-76e5-4c11-b2ad-58cf1e82af13",
             "when": null,
             "workflow_outputs": []
         },
@@ -133,7 +133,7 @@
             "tool_state": "{\"default\": 20, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "26ed5910-22cf-4a8e-a144-edbb8d6b1d50",
+            "uuid": "f9030514-9701-42e3-9c05-f11e40bf8c7d",
             "when": null,
             "workflow_outputs": []
         },
@@ -160,7 +160,7 @@
             "tool_state": "{\"default\": 70, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "6521e9f3-6d1b-4e95-8934-3345f858bcf8",
+            "uuid": "6531b15a-2309-44fa-a65f-7455de1666f9",
             "when": null,
             "workflow_outputs": []
         },
@@ -187,7 +187,7 @@
             "tool_state": "{\"default\": 4, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "1b2652b0-235b-4120-9c82-e4d3210c9d2f",
+            "uuid": "62d23264-1b3a-4a55-b8e7-898d6cb0499a",
             "when": null,
             "workflow_outputs": []
         },
@@ -214,7 +214,7 @@
             "tool_state": "{\"default\": 15, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "53e87ca4-6745-4835-b25f-878705737f0d",
+            "uuid": "8139e839-01a8-4e63-97b5-692058edd3ad",
             "when": null,
             "workflow_outputs": []
         },
@@ -241,7 +241,7 @@
             "tool_state": "{\"default\": 3, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "4e1cfaad-b067-4bf3-a6b8-33d3fd826285",
+            "uuid": "e0283550-eacd-438c-a740-529b37f2c8a8",
             "when": null,
             "workflow_outputs": []
         },
@@ -268,7 +268,7 @@
             "tool_state": "{\"default\": 3, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "d48c0437-1ab6-4fd4-8dfa-29dd056acaec",
+            "uuid": "ede57856-5274-4a2b-b365-3d94c7b983dd",
             "when": null,
             "workflow_outputs": []
         },
@@ -295,7 +295,7 @@
             "tool_state": "{\"default\": 100, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "2957cfb6-b542-4354-b94f-fd171df4c9b1",
+            "uuid": "f5859877-5a79-49bb-a4d2-8fbb0c984862",
             "when": null,
             "workflow_outputs": []
         },
@@ -322,7 +322,7 @@
             "tool_state": "{\"default\": 100, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "c898eada-b136-40bf-a78d-240b8d02c660",
+            "uuid": "2da65b33-bdaf-4bb7-bb2d-0caa7f51eac3",
             "when": null,
             "workflow_outputs": []
         },
@@ -349,13 +349,13 @@
             "tool_state": "{\"default\": 10, \"validators\": [], \"parameter_type\": \"integer\", \"optional\": true}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "d8341e6e-1401-48ef-ac1a-68c98309d0e1",
+            "uuid": "42990f60-a6ea-4808-9e5c-f30e8a9a74c7",
             "when": null,
             "workflow_outputs": []
         },
         "12": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.1+galaxy0",
             "errors": null,
             "id": 12,
             "input_connections": {
@@ -404,20 +404,36 @@
             ],
             "position": {
                 "left": 331.5,
-                "top": 0.0
+                "top": 0
             },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4",
+            "post_job_actions": {
+                "HideDatasetActionoutput_paired_coll": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_paired_coll"
+                },
+                "HideDatasetActionreport_html": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "report_html"
+                },
+                "HideDatasetActionreport_json": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "report_json"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.1+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "10678d49d39e",
+                "changeset_revision": "25c59c0ceb55",
                 "name": "fastp",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": {\"__class__\": \"ConnectedValue\"}, \"unqualified_percent_limit\": {\"__class__\": \"ConnectedValue\"}, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": {\"__class__\": \"ConnectedValue\"}, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": null, \"umi_len\": null, \"umi_prefix\": null}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": {\"__class__\": \"ConnectedValue\"}}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 1, \"paired_input\": {\"__class__\": \"RuntimeValue\"}, \"merge_reads\": {\"merge\": \"\", \"__current_case__\": 1}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": null, \"adapter_sequence2\": null, \"detect_adapter_for_pe\": false}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.24.0+galaxy4",
+            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": {\"__class__\": \"ConnectedValue\"}, \"unqualified_percent_limit\": {\"__class__\": \"ConnectedValue\"}, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": {\"__class__\": \"ConnectedValue\"}, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": null, \"umi_len\": null, \"umi_prefix\": null}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": {\"__class__\": \"ConnectedValue\"}}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 1, \"paired_input\": {\"__class__\": \"ConnectedValue\"}, \"merge_reads\": {\"merge\": \"\", \"__current_case__\": 1}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": null, \"adapter_sequence2\": null, \"detect_adapter_for_pe\": false}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.24.1+galaxy0",
             "type": "tool",
-            "uuid": "9b7f1d2d-d39f-407d-a709-a5095fca62c2",
+            "uuid": "f3f635e6-b92d-482b-83ff-f0500ce0bbb6",
             "when": null,
             "workflow_outputs": []
         },
@@ -479,7 +495,7 @@
             "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "f151e04c-8502-45b7-8503-38838efe39ee",
+            "uuid": "b2634940-c083-497c-a78a-87a0e8ca7d47",
             "when": null,
             "workflow_outputs": []
         },
@@ -553,7 +569,7 @@
             "tool_state": "{\"general_options\": {\"first_read_discarded\": null, \"second_read_discarded\": null, \"phred64\": false, \"quality_cutoff\": \"13\", \"min_length\": \"30\"}, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"input2\": {\"__class__\": \"ConnectedValue\"}, \"merge_reads\": true, \"merging_options\": {\"maximum_quality_score\": null, \"print_overhang\": false, \"min_base_pair_overlap\": \"15\", \"max_mismatch_fraction\": \"0.02\", \"min_match_fraction\": \"0.9\"}, \"trimming_options\": {\"adapter_a\": \"AGATCGGAAGAGCGGTTCAG\", \"adapter_b\": \"AGATCGGAAGAGCGTCGTGT\", \"adapter_overlap\": \"10\", \"max_mismatch_fraction\": \"0.02\", \"min_match_fraction\": \"0.87\", \"adapter_bandwidth\": \"50\", \"gap_open\": \"8\", \"gap_extend\": \"2\", \"gap_end\": \"2\", \"local_alignment_score\": \"26\", \"read_alignment_bandwidth\": \"50\", \"read_alignment_gap_open\": \"26\", \"read_alignment_gap_extend\": \"9\", \"read_alignment_gap_end\": \"5\", \"read_alignment_max_gap_fraction\": \"0.125\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.2+galaxy0",
             "type": "tool",
-            "uuid": "670c6abb-2a49-4a77-9cad-eaae9ebfe74e",
+            "uuid": "01eb7691-59b3-4c13-a1ed-baaf12a3cf5e",
             "when": null,
             "workflow_outputs": []
         },
@@ -623,7 +639,7 @@
             "tool_state": "{\"illuminaclip\": {\"do_illuminaclip\": \"no\", \"__current_case__\": 1}, \"operations\": [{\"__index__\": 0, \"operation\": {\"name\": \"SLIDINGWINDOW\", \"__current_case__\": 0, \"window_size\": {\"__class__\": \"ConnectedValue\"}, \"required_quality\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"operation\": {\"name\": \"LEADING\", \"__current_case__\": 2, \"leading\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"operation\": {\"name\": \"TRAILING\", \"__current_case__\": 3, \"trailing\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 3, \"operation\": {\"name\": \"MINLEN\", \"__current_case__\": 1, \"minlen\": {\"__class__\": \"ConnectedValue\"}}}], \"output_err\": false, \"output_logs\": false, \"quality_score\": \"-phred33\", \"readtype\": {\"single_or_paired\": \"se\", \"__current_case__\": 0, \"fastq_in\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.39+galaxy2",
             "type": "tool",
-            "uuid": "c2079512-2019-41aa-beea-d1b597e59b42",
+            "uuid": "b8e5e4d7-b01e-452d-bc88-7c3f95a9a817",
             "when": null,
             "workflow_outputs": []
         },
@@ -697,7 +713,7 @@
             "tool_state": "{\"adapters\": {\"__class__\": \"RuntimeValue\"}, \"contaminants\": {\"__class__\": \"RuntimeValue\"}, \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"kmers\": \"7\", \"limits\": {\"__class__\": \"RuntimeValue\"}, \"min_length\": null, \"nogroup\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.74+galaxy1",
             "type": "tool",
-            "uuid": "c48ed7ed-5a1d-40e8-8423-434578e91568",
+            "uuid": "fd1b2b83-d619-47b5-bb3e-89fba59ab1c7",
             "when": null,
             "workflow_outputs": []
         },
@@ -746,7 +762,7 @@
             "tool_state": "{\"fastq_filters\": [], \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"max_num_deviants\": \"0\", \"max_quality\": \"0.0\", \"max_size\": \"0\", \"min_quality\": \"0.0\", \"min_size\": {\"__class__\": \"ConnectedValue\"}, \"paired_end\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.5+galaxy2",
             "type": "tool",
-            "uuid": "a12d9770-de9e-45cf-8d18-2be9cc7873ed",
+            "uuid": "21e6a7b9-7dcd-4f71-a2fc-7437c1f8d6a7",
             "when": null,
             "workflow_outputs": []
         },
@@ -820,13 +836,13 @@
             "tool_state": "{\"adapters\": {\"__class__\": \"RuntimeValue\"}, \"contaminants\": {\"__class__\": \"RuntimeValue\"}, \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"kmers\": \"7\", \"limits\": {\"__class__\": \"RuntimeValue\"}, \"min_length\": null, \"nogroup\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.74+galaxy1",
             "type": "tool",
-            "uuid": "01bb817a-6e2a-4a81-b5a7-ec42f0355b3e",
+            "uuid": "e7cfb998-3b8a-488f-ace2-608f95ceaf5c",
             "when": null,
             "workflow_outputs": []
         },
         "19": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
             "errors": null,
             "id": 19,
             "input_connections": {
@@ -855,17 +871,17 @@
                     "output_name": "outfile"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "86755160afbf",
+                "changeset_revision": "6073bb457ec0",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"\\\\t(.*?)\\\\.gz\", \"replace_pattern\": \"\\\\t$1_initial_reads\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "9.3+galaxy1",
+            "tool_version": "9.5+galaxy0",
             "type": "tool",
-            "uuid": "680b293b-0b1e-4b95-9dc9-233354651b61",
+            "uuid": "68b63850-2c14-4d03-91e3-8ab8ff29a024",
             "when": null,
             "workflow_outputs": []
         },
@@ -928,7 +944,7 @@
             "tool_state": "{\"filter_treatments\": {\"apply_filter_treatments\": \"true\", \"__current_case__\": 0, \"length_filter_treatments\": {\"apply_length_filter_treatments\": \"false\", \"__current_case__\": 1}, \"quality_filter_treatments\": {\"apply_quality_filter_treatments\": \"false\", \"__current_case__\": 1}, \"base_content_filter_treatments\": {\"apply_base_content_filter_treatments\": \"true\", \"__current_case__\": 0, \"GC_perc_content_filter_treatments\": {\"apply_GC_perc_content_filter_treatments\": \"false\", \"__current_case__\": 1}, \"N_number_content_filter_treatments\": {\"apply_N_number_content_filter_treatments\": \"false\", \"__current_case__\": 1}, \"N_percentage_content_filter_treatments\": {\"apply_N_percentage_content_filter_treatments\": \"true\", \"__current_case__\": 0, \"N_percentage_content_filter_treatment_value\": {\"__class__\": \"ConnectedValue\"}}, \"apply_other_base_content_filter_treatments\": true}, \"complexity_filter_treatments\": {\"apply_complexity_filter_treatments\": \"false\", \"__current_case__\": 1}}, \"seq_type\": {\"seq_type_opt\": \"single\", \"__current_case__\": 0, \"input_singles\": {\"__class__\": \"ConnectedValue\"}}, \"trimming_treatments\": {\"apply_trimming_treatments\": \"false\", \"__current_case__\": 1}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.20.4+galaxy2",
             "type": "tool",
-            "uuid": "d65b0e38-5f52-425a-a3c3-9cb126ead9f7",
+            "uuid": "f9b16007-ffaf-491e-aad7-7e6e9b7ade1d",
             "when": null,
             "workflow_outputs": []
         },
@@ -1002,13 +1018,13 @@
             "tool_state": "{\"adapters\": {\"__class__\": \"RuntimeValue\"}, \"contaminants\": {\"__class__\": \"RuntimeValue\"}, \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"kmers\": \"7\", \"limits\": {\"__class__\": \"RuntimeValue\"}, \"min_length\": null, \"nogroup\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.74+galaxy1",
             "type": "tool",
-            "uuid": "f291100e-19ae-4baf-824b-16244df1e9f3",
+            "uuid": "c7287ff8-04bb-4618-9cb8-dd4a042691cc",
             "when": null,
             "workflow_outputs": []
         },
         "22": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
             "errors": null,
             "id": 22,
             "input_connections": {
@@ -1037,17 +1053,17 @@
                     "output_name": "outfile"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "86755160afbf",
+                "changeset_revision": "6073bb457ec0",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"\\\\t(.*?)\\\\.gz\", \"replace_pattern\": \"\\\\t$1_trimming\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "9.3+galaxy1",
+            "tool_version": "9.5+galaxy0",
             "type": "tool",
-            "uuid": "2bb5af38-51bd-4828-bc34-7b4c7273c9e2",
+            "uuid": "4841a66e-66ee-4f7b-b35e-8bb1023bdc40",
             "when": null,
             "workflow_outputs": []
         },
@@ -1092,7 +1108,7 @@
             "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.5+galaxy2",
             "type": "tool",
-            "uuid": "7b5c5aeb-0201-4378-984c-ded57d114157",
+            "uuid": "ffa58ffe-3b41-4b98-a9cf-401d04b3746e",
             "when": null,
             "workflow_outputs": []
         },
@@ -1166,13 +1182,13 @@
             "tool_state": "{\"adapters\": {\"__class__\": \"RuntimeValue\"}, \"contaminants\": {\"__class__\": \"RuntimeValue\"}, \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"kmers\": \"7\", \"limits\": {\"__class__\": \"RuntimeValue\"}, \"min_length\": null, \"nogroup\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.74+galaxy1",
             "type": "tool",
-            "uuid": "9afd3a4f-fdae-4d9d-9afc-5990276dc8c5",
+            "uuid": "be905a37-b18a-446c-a6d0-62736accf241",
             "when": null,
             "workflow_outputs": []
         },
         "25": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
             "errors": null,
             "id": 25,
             "input_connections": {
@@ -1201,17 +1217,17 @@
                     "output_name": "outfile"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "86755160afbf",
+                "changeset_revision": "6073bb457ec0",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"\\\\t(.*?)\\\\.gz\", \"replace_pattern\": \"\\\\t$1_length_filtering\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "9.3+galaxy1",
+            "tool_version": "9.5+galaxy0",
             "type": "tool",
-            "uuid": "8c5dc662-6bcc-4772-bc0e-d0b747113ef3",
+            "uuid": "d04f1047-4ec1-46e0-ad0f-99d91c54ea79",
             "when": null,
             "workflow_outputs": []
         },
@@ -1250,7 +1266,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_formatter/cshl_fasta_formatter/1.0.1+galaxy2",
             "tool_shed_repository": {
-                "changeset_revision": "516b97a23d7e",
+                "changeset_revision": "e773f1eb16cf",
                 "name": "fasta_formatter",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1258,19 +1274,19 @@
             "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"width\": \"60\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.1+galaxy2",
             "type": "tool",
-            "uuid": "b899fa36-d2c9-4cbe-880a-9984f2b48462",
+            "uuid": "d0ad7bad-5049-48b5-9e06-4d0c5a37785e",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Paired-end post quality control FASTA files",
                     "output_name": "output",
-                    "uuid": "ab65a776-f7bb-4495-8eeb-12079046ae1b"
+                    "uuid": "05008f5e-c45d-4346-8e85-ec2fb5877a95"
                 }
             ]
         },
         "27": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
             "errors": null,
             "id": 27,
             "input_connections": {
@@ -1299,23 +1315,23 @@
                     "output_name": "outfile"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "86755160afbf",
+                "changeset_revision": "6073bb457ec0",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"\\\\t(.*?)\\\\.gz\", \"replace_pattern\": \"\\\\t$1_ambiguous_base_filtering\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "9.3+galaxy1",
+            "tool_version": "9.5+galaxy0",
             "type": "tool",
-            "uuid": "aacb9221-34de-46f7-91ec-ff796e98db10",
+            "uuid": "177b016a-0565-4f33-b3d7-10324f42c939",
             "when": null,
             "workflow_outputs": []
         },
         "28": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy3",
             "errors": null,
             "id": 28,
             "input_connections": {
@@ -1336,7 +1352,12 @@
                     "output_name": "outfile"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool MultiQC",
+                    "name": "image_content_input"
+                }
+            ],
             "label": null,
             "name": "MultiQC",
             "outputs": [
@@ -1369,28 +1390,28 @@
                     "output_name": "stats"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "a7e081ceb76a",
+                "changeset_revision": "31c42a2c02d3",
                 "name": "multiqc",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastqc\", \"__current_case__\": 8, \"output\": [{\"__index__\": 0, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 2, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 3, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}]}}], \"title\": \"\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.27+galaxy0",
+            "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"image_content_input\": {\"__class__\": \"RuntimeValue\"}, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastqc\", \"__current_case__\": 8, \"output\": [{\"__index__\": 0, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 2, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 3, \"type\": \"data\", \"input\": {\"__class__\": \"ConnectedValue\"}}]}}], \"title\": \"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.27+galaxy3",
             "type": "tool",
-            "uuid": "e04ee136-c52f-4d7e-85c5-3b3ed78b0cce",
+            "uuid": "1f1d05a9-ab77-46d0-832c-57262cd45e48",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Paired-end MultiQC statistics",
-                    "output_name": "stats",
-                    "uuid": "fc6047b2-201d-4e77-ab0d-9c8107897088"
-                },
-                {
                     "label": "Paired-end MultiQC report",
                     "output_name": "html_report",
-                    "uuid": "1d870a5b-942b-4f61-b8fd-a68b121b7f8c"
+                    "uuid": "82fc1b1a-80b4-4abf-8150-cca1d82337bb"
+                },
+                {
+                    "label": "Paired-end MultiQC statistics",
+                    "output_name": "stats",
+                    "uuid": "6b214cd1-fd0b-4d57-89f4-5758e4ad0c32"
                 }
             ]
         }
@@ -1401,6 +1422,6 @@
         "metagenomics",
         "name:microgalaxy"
     ],
-    "uuid": "3af45a28-126d-4c9d-9948-cabfe43566f3",
-    "version": 21
+    "uuid": "467d4418-a41e-44eb-9959-7c4a242d2082",
+    "version": 4
 }


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [x] License permits unrestricted use (educational + commercial)
* [x] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file


**Updates**:
- `toolshed.g2.bx.psu.edu/repos/iuc/fastq_dl/fastq_dl/3.0.0+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/fastq_dl/fastq_dl/3.0.1+galaxy0`
- `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.3+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy0`
- `toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy3`
- `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.0+galaxy4` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.1+galaxy0`
- `CONVERTER_gz_to_uncompressed` output format was updated to `fastqsanger`
- `CONVERTER_uncompressed_to_gz` output format was updated to `fastqsanger.gz`
