### PR TITLE
Release v0.2 of influenza workflow

### DIFF
--- a/workflows/virology/influenza-isolates-consensus-and-subtyping/.dockstore.yml
+++ b/workflows/virology/influenza-isolates-consensus-and-subtyping/.dockstore.yml
@@ -11,3 +11,5 @@ workflows:
     orcid: 0000-0001-6897-1215
   - name: Wolfgang Maier
     orcid: 0000-0002-9464-6640
+  - name: Aaron Kolbecher
+    orcid: 0009-0000-8844-2812

--- a/workflows/virology/influenza-isolates-consensus-and-subtyping/CHANGELOG.md
+++ b/workflows/virology/influenza-isolates-consensus-and-subtyping/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## [0.2] - 2025-05-02
+
+### Changed
+
+Aaron Kolbecher, in the course of his Master thesis, discovered several
+edge-cases in which the previous version of the workflow would fail. The
+corresponding fixes listed below make the workflow much more robust and ready
+for use in high-throughput scenarioss.
+
+- Added processing logic for handling diverse VAPOR failures.
+
+- Improved subtyping report to handle cases of undetermined HA and/or NA subtypes.
+
+  The subtyping report will now contain H? and/or N? for unresolved subtypes.
+
+- Added logic for skipping multiple-sequence alignment of a genome segment if a
+  consensus sequence for that segment could be generated for only a single
+  sample (instead of causing a MAFFT error).
+
+- Added logic for skipping phylogenetic analysis with IQ-Tree for segments for
+  which fewer than three samples yielded a consensus sequence (instead of
+  causing an IQ-Tree error).
+
+  Note: IQ-Tree can still fail if a consensus sequence consists of Ns only.
+
+- No longer assume eight genome segments, but autodetect the number of segments
+  from the reference collection.
+
+  This makes it simpler to adapt the workflow to influenza species with seven
+  instead of eight segments, and makes it usable with partial reference
+  collections, for example if the purpose is to generate consensus sequences
+  only for certain segments of interest.
+
+- Added Aaron as a co-author of the workflow.
+
+- Changed license to AGPL-3.0-or-later.
+
+### Updated tools
+
+- `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.4+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.1+galaxy0`.
+- `toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.18` was updated to `toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.19`.
+- `toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.15.1+galaxy2` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.20+galaxy3`.
+- `toolshed.g2.bx.psu.edu/repos/iuc/qualimap_bamqc/qualimap_bamqc/2.2.2d+galaxy3` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/qualimap_bamqc/qualimap_bamqc/2.3+galaxy0`.
+- `toolshed.g2.bx.psu.edu/repos/iuc/ivar_consensus/ivar_consensus/1.4.3+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/ivar_consensus/ivar_consensus/1.4.4+galaxy0`.
+- `toolshed.g2.bx.psu.edu/repos/rnateam/mafft/rbc_mafft/7.520+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/rnateam/mafft/rbc_mafft/7.526+galaxy1`.
+- `toolshed.g2.bx.psu.edu/repos/iuc/snipit/snipit/1.2+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/snipit/snipit/1.6+galaxy0`.
+- `toolshed.g2.bx.psu.edu/repos/iuc/iqtree/iqtree/2.3.3+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/iqtree/iqtree/2.4.0+galaxy0`.
+- `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0`.
+
 ## [0.1] - 2025-01-09
 
 First release.

--- a/workflows/virology/influenza-isolates-consensus-and-subtyping/CHANGELOG.md
+++ b/workflows/virology/influenza-isolates-consensus-and-subtyping/CHANGELOG.md
@@ -7,9 +7,12 @@
 Aaron Kolbecher, in the course of his Master thesis, discovered several
 edge-cases in which the previous version of the workflow would fail. The
 corresponding fixes listed below make the workflow much more robust and ready
-for use in high-throughput scenarioss.
+for use in high-throughput scenarios.
 
 - Added processing logic for handling diverse VAPOR failures.
+
+  Note: As a limitation of the new logic elements in the "References per segment"
+  collection can no longer contain colons (`:`) in their identifiers.
 
 - Improved subtyping report to handle cases of undetermined HA and/or NA subtypes.
 

--- a/workflows/virology/influenza-isolates-consensus-and-subtyping/README.md
+++ b/workflows/virology/influenza-isolates-consensus-and-subtyping/README.md
@@ -30,7 +30,9 @@ The workflow provides a subtyping report, the consensus sequences arranged by ge
 
   **NOTE 2**: Sequences containing the ambiguity symbol N will be ignored by the workflow entirely.
 
-  **NOTE 3**: A well-formatted collection of Influenza A reference sequences suitable for most analysis needs is linked from the "Data resources" section of the page: https://virology.usegalaxy.eu/published/page?id=a04ab8d6ecb698fa.
+  **NOTE 3**: Datasets in this collection must not use colons (`:`) as part of their names.
+
+  **NOTE 4**: A well-formatted collection of Influenza A reference sequences suitable for most analysis needs is linked from the "Data resources" section of the page: https://virology.usegalaxy.eu/published/page?id=a04ab8d6ecb698fa.
 
 ## Outputs:
 

--- a/workflows/virology/influenza-isolates-consensus-and-subtyping/README.md
+++ b/workflows/virology/influenza-isolates-consensus-and-subtyping/README.md
@@ -1,6 +1,6 @@
 # Subtyping and consensus sequence generation for batches of Influenza A isolates
 
-This workflow performs subtyping (with respect to the HA and NA genes) and consensus sequence generation for batches of Illumina PE sequenced Influenza A isolates. It overcomes Influenza genome variability by compiling the best possible reference for read mapping from a collection of reference sequences for each viral genome segment.
+This workflow performs subtyping (with respect to the HA and NA genes) and consensus sequence generation for batches of Illumina PE sequenced Influenza isolates. It overcomes Influenza genome variability by compiling the best possible reference for read mapping from a collection of reference sequences for each viral genome segment. The workflow has been tested for Influenza A isolates only but should also work with other types if a suitable collection of per-segment reference sequences (see "Input datasets" below) is provided.
 
 It uses:
 - **VAPOR** for identifying, from a collection of reference sequences of each of the eight viral genome segments, the individual segment sequences that match the sequencing data for each sample most closely
@@ -15,7 +15,7 @@ The workflow provides a subtyping report, the consensus sequences arranged by ge
 ## Input datasets
 
 - **Sequenced paired-end data**: a list of pairs of sequencing datasets, one fw-/rv-reads pair per sequenced isolate
-- **References per segment collection**: this must be provided as a list of 8 FASTA datasets, one for each Influenza genome segment. Each of these datasets should contain all reference sequences of the corresponding segment that you wish to use in the analysis.
+- **References per segment collection**: this must be provided as a list of FASTA datasets, one for each Influenza genome segment to analyze. Each of these datasets should contain all reference sequences of the corresponding segment that you wish to use in the analysis.
 
   **NOTE 1**: For subtyping to work correctly *all* FASTA sequence title lines in the input need to follow the scheme (note the use of both `|` and `/`):
 
@@ -30,21 +30,21 @@ The workflow provides a subtyping report, the consensus sequences arranged by ge
 
   **NOTE 2**: Sequences containing the ambiguity symbol N will be ignored by the workflow entirely.
 
-  **NOTE 3**: A well-formatted collection of reference sequences suitable for most analysis needs is linked from the "Data resources" section of the page: https://virology.usegalaxy.eu/published/page?id=a04ab8d6ecb698fa.
+  **NOTE 3**: A well-formatted collection of Influenza A reference sequences suitable for most analysis needs is linked from the "Data resources" section of the page: https://virology.usegalaxy.eu/published/page?id=a04ab8d6ecb698fa.
 
 ## Outputs:
 
-- **Vapor - closest references**: a nested collection listing, for each sample and segment, the up to 500 best matching reference sequences according to VAPOR; inspect this collection if you are curious how many good matches to your data there were in the reference collection; useful for debugging, for example, if generated consensus sequences contain unresolved bases (Ns)
-- **Subtyping results**: a table listing one sample and its detected subtype (with respect to the HA and NA segments) per row
+- **successful VAPOR runs - closest references**: a nested collection listing, for each sample and segment, the up to 500 best matching reference sequences according to VAPOR; inspect this collection if you are curious how many good matches to your data there were in the reference collection; useful for debugging, for example, if generated consensus sequences contain unresolved bases (Ns); missing segments or samples in this collection indicate that VAPOR failed to identify any matches for the respective item
+- **Subtyping results**: a table listing one sample and its detected subtype (with respect to the HA and NA segments) per row; missing subtype information for HA, NA or both segments is indicated by H?, N? and H?N?, respectively, in the corresponding sample line.
 - **Hybrid reference genomes used for mapping**: collection of compiled reference genomes (in FASTA format, one per sample) that served as input for bwa-mem; each reference genome consists of the genome segments from the reference collections that best matched the corresponding sample's sequencing data
 - **fastp reports**: QC and read trimming and filtering results from fastp
 - **Final read mapping results**: bwa-mem mapping results in BAM format post-processed with samtools view
 - **QC reports for mapping results**: a collection of reports of QC metrics for the "Final read mapping results" generated with Qualimap
 - **Per-sample consensus sequences**: a nested collection of consensus sequences organized first by sample, then by segment
 - **Per-segment consensus sequences with samples combined**: a collection of the same consensus sequences organized by segment; each collection element is a multi-sequence FASTA dataset with the segment-specific sequences of all samples
-- **Multiple sequence alignments per segment**: a collection of multiple sequence alignments generated with MAFFT from each of the "Per-segment consensus sequences with samples combined" above; generated only if you provided input sequencing data of at least two samples
-- **Snipit plots per segment**: a collection of SNP plots across samples generated with Snipit; one plot per segment; generated  only if you provided input sequencing data of at least two samples; the first input sample will be used as the reference in the plot
-- **IQ-Tree per-segment ML tree**, **IQ-Tree per-segment ML distance matrix** and **IQ-Tree per-segment report**: collections of IQ-Tree ML trees, distance matrices and reports; each collection has one element per segment; generated  only if you provided input sequencing data of at least three samples
+- **Multiple sequence alignments per segment**: a collection of multiple sequence alignments generated with MAFFT from each of the "Per-segment consensus sequences with samples combined" above; generated only for segments for which at least two samples yielded a consensus sequence
+- **Snipit plots per segment**: a collection of SNP plots across samples generated with Snipit; one plot per segment; generated only for segments for which at least two samples yielded a consensus sequence; the first input sample will be used as the reference in the plot
+- **IQ-Tree per-segment ML tree**, **IQ-Tree per-segment ML distance matrix** and **IQ-Tree per-segment report**: collections of IQ-Tree ML trees, distance matrices and reports; each collection has one element per segment; generated  only for segments for which at least three samples yielded a consensus sequence
 
 ## Related training material
 

--- a/workflows/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping-test.yml
+++ b/workflows/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping-test.yml
@@ -5,36 +5,12 @@
       collection_type: list
       elements:
       - class: File
-        identifier: ref_1_pb2
-        location: https://zenodo.org/records/14628364/files/ref_1_pb2.fasta
-        filetype: fasta
-      - class: File
-        identifier: ref_2_pb1
-        location: https://zenodo.org/records/14628364/files/ref_2_pb1.fasta
-        filetype: fasta
-      - class: File
-        identifier: ref_3_pa
-        location: https://zenodo.org/records/14628364/files/ref_3_pa.fasta
-        filetype: fasta
-      - class: File
         identifier: ref_4_ha
         location: https://zenodo.org/records/14628364/files/ref_4_ha.fasta
         filetype: fasta
       - class: File
-        identifier: ref_5_np
-        location: https://zenodo.org/records/14628364/files/ref_5_np.fasta
-        filetype: fasta
-      - class: File
         identifier: ref_6_na
         location: https://zenodo.org/records/14628364/files/ref_6_na.fasta
-        filetype: fasta
-      - class: File
-        identifier: ref_7_mp
-        location: https://zenodo.org/records/14628364/files/ref_7_mp.fasta
-        filetype: fasta
-      - class: File
-        identifier: ref_8_ns
-        location: https://zenodo.org/records/14628364/files/ref_8_ns.fasta
         filetype: fasta
     Sequenced paired-end data:
       class: Collection
@@ -79,160 +55,52 @@
         SRR6674560:
           asserts:
             has_text:
-              text: "<tbody><tr><td class=\"col1\">total reads:</td><td class=\"col2\">345.266000 K</td></tr>"
-    Vapor - closest references:
+              text: "<tr><td class='col1'>total reads:</td><td class='col2'>345.266000 K</td></tr>"
+    successful VAPOR runs - closest references:
       element_tests:
         SRR6674560:
           elements:
-            ref_1_pb2:
-              asserts:
-                has_text:
-                  text: "0.9912280701754386\t6353408.0\t2280\t2786.582456140351\t31588\t>PB2|A/Texas/50/2012|A/H3N2|KJ942623.1"
-            ref_2_pb1:
-              asserts:
-                has_text:
-                  text: "0.9938515590689504\t5162362.0\t2277\t2267.176987263944\t25586\t>PB1|A/Texas/50/2012|A/H3N2|KJ942622.1"
-            ref_3_pa:
-              asserts:
-                has_text:
-                  text: "0.99302649930265\t4983278.0\t2151\t2316.7261738726174\t24765\t>PA|A/Netherlands/10407/2018|A/H1N2"
             ref_4_ha:
               asserts:
                 has_text:
                   text: "0.9841269841269841\t12026563.0\t1701\t7070.289829512052\t60505\t>HA|A/Texas/50/2012|A/H3N2|KJ942616.1"
-            ref_5_np:
-              asserts:
-                has_text:
-                  text: "0.9933199732798931\t9583550.0\t1497\t6401.837007348029\t47910\t>NP|A/Texas/50/2012|A/H3N2|KJ942619.1"
             ref_6_na:
               asserts:
                 has_text:
                   text: "0.9929078014184397\t6935928.0\t1410\t4919.097872340426\t34376\t>NA|A/Texas/50/2012|A/H3N2|KJ942618.1"
-            ref_7_mp:
-              asserts:
-                has_text:
-                  text: "1.0\t13252717.0\t982\t13495.63849287169\t66742\t>MP|A/Victoria/361/2011|A/H3N2|KJ942681.1"
-            ref_8_ns:
-              asserts:
-                has_text:
-                  text: "0.9952267303102625\t10526974.0\t838\t12562.021479713603\t52978\t>NS|A/Texas/50/2012|A/H3N2|KJ942620.1"
     Per-sample consensus sequences:
       element_tests:
         SRR6674560:
           elements:
-            PB2:
-              asserts:
-                has_text:
-                  text: ">Consensus_PB2_threshold_0.7_quality_20"
-            PB1:
-              asserts:
-                has_text:
-                  text: ">Consensus_PB1_threshold_0.7_quality_20"
-            PA:
-              asserts:
-                has_text:
-                  text: ">Consensus_PA_threshold_0.7_quality_20"
             HA:
               asserts:
                 has_text:
                   text: ">Consensus_HA_threshold_0.7_quality_20"
-            NP:
-              asserts:
-                has_text:
-                  text: ">Consensus_NP_threshold_0.7_quality_20"
             NA:
               asserts:
                 has_text:
                   text: ">Consensus_NA_threshold_0.7_quality_20"
-            MP:
-              asserts:
-                has_text:
-                  text: ">Consensus_MP_threshold_0.7_quality_20"
-            NS:
-              asserts:
-                has_text:
-                  text: ">Consensus_NS_threshold_0.7_quality_20"
     Per-segment consensus sequences with samples combined:
       element_tests:
-        PB2:
-          asserts:
-            has_text:
-              text: ">SRR6674560|PB2"
-              text: ">SRR24839074|PB2"
-        PB1:
-          asserts:
-            has_text:
-              text: ">SRR6674560|PB1"
-              text: ">SRR24839074|PB1"
-        PA:
-          asserts:
-            has_text:
-              text: ">SRR6674560|PA"
-              text: ">SRR24839074|PA"
         HA:
           asserts:
             has_text:
               text: ">SRR6674560|HA"
               text: ">SRR24839074|HA"
-        NP:
-          asserts:
-            has_text:
-              text: ">SRR6674560|NP"
-              text: ">SRR24839074|NP"
         NA:
           asserts:
             has_text:
               text: ">SRR6674560|NA"
               text: ">SRR24839074|NA"
-        MP:
-          asserts:
-            has_text:
-              text: ">SRR6674560|MP"
-              text: ">SRR24839074|MP"
-        NS:
-          asserts:
-            has_text:
-              text: ">SRR6674560|NS"
-              text: ">SRR24839074|NS"
     Snipit plots per segment:
       element_tests:
-        PB2:
-          asserts:
-            has_size:
-              value: 571300
-              delta: 10000
-        PB1:
-          asserts:
-            has_size:
-              value: 548800
-              delta: 10000
-        PA:
-          asserts:
-            has_size:
-              value: 606800
-              delta: 10000
         HA:
           asserts:
             has_size:
               value: 961300
               delta: 10000
-        NP:
-          asserts:
-            has_size:
-              value: 495700
-              delta: 10000
         NA:
           asserts:
             has_size:
               value: 809800
-              delta: 10000
-        MP:
-          asserts:
-            has_size:
-              value: 296100
-              delta: 10000
-        NS:
-          asserts:
-            has_size:
-              value: 278600
               delta: 10000

--- a/workflows/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.ga
+++ b/workflows/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.ga
@@ -227,6 +227,11 @@
             "class": "Person",
             "identifier": "0009-0000-8844-2812",
             "name": "Aaron Kolbecher"
+        },
+        {
+            "class": "Person",
+            "identifier": "0009-0003-9935-828X",
+            "name": "Saim Momin"
         }
     ],
     "format-version": "0.1",

--- a/workflows/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.ga
+++ b/workflows/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.ga
@@ -1,150 +1,213 @@
 {
     "a_galaxy_workflow": "true",
-    "annotation": "This workflow performs subtyping and consensus sequence generation for batches of Illumina PE sequenced Influenza A isolates.",
+    "annotation": "Influenza A isolate subtyping and consensus sequence generation",
     "comments": [
         {
             "child_steps": [
-                0,
-                1,
-                2,
+                3,
                 4,
-                5,
                 6,
                 7,
                 8,
                 9,
-                12,
-                13
+                10,
+                11,
+                13,
+                14,
+                16,
+                18
             ],
             "color": "lime",
             "data": {
-                "title": "Prepare m x n VAPOR jobs mapping over sequenced samples and genome segments"
+                "title": "Set up data structure part 1 - prepare inputs for samples x segments VAPOR runs"
             },
             "id": 0,
             "position": [
-                0.0,
-                0
+                235.07876749744884,
+                290.50000000000006
             ],
             "size": [
-                1077,
-                849
+                995.1,
+                1185.7
             ],
             "type": "frame"
         },
         {
             "child_steps": [
+                2,
+                12,
+                15,
+                17,
+                19,
+                21,
+                22,
                 24,
                 28,
                 30,
-                32,
                 33,
-                34,
-                35,
-                36,
-                37,
-                38,
-                31
+                35
             ],
-            "color": "none",
+            "color": "turquoise",
             "data": {
-                "title": "Build per-sample x per-segment consensus sequences"
+                "title": "Set up data structures part 2 - prepare per-segment ID lists for each sample (with fallback empty lists where VAPOR failed)"
             },
-            "id": 4,
+            "id": 1,
             "position": [
-                2553.1,
-                469.3
+                1250.178767497449,
+                288.50000000000006
             ],
             "size": [
-                1645.5,
-                711.4
+                2384.5,
+                623.7
             ],
             "type": "frame"
         },
         {
             "child_steps": [
-                42,
-                41
+                66,
+                68,
+                69
             ],
             "color": "turquoise",
             "data": {
                 "title": "Compare samples segment-wise"
             },
-            "id": 5,
+            "id": 7,
             "position": [
-                4592.5,
-                72.1
+                6655.3,
+                0.0
             ],
             "size": [
-                346,
-                1319
+                620.9,
+                1213.5
             ],
             "type": "frame"
         },
         {
             "child_steps": [
-                21,
-                22,
-                18,
-                20,
                 25,
-                27,
-                29
-            ],
-            "color": "orange",
-            "data": {
-                "title": "Generate Subtyping report"
-            },
-            "id": 2,
-            "position": [
-                1422.2,
-                958.9
-            ],
-            "size": [
-                1010.4,
-                824.1
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                14,
-                15,
-                16
+                26,
+                20,
+                23,
+                27
             ],
             "color": "blue",
             "data": {
-                "title": "Run VAPOR and extract IDs of best hits"
+                "title": "Run VAPOR"
             },
-            "id": 1,
+            "id": 2,
             "position": [
-                1129.1000000000001,
-                469.6
+                1285.4,
+                962.6999999999999
             ],
             "size": [
-                557.1,
-                420.7
+                868,
+                405
             ],
             "type": "frame"
         },
         {
             "child_steps": [
-                19,
-                23,
-                17,
-                26
+                29,
+                31,
+                32,
+                34,
+                36,
+                39,
+                38,
+                41
             ],
-            "color": "green",
+            "color": "orange",
             "data": {
-                "title": "Compile ref genome from per-segment VAPOR hits and map against it"
+                "title": "Generate subtyping report from VAPOR output"
             },
             "id": 3,
             "position": [
-                1722.4,
-                411.7
+                2199.3787674974487,
+                1365.5999999999997
             ],
             "size": [
-                797.6,
-                524.2
+                1346.6,
+                776.6
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                40,
+                42,
+                43,
+                44,
+                37
+            ],
+            "color": "lime",
+            "data": {
+                "title": "Compile hybrid reference genome and map reads to it"
+            },
+            "id": 4,
+            "position": [
+                3672.578767497449,
+                169.60000000000008
+            ],
+            "size": [
+                656,
+                1090
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                45,
+                47,
+                48,
+                49,
+                50,
+                52,
+                53,
+                55,
+                57,
+                59,
+                62,
+                51,
+                46
+            ],
+            "color": "turquoise",
+            "data": {
+                "title": "Build per-sample x per-segment consensus sequences"
+            },
+            "id": 5,
+            "position": [
+                4351.1787674974485,
+                372.7
+            ],
+            "size": [
+                1740,
+                707
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                56,
+                58,
+                54,
+                60,
+                61,
+                63,
+                64
+            ],
+            "color": "red",
+            "data": {
+                "title": "Get segments suitable for MSA (at least 2 samples have data for the segment) and tree building (data from at least 3 samples)"
+            },
+            "id": 6,
+            "position": [
+                5391.378767497449,
+                1201.1000000000001
+            ],
+            "size": [
+                981.8,
+                404
             ],
             "type": "frame"
         }
@@ -159,11 +222,16 @@
             "class": "Person",
             "identifier": "0000-0001-6897-1215",
             "name": "Viktoria Isabel Schwarz"
+        },
+        {
+            "class": "Person",
+            "identifier": "0009-0000-8844-2812",
+            "name": "Aaron Kolbecher"
         }
     ],
     "format-version": "0.1",
-    "license": "MIT",
-    "release": "0.1",
+    "license": "AGPL-3.0-or-later",
+    "release": "0.2",
     "name": "Influenza A isolate subtyping and consensus sequence generation",
     "report": {
         "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
@@ -185,14 +253,14 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "left": 68.9,
-                "top": 78
+                "left": 0,
+                "top": 517.2884793788038
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": \"\", \"collection_type\": \"list\"}",
             "tool_version": null,
             "type": "data_collection_input",
-            "uuid": "09e6896a-8058-4bee-8969-c04a6695dc23",
+            "uuid": "833ff6bd-4f37-4064-9552-fc7981228644",
             "when": null,
             "workflow_outputs": []
         },
@@ -212,25 +280,72 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "left": 72.76249485877617,
-                "top": 712.1781858684114
+                "left": 13.533355712890625,
+                "top": 1207.3550687342724
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": \"\", \"collection_type\": \"list:paired\"}",
             "tool_version": null,
             "type": "data_collection_input",
-            "uuid": "628ec5eb-ecc6-4ea2-856c-80bb78324fed",
+            "uuid": "6624892a-691a-4b53-b1ca-9c05882fca69",
             "when": null,
             "workflow_outputs": []
         },
         "2": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_element_identifiers/collection_element_identifiers/0.0.2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_text_file_with_recurring_lines/9.5+galaxy1",
             "errors": null,
             "id": 2,
+            "input_connections": {},
+            "inputs": [],
+            "label": null,
+            "name": "Create text file",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "txt"
+                }
+            ],
+            "position": {
+                "left": 1270.151494806463,
+                "top": 334.8823902896701
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionoutfile": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "outfile"
+                },
+                "HideDatasetActionoutfile": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_text_file_with_recurring_lines/9.5+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "6073bb457ec0",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"token_set\": [{\"__index__\": 0, \"line\": null, \"repeat_select\": {\"repeat_select_opts\": \"user\", \"__current_case__\": 0, \"times\": \"1\"}}], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "9.5+galaxy1",
+            "type": "tool",
+            "uuid": "2909b887-ffb5-464a-b6db-e753aa90d033",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "3": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_element_identifiers/collection_element_identifiers/0.0.2",
+            "errors": null,
+            "id": 3,
             "input_connections": {
                 "input_collection": {
-                    "id": 1,
+                    "id": 0,
                     "output_name": "output"
                 }
             },
@@ -244,8 +359,8 @@
                 }
             ],
             "position": {
-                "left": 136.76676208116686,
-                "top": 453.4062124875933
+                "left": 254.91890243218222,
+                "top": 381.9558099408882
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -264,15 +379,67 @@
             "tool_state": "{\"input_collection\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.0.2",
             "type": "tool",
-            "uuid": "6f573ad0-03c4-4f16-bbca-77ac8d5cbd09",
+            "uuid": "67d5225f-ee1d-4666-9d94-dc2c204f0b2c",
             "when": null,
             "workflow_outputs": []
         },
-        "3": {
+        "4": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.4+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_element_identifiers/collection_element_identifiers/0.0.2",
             "errors": null,
-            "id": 3,
+            "id": 4,
+            "input_connections": {
+                "input_collection": {
+                    "id": 1,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Extract element identifiers",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "txt"
+                }
+            ],
+            "position": {
+                "left": 303.31892684624455,
+                "top": 918.7557977338569
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionoutput": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "output"
+                },
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_element_identifiers/collection_element_identifiers/0.0.2",
+            "tool_shed_repository": {
+                "changeset_revision": "d3c07d270a50",
+                "name": "collection_element_identifiers",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_collection\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.2",
+            "type": "tool",
+            "uuid": "53791ad0-0fe4-4aaf-a5a2-e8bf18256911",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "5": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.1+galaxy0",
+            "errors": null,
+            "id": 5,
             "input_connections": {
                 "single_paired|paired_input": {
                     "id": 1,
@@ -298,18 +465,20 @@
                 }
             ],
             "position": {
-                "left": 481.4647580560187,
-                "top": 878.4588036869068
+                "left": 385.9666748046875,
+                "top": 1502.5218167811474
             },
             "post_job_actions": {
-                "HideDatasetActionoutput_paired_coll": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
+                "RenameDatasetActionoutput_paired_coll": {
+                    "action_arguments": {
+                        "newname": "fastp-processed data"
+                    },
+                    "action_type": "RenameDatasetAction",
                     "output_name": "output_paired_coll"
                 },
                 "RenameDatasetActionreport_html": {
                     "action_arguments": {
-                        "newname": "fastp reports"
+                        "newname": "fastp report"
                     },
                     "action_type": "RenameDatasetAction",
                     "output_name": "report_html"
@@ -322,34 +491,39 @@
                     "output_name": "report_html"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.23.4+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.1+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "c59d48774d03",
+                "changeset_revision": "25c59c0ceb55",
                 "name": "fastp",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": \"30\", \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": false}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": \"\", \"umi_len\": null, \"umi_prefix\": \"\"}, \"cutting_by_quality_options\": {\"cut_by_quality5\": true, \"cut_by_quality3\": true, \"cut_window_size\": null, \"cut_mean_quality\": \"30\"}, \"base_correction_options\": {\"correction\": false}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 2, \"paired_input\": {\"__class__\": \"ConnectedValue\"}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": \"\", \"adapter_sequence2\": \"\"}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.23.4+galaxy0",
+            "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": \"30\", \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": false}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": \"\", \"umi_len\": null, \"umi_prefix\": \"\"}, \"cutting_by_quality_options\": {\"cut_by_quality5\": true, \"cut_by_quality3\": true, \"cut_window_size\": null, \"cut_mean_quality\": \"30\"}, \"base_correction_options\": {\"correction\": false}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 1, \"paired_input\": {\"__class__\": \"RuntimeValue\"}, \"merge_reads\": {\"merge\": \"\", \"__current_case__\": 1}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": \"\", \"adapter_sequence2\": \"\", \"detect_adapter_for_pe\": true}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.24.1+galaxy0",
             "type": "tool",
-            "uuid": "9240a429-6fd4-488a-a397-52c40e68b9f3",
+            "uuid": "f7f9bf2c-0087-4731-9e61-c8cde95acbf0",
             "when": null,
             "workflow_outputs": [
                 {
+                    "label": "fastp-processed paired collection",
+                    "output_name": "output_paired_coll",
+                    "uuid": "896eacce-9ba8-459d-88c3-3a1ca0df0f8e"
+                },
+                {
                     "label": "fastp reports",
                     "output_name": "report_html",
-                    "uuid": "3ba6ac5d-db7a-43a3-adf1-46f79bfcc4da"
+                    "uuid": "8419d1d0-2f8f-4122-a2a9-fe06ebdf18d7"
                 }
             ]
         },
-        "4": {
+        "6": {
             "annotation": "",
             "content_id": "wc_gnu",
             "errors": null,
-            "id": 4,
+            "id": 6,
             "input_connections": {
                 "input1": {
-                    "id": 2,
+                    "id": 3,
                     "output_name": "output"
                 }
             },
@@ -363,8 +537,8 @@
                 }
             ],
             "position": {
-                "left": 227.27182504593,
-                "top": 256.60694781390674
+                "left": 473.88557723686955,
+                "top": 340.5558465619819
             },
             "post_job_actions": {
                 "ChangeDatatypeActionout_file1": {
@@ -384,18 +558,64 @@
             "tool_state": "{\"include_header\": false, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"options\": [\"lines\"], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "d16e7c5b-a924-4169-ac73-c3e903f28bda",
+            "uuid": "2343d0db-2bf7-414a-abf7-de995edfb341",
             "when": null,
             "workflow_outputs": []
         },
-        "5": {
+        "7": {
+            "annotation": "",
+            "content_id": "wc_gnu",
+            "errors": null,
+            "id": 7,
+            "input_connections": {
+                "input1": {
+                    "id": 4,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Line/Word/Character count",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 297.55220321343205,
+                "top": 719.4224847455756
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionout_file1": {
+                    "action_arguments": {
+                        "newtype": "txt"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "out_file1"
+                },
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "wc_gnu",
+            "tool_state": "{\"include_header\": false, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"options\": [\"lines\"], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "649e39a8-84ed-4bea-8d0c-411684873da8",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "8": {
             "annotation": "",
             "content_id": "__UNZIP_COLLECTION__",
             "errors": null,
-            "id": 5,
+            "id": 8,
             "input_connections": {
                 "input": {
-                    "id": 3,
+                    "id": 5,
                     "output_name": "output_paired_coll"
                 }
             },
@@ -413,8 +633,8 @@
                 }
             ],
             "position": {
-                "left": 395.184459729144,
-                "top": 579.1904362376869
+                "left": 527.7255427965583,
+                "top": 1244.5178463940645
             },
             "post_job_actions": {
                 "HideDatasetActionforward": {
@@ -432,18 +652,18 @@
             "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "d9b4f336-85fa-43e0-b8ef-fbaa647379c1",
+            "uuid": "b50ad9e4-2661-49c0-9baf-9685579f2d2b",
             "when": null,
             "workflow_outputs": []
         },
-        "6": {
+        "9": {
             "annotation": "",
             "content_id": "param_value_from_file",
             "errors": null,
-            "id": 6,
+            "id": 9,
             "input_connections": {
                 "input1": {
-                    "id": 4,
+                    "id": 6,
                     "output_name": "out_file1"
                 }
             },
@@ -457,8 +677,8 @@
                 }
             ],
             "position": {
-                "left": 445.339540573655,
-                "top": 308.6365185896452
+                "left": 698.6189756743702,
+                "top": 330.4224847455757
             },
             "post_job_actions": {
                 "HideDatasetActioninteger_param": {
@@ -471,100 +691,61 @@
             "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"integer\", \"remove_newlines\": true, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.1.0",
             "type": "tool",
-            "uuid": "8562f219-b541-4910-a673-5baaaba10112",
+            "uuid": "8e5475c0-b4d3-44eb-9bb9-3c812e438aa4",
             "when": null,
             "workflow_outputs": []
         },
-        "7": {
+        "10": {
+            "annotation": "",
+            "content_id": "param_value_from_file",
+            "errors": null,
+            "id": 10,
+            "input_connections": {
+                "input1": {
+                    "id": 7,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Parse parameter value",
+            "outputs": [
+                {
+                    "name": "integer_param",
+                    "type": "expression.json"
+                }
+            ],
+            "position": {
+                "left": 515.485552822807,
+                "top": 627.3557733197944
+            },
+            "post_job_actions": {
+                "HideDatasetActioninteger_param": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "integer_param"
+                }
+            },
+            "tool_id": "param_value_from_file",
+            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"integer\", \"remove_newlines\": true, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.1.0",
+            "type": "tool",
+            "uuid": "9b944139-77f6-4bfb-bd89-8c18fc4f2a27",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "11": {
             "annotation": "",
             "content_id": "__DUPLICATE_FILE_TO_COLLECTION__",
             "errors": null,
-            "id": 7,
+            "id": 11,
             "input_connections": {
                 "input": {
-                    "id": 5,
+                    "id": 8,
                     "output_name": "forward"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Duplicate file to collection",
-            "outputs": [
-                {
-                    "name": "output",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 701.4020466610151,
-                "top": 497.96176181070183
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output"
-                }
-            },
-            "tool_id": "__DUPLICATE_FILE_TO_COLLECTION__",
-            "tool_state": "{\"element_identifier\": \"segment\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"number\": \"8\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.0",
-            "type": "tool",
-            "uuid": "0c27055c-2890-4c15-917c-6cd7b1e6c327",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "8": {
-            "annotation": "",
-            "content_id": "__DUPLICATE_FILE_TO_COLLECTION__",
-            "errors": null,
-            "id": 8,
-            "input_connections": {
-                "input": {
-                    "id": 5,
-                    "output_name": "reverse"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Duplicate file to collection",
-            "outputs": [
-                {
-                    "name": "output",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 699.9601177895548,
-                "top": 630.6432442656766
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output"
-                }
-            },
-            "tool_id": "__DUPLICATE_FILE_TO_COLLECTION__",
-            "tool_state": "{\"element_identifier\": \"segment\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"number\": \"8\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.0",
-            "type": "tool",
-            "uuid": "54dd807e-0c64-4a49-a417-7ce56efeb9b1",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "9": {
-            "annotation": "",
-            "content_id": "__DUPLICATE_FILE_TO_COLLECTION__",
-            "errors": null,
-            "id": 9,
-            "input_connections": {
-                "input": {
-                    "id": 0,
-                    "output_name": "output"
                 },
                 "number": {
-                    "id": 6,
+                    "id": 9,
                     "output_name": "integer_param"
                 }
             },
@@ -578,8 +759,137 @@
                 }
             ],
             "position": {
-                "left": 610.8131065769353,
-                "top": 99.39531876213022
+                "left": 975.9522276274952,
+                "top": 1155.2891229291693
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__DUPLICATE_FILE_TO_COLLECTION__",
+            "tool_state": "{\"element_identifier\": \"segment\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"number\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "a10c04fc-4b62-4c08-a23f-4bb35da5d860",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "12": {
+            "annotation": "",
+            "content_id": "__DUPLICATE_FILE_TO_COLLECTION__",
+            "errors": null,
+            "id": 12,
+            "input_connections": {
+                "input": {
+                    "id": 2,
+                    "output_name": "outfile"
+                },
+                "number": {
+                    "id": 9,
+                    "output_name": "integer_param"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Duplicate file to collection",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1499.5515192205255,
+                "top": 372.2824147037326
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__DUPLICATE_FILE_TO_COLLECTION__",
+            "tool_state": "{\"element_identifier\": \"1\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"number\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "b6cba5cb-98f5-4d1e-91f0-4e952670623d",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "13": {
+            "annotation": "",
+            "content_id": "__DUPLICATE_FILE_TO_COLLECTION__",
+            "errors": null,
+            "id": 13,
+            "input_connections": {
+                "input": {
+                    "id": 8,
+                    "output_name": "reverse"
+                },
+                "number": {
+                    "id": 9,
+                    "output_name": "integer_param"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Duplicate file to collection",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 976.5188780181202,
+                "top": 1312.1224969526068
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__DUPLICATE_FILE_TO_COLLECTION__",
+            "tool_state": "{\"element_identifier\": \"segment\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"number\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "6ce2cc5c-6a98-4c74-936f-2125bfaae539",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "14": {
+            "annotation": "",
+            "content_id": "__DUPLICATE_FILE_TO_COLLECTION__",
+            "errors": null,
+            "id": 14,
+            "input_connections": {
+                "input": {
+                    "id": 0,
+                    "output_name": "output"
+                },
+                "number": {
+                    "id": 10,
+                    "output_name": "integer_param"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Duplicate file to collection",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 734.2856016509327,
+                "top": 524.4558099408881
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -592,169 +902,18 @@
             "tool_state": "{\"element_identifier\": \"seq\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"number\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "51029cc7-325e-4953-a951-ce1faa3a0efc",
+            "uuid": "b4259136-c6f9-4a4a-86a5-429847c70433",
             "when": null,
             "workflow_outputs": []
         },
-        "10": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
-            "errors": null,
-            "id": 10,
-            "input_connections": {
-                "input_param_type|input_param": {
-                    "id": 6,
-                    "output_name": "integer_param"
-                }
-            },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Map parameter value",
-                    "name": "input_param_type"
-                }
-            ],
-            "label": "Run IQ-Tree (at least 3 samples)",
-            "name": "Map parameter value",
-            "outputs": [
-                {
-                    "name": "output_param_boolean",
-                    "type": "expression.json"
-                }
-            ],
-            "position": {
-                "left": 2914.2167433441446,
-                "top": 88.24261883436165
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput_param_boolean": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output_param_boolean"
-                },
-                "RenameDatasetActionoutput_param_boolean": {
-                    "action_arguments": {
-                        "newname": "IQ-Tree flag"
-                    },
-                    "action_type": "RenameDatasetAction",
-                    "output_name": "output_param_boolean"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
-            "tool_shed_repository": {
-                "changeset_revision": "5ac8a4bf7a8d",
-                "name": "map_param_value",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"input_param_type\": {\"type\": \"integer\", \"__current_case__\": 1, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": \"1\", \"to\": \"false\"}, {\"__index__\": 1, \"from\": \"2\", \"to\": \"false\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"default\", \"__current_case__\": 2, \"default_value\": \"true\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.2.0",
-            "type": "tool",
-            "uuid": "084f559e-e02d-4f2e-8b84-afd66b571ddb",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "11": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
-            "errors": null,
-            "id": 11,
-            "input_connections": {
-                "input_param_type|input_param": {
-                    "id": 6,
-                    "output_name": "integer_param"
-                }
-            },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Map parameter value",
-                    "name": "input_param_type"
-                }
-            ],
-            "label": "Multiple sequences flag",
-            "name": "Map parameter value",
-            "outputs": [
-                {
-                    "name": "output_param_boolean",
-                    "type": "expression.json"
-                }
-            ],
-            "position": {
-                "left": 3676.209740366546,
-                "top": 237.44118277330173
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput_param_boolean": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output_param_boolean"
-                },
-                "HideDatasetActionoutput_param_text": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output_param_text"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
-            "tool_shed_repository": {
-                "changeset_revision": "5ac8a4bf7a8d",
-                "name": "map_param_value",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"input_param_type\": {\"type\": \"integer\", \"__current_case__\": 1, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": \"1\", \"to\": \"false\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"default\", \"__current_case__\": 2, \"default_value\": \"true\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.2.0",
-            "type": "tool",
-            "uuid": "af835b41-07e1-4123-9788-51484647f80f",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "12": {
-            "annotation": "",
-            "content_id": "__APPLY_RULES__",
-            "errors": null,
-            "id": 12,
-            "input_connections": {
-                "input": {
-                    "id": 9,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Apply rules",
-            "outputs": [
-                {
-                    "name": "output",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 846.8171456303577,
-                "top": 183.27355273774876
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output"
-                }
-            },
-            "tool_id": "__APPLY_RULES__",
-            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"rules\": {\"mapping\": [{\"columns\": [1, 0], \"editing\": false, \"type\": \"list_identifiers\"}], \"rules\": [{\"error\": null, \"type\": \"add_column_metadata\", \"value\": \"identifier0\", \"warn\": null}, {\"error\": null, \"type\": \"add_column_metadata\", \"value\": \"identifier1\", \"warn\": null}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.1.0",
-            "type": "tool",
-            "uuid": "ef68a12d-d216-4029-a853-08c3b76cb42d",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "13": {
+        "15": {
             "annotation": "",
             "content_id": "__RELABEL_FROM_FILE__",
             "errors": null,
-            "id": 13,
+            "id": 15,
             "input_connections": {
                 "how|labels": {
-                    "id": 2,
+                    "id": 3,
                     "output_name": "output"
                 },
                 "input": {
@@ -777,8 +936,8 @@
                 }
             ],
             "position": {
-                "left": 785.4245477462141,
-                "top": 318.04767383103456
+                "left": 1748.284795587713,
+                "top": 456.5824024967014
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -789,28 +948,197 @@
             },
             "tool_id": "__RELABEL_FROM_FILE__",
             "tool_state": "{\"how\": {\"how_select\": \"txt\", \"__current_case__\": 0, \"labels\": {\"__class__\": \"ConnectedValue\"}, \"strict\": true}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.0",
+            "tool_version": "1.1.0",
             "type": "tool",
-            "uuid": "3788b42c-b86a-4f05-af5d-c51b88407a07",
+            "uuid": "5fe8b42e-ed25-4e8d-9eb6-a0363e10a76d",
             "when": null,
             "workflow_outputs": []
         },
-        "14": {
+        "16": {
+            "annotation": "",
+            "content_id": "__APPLY_RULES__",
+            "errors": null,
+            "id": 16,
+            "input_connections": {
+                "input": {
+                    "id": 14,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Apply rules",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 979.2522764556202,
+                "top": 583.3224481244819
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__APPLY_RULES__",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"rules\": {\"mapping\": [{\"columns\": [1, 0], \"editing\": false, \"type\": \"list_identifiers\"}], \"rules\": [{\"error\": null, \"type\": \"add_column_metadata\", \"value\": \"identifier0\", \"warn\": null}, {\"error\": null, \"type\": \"add_column_metadata\", \"value\": \"identifier1\", \"warn\": null}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0",
+            "type": "tool",
+            "uuid": "2d3daf2b-dc32-423b-8cfd-aab426076931",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "17": {
+            "annotation": "",
+            "content_id": "__DUPLICATE_FILE_TO_COLLECTION__",
+            "errors": null,
+            "id": 17,
+            "input_connections": {
+                "input": {
+                    "id": 15,
+                    "output_name": "output"
+                },
+                "number": {
+                    "id": 10,
+                    "output_name": "integer_param"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Duplicate file to collection",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1969.7847955877132,
+                "top": 551.3823902896701
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__DUPLICATE_FILE_TO_COLLECTION__",
+            "tool_state": "{\"element_identifier\": null, \"input\": {\"__class__\": \"ConnectedValue\"}, \"number\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "c8562b0f-1b59-44b0-adac-dbbf4aa5952e",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "18": {
+            "annotation": "",
+            "content_id": "__RELABEL_FROM_FILE__",
+            "errors": null,
+            "id": 18,
+            "input_connections": {
+                "how|labels": {
+                    "id": 4,
+                    "output_name": "output"
+                },
+                "input": {
+                    "id": 16,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Relabel identifiers",
+                    "name": "how"
+                }
+            ],
+            "label": null,
+            "name": "Relabel identifiers",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1003.9855528228079,
+                "top": 800.8557733197944
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__RELABEL_FROM_FILE__",
+            "tool_state": "{\"how\": {\"how_select\": \"txt\", \"__current_case__\": 0, \"labels\": {\"__class__\": \"ConnectedValue\"}, \"strict\": true}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0",
+            "type": "tool",
+            "uuid": "96359349-f458-4ba7-ba71-c370fb967c4f",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "19": {
+            "annotation": "",
+            "content_id": "__APPLY_RULES__",
+            "errors": null,
+            "id": 19,
+            "input_connections": {
+                "input": {
+                    "id": 17,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Apply rules",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2245.4849909002132,
+                "top": 718.5824024967013
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__APPLY_RULES__",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"rules\": {\"mapping\": [{\"columns\": [1, 0], \"editing\": false, \"type\": \"list_identifiers\"}], \"rules\": [{\"error\": null, \"type\": \"add_column_metadata\", \"value\": \"identifier0\", \"warn\": null}, {\"error\": null, \"type\": \"add_column_metadata\", \"value\": \"identifier1\", \"warn\": null}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0",
+            "type": "tool",
+            "uuid": "34ad0046-ba51-4079-acd8-94ea260d53bf",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "20": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/vapor/vapor/1.0.2+galaxy3",
             "errors": null,
-            "id": 14,
+            "id": 20,
             "input_connections": {
                 "fasta_file": {
-                    "id": 13,
+                    "id": 18,
                     "output_name": "output"
                 },
                 "fastq_input|fastq1": {
-                    "id": 7,
+                    "id": 11,
                     "output_name": "output"
                 },
                 "fastq_input|fastq2": {
-                    "id": 8,
+                    "id": 13,
                     "output_name": "output"
                 }
             },
@@ -833,25 +1161,10 @@
                 }
             ],
             "position": {
-                "left": 1156.7986831355713,
-                "top": 519.1100241959895
+                "left": 1305.4063482090057,
+                "top": 1011.8128587599285
             },
-            "post_job_actions": {
-                "RenameDatasetActionoutput_scores": {
-                    "action_arguments": {
-                        "newname": "Vapor - closest references"
-                    },
-                    "action_type": "RenameDatasetAction",
-                    "output_name": "output_scores"
-                },
-                "TagDatasetActionoutput_scores": {
-                    "action_arguments": {
-                        "tags": "\ud83d\udd0d"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "output_scores"
-                }
-            },
+            "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/vapor/vapor/1.0.2+galaxy3",
             "tool_shed_repository": {
                 "changeset_revision": "244812f5bd1f",
@@ -862,28 +1175,256 @@
             "tool_state": "{\"fasta_file\": {\"__class__\": \"ConnectedValue\"}, \"fastq_input\": {\"fastq_input_selector\": \"paired\", \"__current_case__\": 1, \"fastq1\": {\"__class__\": \"ConnectedValue\"}, \"fastq2\": {\"__class__\": \"ConnectedValue\"}}, \"opt\": {\"kmer_length\": \"21\", \"threshold\": \"0.1\", \"min_kmer_cov\": \"5\", \"min_kmer_prop\": \"0.1\", \"top_seed_frac\": \"1.0\"}, \"output_type\": \"scores\", \"return_best_n\": \"500\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.2+galaxy3",
             "type": "tool",
-            "uuid": "4483138c-4bef-4a76-81a4-2afe4fabbcd8",
+            "uuid": "0c77b8db-e942-41e9-af13-137b5bb9afa3",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": "Vapor - closest references",
-                    "output_name": "output_scores",
-                    "uuid": "827db122-2ddd-4416-8aaf-35752a84825b"
-                }
-            ]
+            "workflow_outputs": []
         },
-        "15": {
+        "21": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "content_id": "__FLATTEN__",
             "errors": null,
-            "id": 15,
+            "id": 21,
             "input_connections": {
-                "infile": {
-                    "id": 14,
+                "input": {
+                    "id": 18,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Flatten collection",
+                    "name": "input"
+                }
+            ],
+            "label": null,
+            "name": "Flatten collection",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1977.8848932439632,
+                "top": 328.5157521060764
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__FLATTEN__",
+            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"join_identifier\": \":\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "d0b9e525-3773-4cfb-8331-5c43a918e3c0",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "22": {
+            "annotation": "",
+            "content_id": "__RELABEL_FROM_FILE__",
+            "errors": null,
+            "id": 22,
+            "input_connections": {
+                "how|labels": {
+                    "id": 4,
+                    "output_name": "output"
+                },
+                "input": {
+                    "id": 19,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Relabel identifiers",
+                    "name": "how"
+                }
+            ],
+            "label": null,
+            "name": "Relabel identifiers",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2462.6849420720882,
+                "top": 748.1824391177951
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__RELABEL_FROM_FILE__",
+            "tool_state": "{\"how\": {\"how_select\": \"txt\", \"__current_case__\": 0, \"labels\": {\"__class__\": \"ConnectedValue\"}, \"strict\": false}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0",
+            "type": "tool",
+            "uuid": "aea469b8-f918-47ee-b03e-e34742e2e959",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "23": {
+            "annotation": "",
+            "content_id": "__FILTER_FAILED_DATASETS__",
+            "errors": null,
+            "id": 23,
+            "input_connections": {
+                "input": {
+                    "id": 20,
                     "output_name": "output_scores"
                 }
             },
             "inputs": [],
+            "label": null,
+            "name": "Filter failed datasets",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1532.566017423161,
+                "top": 1008.0223833761975
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__FILTER_FAILED_DATASETS__",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "b0ccb093-c5c3-45f4-ad41-b8d2e0f1e101",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "24": {
+            "annotation": "",
+            "content_id": "__FLATTEN__",
+            "errors": null,
+            "id": 24,
+            "input_connections": {
+                "input": {
+                    "id": 22,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Flatten collection",
+                    "name": "input"
+                }
+            ],
+            "label": null,
+            "name": "Flatten collection",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2676.2847955877132,
+                "top": 580.6491139224826
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__FLATTEN__",
+            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"join_identifier\": \":\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "6aaf6649-8f25-4f33-a4e2-6680b3298865",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "25": {
+            "annotation": "This seemingly no-op transformation will remove samples with no remaining segment results (cases where vapor failed for  every segment).",
+            "content_id": "__APPLY_RULES__",
+            "errors": null,
+            "id": 25,
+            "input_connections": {
+                "input": {
+                    "id": 23,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Apply rules",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1642.4884249404474,
+                "top": 1171.4434843673182
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "successful VAPOR runs - closest references"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                },
+                "TagDatasetActionoutput": {
+                    "action_arguments": {
+                        "tags": "\ud83d\udd0d"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__APPLY_RULES__",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"rules\": {\"mapping\": [{\"columns\": [0, 1], \"editing\": false, \"type\": \"list_identifiers\"}], \"rules\": [{\"error\": null, \"type\": \"add_column_metadata\", \"value\": \"identifier0\", \"warn\": null}, {\"error\": null, \"type\": \"add_column_metadata\", \"value\": \"identifier1\", \"warn\": null}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0",
+            "type": "tool",
+            "uuid": "e656dd3c-8432-4bcd-af42-a185a7449ee6",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "successful VAPOR runs - closest references",
+                    "output_name": "output",
+                    "uuid": "246cdfd3-52d0-4d6f-8c63-90d148402487"
+                }
+            ]
+        },
+        "26": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
+            "errors": null,
+            "id": 26,
+            "input_connections": {
+                "infile": {
+                    "id": 25,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Replace",
+                    "name": "infile"
+                }
+            ],
             "label": null,
             "name": "Replace",
             "outputs": [
@@ -893,32 +1434,38 @@
                 }
             ],
             "position": {
-                "left": 1396.7646298414118,
-                "top": 546.6159249079953
+                "left": 1925.77175013576,
+                "top": 1002.6934843673187
             },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "post_job_actions": {
+                "HideDatasetActionoutfile": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "86755160afbf",
+                "changeset_revision": "6073bb457ec0",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"^.+\\\\t>(.+)$\", \"replace_pattern\": \"$1\", \"is_regex\": true, \"global\": false, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "9.3+galaxy1",
+            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"^.+\\\\t>(.+)$\", \"replace_pattern\": \"$1\", \"is_regex\": true, \"global\": false, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "9.5+galaxy0",
             "type": "tool",
-            "uuid": "6ccab17e-c55c-457b-947f-82e5cf4729ef",
+            "uuid": "c640f2b3-27dd-442a-9898-55ecf26238b2",
             "when": null,
             "workflow_outputs": []
         },
-        "16": {
+        "27": {
             "annotation": "",
             "content_id": "Show beginning1",
             "errors": null,
-            "id": 16,
+            "id": 27,
             "input_connections": {
                 "input": {
-                    "id": 15,
+                    "id": 26,
                     "output_name": "outfile"
                 }
             },
@@ -932,74 +1479,70 @@
                 }
             ],
             "position": {
-                "left": 1422.8063658972999,
-                "top": 703.3761105306064
+                "left": 1933.205099745135,
+                "top": 1125.5267973555995
             },
             "post_job_actions": {},
             "tool_id": "Show beginning1",
             "tool_state": "{\"header\": false, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineNum\": \"1\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.2",
             "type": "tool",
-            "uuid": "d4cdb8cd-5892-4322-88b7-978c7f8e30fc",
+            "uuid": "10056d50-865e-4d85-aa5d-f6fe4962c55f",
             "when": null,
             "workflow_outputs": []
         },
-        "17": {
+        "28": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_subseq/1.4+galaxy0",
+            "content_id": "__FLATTEN__",
             "errors": null,
-            "id": 17,
+            "id": 28,
             "input_connections": {
-                "in_file": {
-                    "id": 13,
-                    "output_name": "output"
-                },
-                "source|name_list": {
-                    "id": 16,
+                "input": {
+                    "id": 27,
                     "output_name": "out_file1"
                 }
             },
             "inputs": [
                 {
-                    "description": "runtime parameter for tool seqtk_subseq",
-                    "name": "source"
+                    "description": "runtime parameter for tool Flatten collection",
+                    "name": "input"
                 }
             ],
             "label": null,
-            "name": "seqtk_subseq",
+            "name": "Flatten collection",
             "outputs": [
                 {
-                    "name": "default",
+                    "name": "output",
                     "type": "input"
                 }
             ],
             "position": {
-                "left": 1745.3865144373408,
-                "top": 443.62606496341493
+                "left": 2294.8039484344677,
+                "top": 454.37677351676365
             },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_subseq/1.4+galaxy0",
-            "tool_shed_repository": {
-                "changeset_revision": "a019807f4e67",
-                "name": "seqtk",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
             },
-            "tool_state": "{\"in_file\": {\"__class__\": \"ConnectedValue\"}, \"l\": \"0\", \"source\": {\"type\": \"name\", \"__current_case__\": 1, \"name_list\": {\"__class__\": \"ConnectedValue\"}}, \"t\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.4+galaxy0",
+            "tool_id": "__FLATTEN__",
+            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"join_identifier\": \":\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "df2f3828-807e-48cd-a30e-b274fe120292",
+            "uuid": "7f3ae2fe-cc1b-45df-94ee-c0a2dbf41215",
             "when": null,
             "workflow_outputs": []
         },
-        "18": {
+        "29": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
             "errors": null,
-            "id": 18,
+            "id": 29,
             "input_connections": {
                 "input_list": {
-                    "id": 16,
+                    "id": 27,
                     "output_name": "out_file1"
                 }
             },
@@ -1013,8 +1556,8 @@
                 }
             ],
             "position": {
-                "left": 1532.0815683391677,
-                "top": 987.9238806639823
+                "left": 2219.382125985714,
+                "top": 1405.5529141558861
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1033,18 +1576,479 @@
             "tool_state": "{\"filename\": {\"add_name\": false, \"__current_case__\": 1}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "5.1.0",
             "type": "tool",
-            "uuid": "00bd9284-86b1-49e2-87ea-69e0c66dde62",
+            "uuid": "a39722d7-3f4c-47cd-884f-8298324cceb1",
             "when": null,
             "workflow_outputs": []
         },
-        "19": {
+        "30": {
+            "annotation": "",
+            "content_id": "__MERGE_COLLECTION__",
+            "errors": null,
+            "id": 30,
+            "input_connections": {
+                "inputs_0|input": {
+                    "id": 28,
+                    "output_name": "output"
+                },
+                "inputs_1|input": {
+                    "id": 24,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Merge collections",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2916.8515680486507,
+                "top": 482.8490650943576
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__MERGE_COLLECTION__",
+            "tool_state": "{\"advanced\": {\"conflict\": {\"duplicate_options\": \"keep_first\", \"__current_case__\": 3}}, \"inputs\": [{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "f34d37dd-07c6-484b-939e-0ed8d3b56f82",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "31": {
+            "annotation": "",
+            "content_id": "Grep1",
+            "errors": null,
+            "id": 31,
+            "input_connections": {
+                "input": {
+                    "id": 29,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Select",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2520.300028483073,
+                "top": 1436.877366911356
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "Grep1",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"invert\": \"\", \"keep_header\": false, \"pattern\": \"^HA.+\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.4",
+            "type": "tool",
+            "uuid": "cec2eb0b-4f51-4f3d-93c6-6e0e19b57415",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "32": {
+            "annotation": "",
+            "content_id": "Grep1",
+            "errors": null,
+            "id": 32,
+            "input_connections": {
+                "input": {
+                    "id": 29,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Select",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2517.6555786132817,
+                "top": 1542.899583708231
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "Grep1",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"invert\": \"\", \"keep_header\": false, \"pattern\": \"^NA.+\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.4",
+            "type": "tool",
+            "uuid": "85bfc235-4e53-45d9-816e-59a55991202a",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "33": {
+            "annotation": "",
+            "content_id": "__HARMONIZELISTS__",
+            "errors": null,
+            "id": 33,
+            "input_connections": {
+                "input1": {
+                    "id": 21,
+                    "output_name": "output"
+                },
+                "input2": {
+                    "id": 30,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Harmonize two collections",
+            "outputs": [
+                {
+                    "name": "output1",
+                    "type": "input"
+                },
+                {
+                    "name": "output2",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3179.8182428533382,
+                "top": 360.1824391177951
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output1"
+                },
+                "HideDatasetActionoutput2": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output2"
+                }
+            },
+            "tool_id": "__HARMONIZELISTS__",
+            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"input2\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "b5e552b0-bfc5-4d5f-a5b2-0b54cf8a8647",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "34": {
+            "annotation": "",
+            "content_id": "Paste1",
+            "errors": null,
+            "id": 34,
+            "input_connections": {
+                "input1": {
+                    "id": 31,
+                    "output_name": "out_file1"
+                },
+                "input2": {
+                    "id": 32,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Paste",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2770.3888142903647,
+                "top": 1504.077399463439
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "Paste1",
+            "tool_state": "{\"delimiter\": \"T\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"input2\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "43c046b8-f80b-4e7f-b344-bcf628c133fb",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "35": {
+            "annotation": "",
+            "content_id": "__APPLY_RULES__",
+            "errors": null,
+            "id": 35,
+            "input_connections": {
+                "input": {
+                    "id": 33,
+                    "output_name": "output2"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Apply rules",
+                    "name": "input"
+                }
+            ],
+            "label": null,
+            "name": "Apply rules",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3414.6514948064632,
+                "top": 356.4823658756076
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__APPLY_RULES__",
+            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"rules\": {\"mapping\": [{\"collapsible_value\": {\"__class__\": \"RuntimeValue\"}, \"columns\": [1, 2], \"connectable\": true, \"editing\": false, \"is_workflow\": false, \"type\": \"list_identifiers\"}], \"rules\": [{\"collapsible_value\": {\"__class__\": \"RuntimeValue\"}, \"connectable\": true, \"error\": null, \"is_workflow\": false, \"type\": \"add_column_metadata\", \"value\": \"identifier0\", \"warn\": null}, {\"collapsible_value\": {\"__class__\": \"RuntimeValue\"}, \"connectable\": true, \"error\": null, \"expression\": \"(.+):(.+)\", \"group_count\": 2, \"is_workflow\": false, \"replacement\": null, \"target_column\": 0, \"type\": \"add_column_regex\", \"warn\": null}]}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0",
+            "type": "tool",
+            "uuid": "d36b2a8e-d7c2-4828-86b9-f8e5e1208e60",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "36": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
             "errors": null,
-            "id": 19,
+            "id": 36,
             "input_connections": {
                 "input_list": {
-                    "id": 17,
+                    "id": 34,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Collapse Collection",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2984.8111775716147,
+                "top": 1641.344001025939
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+            "tool_shed_repository": {
+                "changeset_revision": "90981f86000f",
+                "name": "collapse_collections",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"filename\": {\"add_name\": true, \"__current_case__\": 0, \"place_name\": \"same_multiple\"}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "5.1.0",
+            "type": "tool",
+            "uuid": "064cc95e-f750-4f60-809d-c6cb66cee933",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "37": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_subseq/1.4+galaxy0",
+            "errors": null,
+            "id": 37,
+            "input_connections": {
+                "in_file": {
+                    "id": 18,
+                    "output_name": "output"
+                },
+                "source|name_list": {
+                    "id": 35,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool seqtk_subseq",
+                    "name": "source"
+                }
+            ],
+            "label": null,
+            "name": "seqtk_subseq",
+            "outputs": [
+                {
+                    "name": "default",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3692.6501693754744,
+                "top": 209.5512921456354
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_subseq/1.4+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "a019807f4e67",
+                "name": "seqtk",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"in_file\": {\"__class__\": \"ConnectedValue\"}, \"l\": \"0\", \"source\": {\"type\": \"name\", \"__current_case__\": 1, \"name_list\": {\"__class__\": \"ConnectedValue\"}}, \"t\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.4+galaxy0",
+            "type": "tool",
+            "uuid": "f4cfffcd-2ffc-4865-9b36-6c47de96ef29",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "38": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.5+galaxy0",
+            "errors": null,
+            "id": 38,
+            "input_connections": {
+                "infile1": {
+                    "id": 4,
+                    "output_name": "output"
+                },
+                "infile2": {
+                    "id": 36,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Join",
+                    "name": "infile1"
+                },
+                {
+                    "description": "runtime parameter for tool Join",
+                    "name": "infile2"
+                }
+            ],
+            "label": null,
+            "name": "Join",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3023.9351273151105,
+                "top": 1869.7409117090144
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.5+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "6073bb457ec0",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"column1\": \"1\", \"column2\": \"1\", \"empty_string_filler\": \"H?N?\", \"header\": false, \"ignore_case\": false, \"infile1\": {\"__class__\": \"RuntimeValue\"}, \"infile2\": {\"__class__\": \"RuntimeValue\"}, \"jointype\": \"-v 1\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "9.5+galaxy0",
+            "type": "tool",
+            "uuid": "9d907088-2239-4265-ac40-f1ce8ef2e23a",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "39": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
+            "errors": null,
+            "id": 39,
+            "input_connections": {
+                "infile": {
+                    "id": 36,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Replace",
+                    "name": "infile"
+                }
+            ],
+            "label": null,
+            "name": "Replace",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3234.7017288776105,
+                "top": 1645.6742613183894
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutfile": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "6073bb457ec0",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"^(.+\\\\t)(\\\\t.*)$\", \"replace_pattern\": \"$1H?$2\", \"is_regex\": true, \"global\": false, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}, {\"__index__\": 1, \"find_pattern\": \"^(.+\\\\t)$\", \"replace_pattern\": \"$1N?\", \"is_regex\": true, \"global\": false, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}, {\"__index__\": 2, \"find_pattern\": \"^(.+\\\\t)HA.+\\\\|.*(H\\\\d{1,2})N\\\\d{1,2}\\\\|[^|]+(\\\\t.+)$\", \"replace_pattern\": \"$1$2$3\", \"is_regex\": true, \"global\": false, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}, {\"__index__\": 3, \"find_pattern\": \"(.+\\\\t)(.+\\\\t)NA.+\\\\|.*H\\\\d{1,2}(N\\\\d{1,2})\\\\|.+$\", \"replace_pattern\": \"$1$2$3\", \"is_regex\": true, \"global\": false, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}, {\"__index__\": 4, \"find_pattern\": \"^(.+\\\\t)(.+)\\\\t(.+)$\", \"replace_pattern\": \"$1$2$3\", \"is_regex\": true, \"global\": false, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "9.5+galaxy0",
+            "type": "tool",
+            "uuid": "df63a615-c395-4a83-af8d-b157e24d6ed9",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "40": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+            "errors": null,
+            "id": 40,
+            "input_connections": {
+                "input_list": {
+                    "id": 37,
                     "output_name": "default"
                 }
             },
@@ -1058,8 +2062,8 @@
                 }
             ],
             "position": {
-                "left": 1980.4301950287581,
-                "top": 447.74854938603744
+                "left": 3780.0240300525575,
+                "top": 445.5109405091536
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1085,70 +2089,33 @@
             "tool_state": "{\"filename\": {\"add_name\": false, \"__current_case__\": 1}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "5.1.0",
             "type": "tool",
-            "uuid": "4abd34a3-1e91-4101-84b2-bd49171cd43d",
+            "uuid": "f2b17dc8-8d6a-406a-be29-9c76ab00197f",
             "when": null,
             "workflow_outputs": []
         },
-        "20": {
+        "41": {
             "annotation": "",
-            "content_id": "__EXTRACT_DATASET__",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy0",
             "errors": null,
-            "id": 20,
+            "id": 41,
             "input_connections": {
-                "input": {
-                    "id": 18,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Extract dataset",
-            "outputs": [
-                {
-                    "name": "output",
-                    "type": "data"
-                }
-            ],
-            "position": {
-                "left": 1848.8191275691797,
-                "top": 993.1032099697546
-            },
-            "post_job_actions": {
-                "ChangeDatatypeActionoutput": {
-                    "action_arguments": {
-                        "newtype": "txt"
-                    },
-                    "action_type": "ChangeDatatypeAction",
-                    "output_name": "output"
+                "inputs": {
+                    "id": 39,
+                    "output_name": "outfile"
                 },
-                "HideDatasetActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
+                "queries_0|inputs2": {
+                    "id": 38,
                     "output_name": "output"
                 }
             },
-            "tool_id": "__EXTRACT_DATASET__",
-            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"which\": {\"which_dataset\": \"first\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.1",
-            "type": "tool",
-            "uuid": "9922ea40-a153-41c1-861b-ca079cf59891",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "21": {
-            "annotation": "",
-            "content_id": "Grep1",
-            "errors": null,
-            "id": 21,
-            "input_connections": {
-                "input": {
-                    "id": 18,
-                    "output_name": "output"
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Concatenate datasets",
+                    "name": "inputs"
                 }
-            },
-            "inputs": [],
+            ],
             "label": null,
-            "name": "Select",
+            "name": "Concatenate datasets",
             "outputs": [
                 {
                     "name": "out_file1",
@@ -1156,75 +2123,62 @@
                 }
             ],
             "position": {
-                "left": 1854.0668838127747,
-                "top": 1143.4495210124612
+                "left": 3279.9683304401105,
+                "top": 1874.207586513702
             },
             "post_job_actions": {
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
+                "RenameDatasetActionout_file1": {
+                    "action_arguments": {
+                        "newname": "Subtyping Results"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out_file1"
+                },
+                "TagDatasetActionout_file1": {
+                    "action_arguments": {
+                        "tags": "\u2b50"
+                    },
+                    "action_type": "TagDatasetAction",
                     "output_name": "out_file1"
                 }
             },
-            "tool_id": "Grep1",
-            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"invert\": \"\", \"keep_header\": false, \"pattern\": \"^HA.+\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.4",
-            "type": "tool",
-            "uuid": "1a3a6027-721a-4ea8-bbed-525ced3fa5a6",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "22": {
-            "annotation": "",
-            "content_id": "Grep1",
-            "errors": null,
-            "id": 22,
-            "input_connections": {
-                "input": {
-                    "id": 18,
-                    "output_name": "output"
-                }
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "6073bb457ec0",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "inputs": [],
-            "label": null,
-            "name": "Select",
-            "outputs": [
+            "tool_state": "{\"inputs\": {\"__class__\": \"RuntimeValue\"}, \"queries\": [{\"__index__\": 0, \"inputs2\": {\"__class__\": \"RuntimeValue\"}}], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "9.5+galaxy0",
+            "type": "tool",
+            "uuid": "dede1e13-3277-4aaf-aff1-758799b603e6",
+            "when": null,
+            "workflow_outputs": [
                 {
-                    "name": "out_file1",
-                    "type": "input"
+                    "label": "Subtyping results",
+                    "output_name": "out_file1",
+                    "uuid": "66585bb3-7c83-478d-8eab-a9429acd8158"
                 }
-            ],
-            "position": {
-                "left": 1851.8655420320315,
-                "top": 1267.6601041651043
-            },
-            "post_job_actions": {
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "out_file1"
-                }
-            },
-            "tool_id": "Grep1",
-            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"invert\": \"\", \"keep_header\": false, \"pattern\": \"^NA.+\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.4",
-            "type": "tool",
-            "uuid": "c2f159ef-78da-41ee-8f93-c8d7e8f6b610",
-            "when": null,
-            "workflow_outputs": []
+            ]
         },
-        "23": {
+        "42": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
             "errors": null,
-            "id": 23,
+            "id": 42,
             "input_connections": {
                 "infile": {
-                    "id": 19,
+                    "id": 40,
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Replace",
+                    "name": "infile"
+                }
+            ],
             "label": null,
             "name": "Replace",
             "outputs": [
@@ -1234,8 +2188,8 @@
                 }
             ],
             "position": {
-                "left": 2209.3806148420026,
-                "top": 457.56505821777
+                "left": 3804.7713814966864,
+                "top": 729.9048059210851
             },
             "post_job_actions": {
                 "RenameDatasetActionoutfile": {
@@ -1246,17 +2200,17 @@
                     "output_name": "outfile"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "86755160afbf",
+                "changeset_revision": "6073bb457ec0",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \">([^|]+).+$\", \"replace_pattern\": \">$1\", \"is_regex\": true, \"global\": false, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "9.3+galaxy1",
+            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \">([^|]+).+$\", \"replace_pattern\": \">$1\", \"is_regex\": true, \"global\": false, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "9.5+galaxy0",
             "type": "tool",
-            "uuid": "f01ffacc-006f-4edd-ac50-dc0da78c4f02",
+            "uuid": "f011dfe0-b80a-4326-9689-dded3c33fca3",
             "when": null,
             "workflow_outputs": [
                 {
@@ -1266,106 +2220,18 @@
                 }
             ]
         },
-        "24": {
+        "43": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.19",
             "errors": null,
-            "id": 24,
-            "input_connections": {
-                "infile": {
-                    "id": 20,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Replace",
-            "outputs": [
-                {
-                    "name": "outfile",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 2798.4469946063095,
-                "top": 1056.5422223493317
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutfile": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "outfile"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
-            "tool_shed_repository": {
-                "changeset_revision": "86755160afbf",
-                "name": "text_processing",
-                "owner": "bgruening",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"^([^|]+).+$\", \"replace_pattern\": \"$1\", \"is_regex\": true, \"global\": false, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "9.3+galaxy1",
-            "type": "tool",
-            "uuid": "b7e8dbf0-ee6d-46fc-bd65-8c6aca5883be",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "25": {
-            "annotation": "",
-            "content_id": "Paste1",
-            "errors": null,
-            "id": 25,
-            "input_connections": {
-                "input1": {
-                    "id": 21,
-                    "output_name": "out_file1"
-                },
-                "input2": {
-                    "id": 22,
-                    "output_name": "out_file1"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Paste",
-            "outputs": [
-                {
-                    "name": "out_file1",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 2153.0739616556525,
-                "top": 1228.4842665319438
-            },
-            "post_job_actions": {
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "out_file1"
-                }
-            },
-            "tool_id": "Paste1",
-            "tool_state": "{\"delimiter\": \"T\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"input2\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.0",
-            "type": "tool",
-            "uuid": "b09f413d-21d2-479f-b1a3-590d8a1e4e96",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "26": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.18",
-            "errors": null,
-            "id": 26,
+            "id": 43,
             "input_connections": {
                 "fastq_input|fastq_input1": {
-                    "id": 3,
+                    "id": 5,
                     "output_name": "output_paired_coll"
                 },
                 "reference_source|ref_file": {
-                    "id": 23,
+                    "id": 42,
                     "output_name": "outfile"
                 }
             },
@@ -1388,38 +2254,44 @@
                 }
             ],
             "position": {
-                "left": 2289.6694675065078,
-                "top": 686.8321592357391
+                "left": 3801.3371367050195,
+                "top": 1013.5916807731211
             },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.18",
+            "post_job_actions": {
+                "HideDatasetActionbam_output": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "bam_output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bwa/bwa_mem/0.7.19",
             "tool_shed_repository": {
-                "changeset_revision": "2477830927ec",
+                "changeset_revision": "1dfc975b48d5",
                 "name": "bwa",
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"analysis_type\": {\"analysis_type_selector\": \"illumina\", \"__current_case__\": 0}, \"fastq_input\": {\"fastq_input_selector\": \"paired_collection\", \"__current_case__\": 2, \"fastq_input1\": {\"__class__\": \"ConnectedValue\"}, \"iset_stats\": \"\"}, \"output_sort\": \"coordinate\", \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"ConnectedValue\"}, \"index_a\": \"auto\"}, \"rg\": {\"rg_selector\": \"set\", \"__current_case__\": 1, \"read_group_id_conditional\": {\"do_auto_name\": true, \"__current_case__\": 0}, \"read_group_sm_conditional\": {\"do_auto_name\": true, \"__current_case__\": 0}, \"PL\": \"ILLUMINA\", \"read_group_lb_conditional\": {\"do_auto_name\": false, \"__current_case__\": 1, \"LB\": null}, \"CN\": null, \"DS\": null, \"DT\": null, \"FO\": null, \"KS\": null, \"PG\": null, \"PI\": null, \"PU\": null}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.7.18",
+            "tool_state": "{\"analysis_type\": {\"analysis_type_selector\": \"illumina\", \"__current_case__\": 0}, \"fastq_input\": {\"fastq_input_selector\": \"paired_collection\", \"__current_case__\": 2, \"fastq_input1\": {\"__class__\": \"RuntimeValue\"}, \"iset_stats\": null}, \"output_sort\": \"coordinate\", \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"RuntimeValue\"}, \"index_a\": \"auto\"}, \"rg\": {\"rg_selector\": \"set\", \"__current_case__\": 1, \"read_group_id_conditional\": {\"do_auto_name\": true, \"__current_case__\": 0}, \"read_group_sm_conditional\": {\"do_auto_name\": true, \"__current_case__\": 0}, \"PL\": \"ILLUMINA\", \"read_group_lb_conditional\": {\"do_auto_name\": false, \"__current_case__\": 1, \"LB\": null}, \"CN\": null, \"DS\": null, \"DT\": null, \"FO\": null, \"KS\": null, \"PG\": null, \"PI\": null, \"PU\": null}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.7.19",
             "type": "tool",
-            "uuid": "b7ee4713-86ab-40d3-a1df-aff33e1b27e7",
+            "uuid": "8b25de57-8d74-48de-8b01-755b5cd59d97",
             "when": null,
             "workflow_outputs": []
         },
-        "27": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+        "44": {
+            "annotation": "bwa mem will fail if no reference for any segment got suggested by vapor, i.e. the reference genome is empty. In that case, we need to skip further analysis of the sample.",
+            "content_id": "__FILTER_FAILED_DATASETS__",
             "errors": null,
-            "id": 27,
+            "id": 44,
             "input_connections": {
-                "input_list": {
-                    "id": 25,
-                    "output_name": "out_file1"
+                "input": {
+                    "id": 43,
+                    "output_name": "bam_output"
                 }
             },
             "inputs": [],
             "label": null,
-            "name": "Collapse Collection",
+            "name": "Filter failed datasets",
             "outputs": [
                 {
                     "name": "output",
@@ -1427,42 +2299,48 @@
                 }
             ],
             "position": {
-                "left": 2154.6046014682556,
-                "top": 1404.299968663298
+                "left": 4073.2016164635425,
+                "top": 943.2563388282821
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
                     "output_name": "output"
+                },
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "BWA-MEM FilterFailed"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
-            "tool_shed_repository": {
-                "changeset_revision": "90981f86000f",
-                "name": "collapse_collections",
-                "owner": "nml",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"filename\": {\"add_name\": true, \"__current_case__\": 0, \"place_name\": \"same_multiple\"}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "5.1.0",
+            "tool_id": "__FILTER_FAILED_DATASETS__",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "66a1dfe9-f0c0-445f-b2b2-30b9950393db",
+            "uuid": "52ce1caf-2663-429a-a96a-7ac6a8668b5c",
             "when": null,
             "workflow_outputs": []
         },
-        "28": {
+        "45": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.15.1+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.20+galaxy3",
             "errors": null,
-            "id": 28,
+            "id": 45,
             "input_connections": {
                 "input": {
-                    "id": 26,
-                    "output_name": "bam_output"
+                    "id": 44,
+                    "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Samtools view",
+                    "name": "input"
+                }
+            ],
             "label": null,
             "name": "Samtools view",
             "outputs": [
@@ -1472,8 +2350,8 @@
                 }
             ],
             "position": {
-                "left": 2557.1234301153786,
-                "top": 762.7716901183999
+                "left": 4407.958917741836,
+                "top": 434.13949065640935
             },
             "post_job_actions": {
                 "RenameDatasetActionoutputsam": {
@@ -1484,98 +2362,82 @@
                     "output_name": "outputsam"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.15.1+galaxy2",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_view/samtools_view/1.20+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "6be888be75f9",
+                "changeset_revision": "32dc5f781059",
                 "name": "samtools_view",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"mode\": {\"outtype\": \"selected_reads\", \"__current_case__\": 1, \"filter_config\": {\"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cond_rg\": {\"select_rg\": \"no\", \"__current_case__\": 0}, \"quality\": \"20\", \"library\": \"\", \"cigarcons\": null, \"inclusive_filter\": [\"1\", \"2\"], \"exclusive_filter\": null, \"exclusive_filter_all\": null, \"tag\": \"\", \"qname_file\": {\"__class__\": \"RuntimeValue\"}}, \"subsample_config\": {\"subsampling_mode\": {\"select_subsample\": \"fraction\", \"__current_case__\": 0, \"factor\": \"1.0\", \"seed\": null}}, \"output_options\": {\"reads_report_type\": \"retained\", \"__current_case__\": 0, \"complementary_output\": false, \"adv_output\": {\"readtags\": [], \"collapsecigar\": false}, \"output_format\": {\"oformat\": \"bam\", \"__current_case__\": 2}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.15.1+galaxy2",
+            "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"mode\": {\"outtype\": \"selected_reads\", \"__current_case__\": 1, \"filter_config\": {\"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cond_rg\": {\"select_rg\": \"no\", \"__current_case__\": 0}, \"cond_expr\": {\"select_expr\": \"no\", \"__current_case__\": 0}, \"quality\": \"20\", \"library\": \"\", \"cigarcons\": null, \"inclusive_filter\": [\"1\", \"2\"], \"exclusive_filter\": null, \"exclusive_filter_all\": null, \"tag\": \"\", \"qname_file\": {\"__class__\": \"RuntimeValue\"}}, \"subsample_config\": {\"subsampling_mode\": {\"select_subsample\": \"fraction\", \"__current_case__\": 0, \"factor\": \"1.0\", \"seed\": null}}, \"output_options\": {\"reads_report_type\": \"retained\", \"__current_case__\": 0, \"complementary_output\": false, \"adv_output\": {\"readtags\": [], \"collapsecigar\": false}, \"output_format\": {\"oformat\": \"bam\", \"__current_case__\": 2}}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.20+galaxy3",
             "type": "tool",
-            "uuid": "daf75af5-ae66-41c5-8aa7-5644110740ea",
+            "uuid": "b3181791-d5a0-4cd5-a013-4aa8480197fe",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Final read mapping results",
+                    "label": "Final read mapping_results",
                     "output_name": "outputsam",
-                    "uuid": "e022c539-044c-4a36-a6ff-9ff43bdaa53c"
+                    "uuid": "aad0e121-6056-455f-84d8-790a80d349c3"
                 }
             ]
         },
-        "29": {
+        "46": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bamtools_split_ref/bamtools_split_ref/2.5.2+galaxy2",
             "errors": null,
-            "id": 29,
+            "id": 46,
             "input_connections": {
-                "infile": {
-                    "id": 27,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Replace",
-            "outputs": [
-                {
-                    "name": "outfile",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 2161.453666034377,
-                "top": 1574.982352705691
-            },
-            "post_job_actions": {
-                "RenameDatasetActionoutfile": {
-                    "action_arguments": {
-                        "newname": "Subtyping results"
-                    },
-                    "action_type": "RenameDatasetAction",
-                    "output_name": "outfile"
-                },
-                "TagDatasetActionoutfile": {
-                    "action_arguments": {
-                        "tags": "\ud83c\udf1f"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "outfile"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
-            "tool_shed_repository": {
-                "changeset_revision": "86755160afbf",
-                "name": "text_processing",
-                "owner": "bgruening",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"^(.+)\\\\tHA.+\\\\|.*(H\\\\d{1,2})N\\\\d{1,2}\\\\|[^|]+\\\\tNA.+\\\\|.*H\\\\d{1,2}(N\\\\d{1,2})\\\\|.+$\", \"replace_pattern\": \"$1\\\\t$2$3\", \"is_regex\": true, \"global\": false, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "9.3+galaxy1",
-            "type": "tool",
-            "uuid": "18b38230-16aa-4017-bb84-4d83cdaa662e",
-            "when": null,
-            "workflow_outputs": [
-                {
-                    "label": "Subtyping results",
-                    "output_name": "outfile",
-                    "uuid": "e589d9e3-2c25-48e2-9710-2f04ca9104eb"
-                }
-            ]
-        },
-        "30": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/qualimap_bamqc/qualimap_bamqc/2.2.2d+galaxy3",
-            "errors": null,
-            "id": 30,
-            "input_connections": {
-                "input1": {
-                    "id": 28,
+                "input_bam": {
+                    "id": 45,
                     "output_name": "outputsam"
                 }
             },
             "inputs": [],
+            "label": null,
+            "name": "Split BAM by reference",
+            "outputs": [
+                {
+                    "name": "output_bams",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 4418.125543718398,
+                "top": 691.5353112740851
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bamtools_split_ref/bamtools_split_ref/2.5.2+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "9b8feb118f9e",
+                "name": "bamtools_split_ref",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"refs\": null, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.5.2+galaxy2",
+            "type": "tool",
+            "uuid": "a8f839cd-2513-4d6b-bbf3-d64e701392f9",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "47": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/qualimap_bamqc/qualimap_bamqc/2.3+galaxy0",
+            "errors": null,
+            "id": 47,
+            "input_connections": {
+                "input1": {
+                    "id": 45,
+                    "output_name": "outputsam"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool QualiMap BamQC",
+                    "name": "input1"
+                }
+            ],
             "label": null,
             "name": "QualiMap BamQC",
             "outputs": [
@@ -1589,8 +2451,8 @@
                 }
             ],
             "position": {
-                "left": 2806.5530105890093,
-                "top": 649.2678440521755
+                "left": 4682.542200212538,
+                "top": 423.6603265328742
             },
             "post_job_actions": {
                 "HideDatasetActionraw_data": {
@@ -1613,73 +2475,34 @@
                     "output_name": "output_html"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/qualimap_bamqc/qualimap_bamqc/2.2.2d+galaxy3",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/qualimap_bamqc/qualimap_bamqc/2.3+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "19ece8afbaab",
+                "changeset_revision": "30a201c9c310",
                 "name": "qualimap_bamqc",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"duplicate_skipping\": null, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"per_base_coverage\": false, \"plot_specific\": {\"n_bins\": \"40\", \"paint_chromosome_limits\": true, \"genome_gc_distr\": null, \"homopolymer_size\": \"3\"}, \"stats_regions\": {\"region_select\": \"all\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.2.2d+galaxy3",
+            "tool_state": "{\"duplicate_skipping\": null, \"input1\": {\"__class__\": \"RuntimeValue\"}, \"per_base_coverage\": false, \"plot_specific\": {\"n_bins\": \"40\", \"paint_chromosome_limits\": true, \"genome_gc_distr\": null, \"homopolymer_size\": \"3\"}, \"stats_regions\": {\"region_select\": \"all\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.3+galaxy0",
             "type": "tool",
-            "uuid": "885b9257-1d9f-40b0-bf2b-2d1327b16776",
+            "uuid": "d0f0b152-9e71-4072-b1e2-118608095de7",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "QC reports for mapping results",
                     "output_name": "output_html",
-                    "uuid": "59b76d32-7890-48f3-9885-c7c7c11d942f"
+                    "uuid": "c0e4866b-da41-4ec0-93e6-24071b8c2de1"
                 }
             ]
         },
-        "31": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bamtools_split_ref/bamtools_split_ref/2.5.2+galaxy2",
-            "errors": null,
-            "id": 31,
-            "input_connections": {
-                "input_bam": {
-                    "id": 28,
-                    "output_name": "outputsam"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Split BAM by reference",
-            "outputs": [
-                {
-                    "name": "output_bams",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 2804.149854475478,
-                "top": 883.1487246046947
-            },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bamtools_split_ref/bamtools_split_ref/2.5.2+galaxy2",
-            "tool_shed_repository": {
-                "changeset_revision": "9b8feb118f9e",
-                "name": "bamtools_split_ref",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"refs\": null, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.5.2+galaxy2",
-            "type": "tool",
-            "uuid": "2a534e6a-0542-4470-9775-80591966b922",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "32": {
+        "48": {
             "annotation": "",
             "content_id": "__APPLY_RULES__",
             "errors": null,
-            "id": 32,
+            "id": 48,
             "input_connections": {
                 "input": {
-                    "id": 31,
+                    "id": 46,
                     "output_name": "output_bams"
                 }
             },
@@ -1693,8 +2516,8 @@
                 }
             ],
             "position": {
-                "left": 3043.9512700139053,
-                "top": 873.3196571359551
+                "left": 4526.313066606582,
+                "top": 916.5769677682257
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1707,22 +2530,176 @@
             "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"rules\": {\"mapping\": [{\"columns\": [1, 0], \"editing\": false, \"type\": \"list_identifiers\"}], \"rules\": [{\"error\": null, \"type\": \"add_column_metadata\", \"value\": \"identifier0\", \"warn\": null}, {\"error\": null, \"type\": \"add_column_metadata\", \"value\": \"identifier1\", \"warn\": null}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.0",
             "type": "tool",
-            "uuid": "3c5be312-d3a6-46de-a9f0-7d31741aff3a",
+            "uuid": "57141fce-c4f0-4480-b461-572852f84686",
             "when": null,
             "workflow_outputs": []
         },
-        "33": {
+        "49": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_element_identifiers/collection_element_identifiers/0.0.2",
+            "errors": null,
+            "id": 49,
+            "input_connections": {
+                "input_collection": {
+                    "id": 48,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Extract element identifiers",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "txt"
+                }
+            ],
+            "position": {
+                "left": 4702.208871965468,
+                "top": 649.431162409339
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionoutput": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "output"
+                },
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_element_identifiers/collection_element_identifiers/0.0.2",
+            "tool_shed_repository": {
+                "changeset_revision": "d3c07d270a50",
+                "name": "collection_element_identifiers",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_collection\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.2",
+            "type": "tool",
+            "uuid": "26b43ad3-b27a-45a8-8957-92592c8d2772",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "50": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_element_identifiers/collection_element_identifiers/0.0.2",
+            "errors": null,
+            "id": 50,
+            "input_connections": {
+                "input_collection": {
+                    "id": 49,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Extract element identifiers",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "txt"
+                }
+            ],
+            "position": {
+                "left": 4918.708887224257,
+                "top": 643.8895135445929
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionoutput": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "output"
+                },
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_element_identifiers/collection_element_identifiers/0.0.2",
+            "tool_shed_repository": {
+                "changeset_revision": "d3c07d270a50",
+                "name": "collection_element_identifiers",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_collection\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.2",
+            "type": "tool",
+            "uuid": "3728390a-ddc4-4cde-8d6d-3aea2cd16081",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "51": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
+            "errors": null,
+            "id": 51,
+            "input_connections": {
+                "infile": {
+                    "id": 50,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Replace",
+                    "name": "infile"
+                }
+            ],
+            "label": null,
+            "name": "Replace",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 4965.877620031967,
+                "top": 833.7727162429312
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutfile": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "6073bb457ec0",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"^(Final read mapping results: (.+))$\", \"replace_pattern\": \"$1\\\\t$2\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "9.5+galaxy0",
+            "type": "tool",
+            "uuid": "92170405-5eaa-4636-a91f-bcda49889533",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "52": {
             "annotation": "",
             "content_id": "__RELABEL_FROM_FILE__",
             "errors": null,
-            "id": 33,
+            "id": 52,
             "input_connections": {
                 "how|labels": {
-                    "id": 24,
+                    "id": 51,
                     "output_name": "outfile"
                 },
                 "input": {
-                    "id": 32,
+                    "id": 48,
                     "output_name": "output"
                 }
             },
@@ -1741,8 +2718,8 @@
                 }
             ],
             "position": {
-                "left": 3265.919754268056,
-                "top": 983.9937307995837
+                "left": 5214.563074235975,
+                "top": 924.7436242623663
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1752,21 +2729,21 @@
                 }
             },
             "tool_id": "__RELABEL_FROM_FILE__",
-            "tool_state": "{\"how\": {\"how_select\": \"txt\", \"__current_case__\": 0, \"labels\": {\"__class__\": \"ConnectedValue\"}, \"strict\": true}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.0",
+            "tool_state": "{\"how\": {\"how_select\": \"tabular\", \"__current_case__\": 1, \"labels\": {\"__class__\": \"ConnectedValue\"}, \"strict\": false}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.0",
             "type": "tool",
-            "uuid": "0bcb9db0-4160-4856-b769-d40feb29955c",
+            "uuid": "d068847a-e4e4-4d0b-ab17-6e136cb54383",
             "when": null,
             "workflow_outputs": []
         },
-        "34": {
+        "53": {
             "annotation": "",
             "content_id": "__APPLY_RULES__",
             "errors": null,
-            "id": 34,
+            "id": 53,
             "input_connections": {
                 "input": {
-                    "id": 33,
+                    "id": 52,
                     "output_name": "output"
                 }
             },
@@ -1780,8 +2757,8 @@
                 }
             ],
             "position": {
-                "left": 3378.69433149217,
-                "top": 727.5370045095681
+                "left": 5276.562313935321,
+                "top": 681.4751658689562
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1794,22 +2771,66 @@
             "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"rules\": {\"mapping\": [{\"columns\": [1, 0], \"editing\": false, \"type\": \"list_identifiers\"}], \"rules\": [{\"error\": null, \"type\": \"add_column_metadata\", \"value\": \"identifier0\", \"warn\": null}, {\"error\": null, \"type\": \"add_column_metadata\", \"value\": \"identifier1\", \"warn\": null}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.0",
             "type": "tool",
-            "uuid": "666137d6-7a9d-4b2f-92da-476da9b2da8f",
+            "uuid": "378fc0b7-f2b4-405c-b541-a8f946bc12c2",
             "when": null,
             "workflow_outputs": []
         },
-        "35": {
+        "54": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_consensus/ivar_consensus/1.4.3+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_element_identifiers/collection_element_identifiers/0.0.2",
             "errors": null,
-            "id": 35,
+            "id": 54,
             "input_connections": {
-                "input_bam": {
-                    "id": 34,
+                "input_collection": {
+                    "id": 52,
                     "output_name": "output"
                 }
             },
             "inputs": [],
+            "label": null,
+            "name": "Extract element identifiers",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "txt"
+                }
+            ],
+            "position": {
+                "left": 5411.190343555684,
+                "top": 1241.0428103451402
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_element_identifiers/collection_element_identifiers/0.0.2",
+            "tool_shed_repository": {
+                "changeset_revision": "d3c07d270a50",
+                "name": "collection_element_identifiers",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_collection\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.2",
+            "type": "tool",
+            "uuid": "0bde584b-029f-426f-a13b-a3a7a5f858e1",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "55": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_consensus/ivar_consensus/1.4.4+galaxy0",
+            "errors": null,
+            "id": 55,
+            "input_connections": {
+                "input_bam": {
+                    "id": 53,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool ivar consensus",
+                    "name": "input_bam"
+                }
+            ],
             "label": null,
             "name": "ivar consensus",
             "outputs": [
@@ -1819,8 +2840,8 @@
                 }
             ],
             "position": {
-                "left": 3373.00829259856,
-                "top": 498.47642565852516
+                "left": 5466.537887828757,
+                "top": 455.29288825387783
             },
             "post_job_actions": {
                 "RenameDatasetActionconsensus": {
@@ -1832,40 +2853,86 @@
                 },
                 "TagDatasetActionconsensus": {
                     "action_arguments": {
-                        "tags": "\ud83c\udf1f"
+                        "tags": "\u2b50"
                     },
                     "action_type": "TagDatasetAction",
                     "output_name": "consensus"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_consensus/ivar_consensus/1.4.3+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ivar_consensus/ivar_consensus/1.4.4+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "3a72fede57ce",
+                "changeset_revision": "253935875d96",
                 "name": "ivar_consensus",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"depth_action\": \"-n N\", \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"min_depth\": \"10\", \"min_freq\": \"0.7\", \"min_indel_freq\": \"0.8\", \"min_qual\": \"20\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.4.3+galaxy0",
+            "tool_state": "{\"depth_action\": \"-n N\", \"input_bam\": {\"__class__\": \"RuntimeValue\"}, \"min_depth\": \"10\", \"min_freq\": \"0.7\", \"min_indel_freq\": \"0.8\", \"min_qual\": \"20\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.4.4+galaxy0",
             "type": "tool",
-            "uuid": "b1295c1b-530d-4ec0-86ab-83c2ed370b83",
+            "uuid": "14efb3a9-2866-4f5d-8c08-7d7ec0c8e09d",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Per-sample consensus sequences",
                     "output_name": "consensus",
-                    "uuid": "772f61e0-4af2-4a6f-b0c6-9359470d7b5c"
+                    "uuid": "9ab002c0-75a1-4bc9-b109-792018bfe86d"
                 }
             ]
         },
-        "36": {
+        "56": {
+            "annotation": "",
+            "content_id": "wc_gnu",
+            "errors": null,
+            "id": 56,
+            "input_connections": {
+                "input1": {
+                    "id": 54,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Line/Word/Character count",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 5453.230174916459,
+                "top": 1445.4955527366963
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionout_file1": {
+                    "action_arguments": {
+                        "newtype": "txt"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "out_file1"
+                },
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "wc_gnu",
+            "tool_state": "{\"include_header\": false, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"options\": [\"lines\"], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "b608ce7a-1d76-49d1-8dac-4f7bba69a1df",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "57": {
             "annotation": "",
             "content_id": "__APPLY_RULES__",
             "errors": null,
-            "id": 36,
+            "id": 57,
             "input_connections": {
                 "input": {
-                    "id": 35,
+                    "id": 55,
                     "output_name": "consensus"
                 }
             },
@@ -1879,8 +2946,8 @@
                 }
             ],
             "position": {
-                "left": 3658.1266044610875,
-                "top": 740.8707182575123
+                "left": 5590.461595122848,
+                "top": 716.7633497326643
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1900,18 +2967,70 @@
             "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"rules\": {\"mapping\": [{\"columns\": [1, 0], \"editing\": false, \"type\": \"list_identifiers\"}], \"rules\": [{\"error\": null, \"type\": \"add_column_metadata\", \"value\": \"identifier0\", \"warn\": null}, {\"error\": null, \"type\": \"add_column_metadata\", \"value\": \"identifier1\", \"warn\": null}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.1.0",
             "type": "tool",
-            "uuid": "773f9899-f5c9-4804-ac43-8b98a14669c5",
+            "uuid": "41bac28e-e62c-44a5-8578-1cefedceb298",
             "when": null,
             "workflow_outputs": []
         },
-        "37": {
+        "58": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
             "errors": null,
-            "id": 37,
+            "id": 58,
             "input_connections": {
                 "input_list": {
-                    "id": 36,
+                    "id": 56,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Collapse Collection",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 5681.3395972870285,
+                "top": 1427.6099745242434
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionoutput": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "output"
+                },
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+            "tool_shed_repository": {
+                "changeset_revision": "90981f86000f",
+                "name": "collapse_collections",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"filename\": {\"add_name\": true, \"__current_case__\": 0, \"place_name\": \"same_multiple\"}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "5.1.0",
+            "type": "tool",
+            "uuid": "e9f9fadd-2829-4d8a-883b-4eab2359c367",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "59": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+            "errors": null,
+            "id": 59,
+            "input_connections": {
+                "input_list": {
+                    "id": 57,
                     "output_name": "output"
                 }
             },
@@ -1925,8 +3044,8 @@
                 }
             ],
             "position": {
-                "left": 3941.7086336866,
-                "top": 565.5606948208823
+                "left": 5760.036196779969,
+                "top": 476.4873297032329
             },
             "post_job_actions": {
                 "ChangeDatatypeActionoutput": {
@@ -1952,22 +3071,105 @@
             "tool_state": "{\"filename\": {\"add_name\": true, \"__current_case__\": 0, \"place_name\": \"same_once\"}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "5.1.0",
             "type": "tool",
-            "uuid": "d16db5b4-85ce-4e3c-8a94-dea5790f8d2f",
+            "uuid": "284353ae-b549-4295-b8da-1032340404db",
             "when": null,
             "workflow_outputs": []
         },
-        "38": {
+        "60": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "content_id": "Filter1",
             "errors": null,
-            "id": 38,
+            "id": 60,
             "input_connections": {
-                "infile": {
-                    "id": 37,
+                "input": {
+                    "id": 58,
                     "output_name": "output"
                 }
             },
             "inputs": [],
+            "label": null,
+            "name": "Filter",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 5911.190343555685,
+                "top": 1273.8786312406626
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "Filter1",
+            "tool_state": "{\"cond\": \"c2 > 1\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.1",
+            "type": "tool",
+            "uuid": "3ffb9dd8-fc94-434b-a711-be08ab3a1422",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "61": {
+            "annotation": "",
+            "content_id": "Filter1",
+            "errors": null,
+            "id": 61,
+            "input_connections": {
+                "input": {
+                    "id": 58,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Filter",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 5920.145567436282,
+                "top": 1491.7890790018553
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "Filter1",
+            "tool_state": "{\"cond\": \"c2 > 2\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.1",
+            "type": "tool",
+            "uuid": "72bcbf67-c851-4832-afe6-de54fbabfb8b",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "62": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
+            "errors": null,
+            "id": 62,
+            "input_connections": {
+                "infile": {
+                    "id": 59,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Replace",
+                    "name": "infile"
+                }
+            ],
             "label": null,
             "name": "Replace",
             "outputs": [
@@ -1977,8 +3179,8 @@
                 }
             ],
             "position": {
-                "left": 3949.894759441091,
-                "top": 767.0987708391559
+                "left": 5880.49636843806,
+                "top": 696.6209830030986
             },
             "post_job_actions": {
                 "ChangeDatatypeActionoutfile": {
@@ -1997,45 +3199,171 @@
                 },
                 "TagDatasetActionoutfile": {
                     "action_arguments": {
-                        "tags": "\ud83c\udf1f"
+                        "tags": "\u2b50"
                     },
                     "action_type": "TagDatasetAction",
                     "output_name": "outfile"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "86755160afbf",
+                "changeset_revision": "6073bb457ec0",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"^(.+)\\\\t>Consensus_(.+)_threshold.+\", \"replace_pattern\": \">$1|$2\", \"is_regex\": true, \"global\": false, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "9.3+galaxy1",
+            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"^(.+)\\\\t>Consensus_(.+)_threshold.+\", \"replace_pattern\": \">$1|$2\", \"is_regex\": true, \"global\": false, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "9.5+galaxy0",
             "type": "tool",
-            "uuid": "cd5cfbd9-309a-42e5-957f-83258ef2a022",
+            "uuid": "d7d950b0-b500-4e46-8f9e-75824998d74d",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Per-segment consensus sequences with samples combined",
                     "output_name": "outfile",
-                    "uuid": "b7a61ef2-ddfa-402f-be33-a6afb461361f"
+                    "uuid": "3fd532fe-a2cb-40f4-869c-836c6fb4502e"
                 }
             ]
         },
-        "39": {
+        "63": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/rnateam/mafft/rbc_mafft/7.520+galaxy0",
+            "content_id": "Cut1",
             "errors": null,
-            "id": 39,
+            "id": 63,
+            "input_connections": {
+                "input": {
+                    "id": 60,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Cut",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 6152.981388331805,
+                "top": 1261.9383327332005
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "Cut1",
+            "tool_state": "{\"columnList\": \"c1\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.2",
+            "type": "tool",
+            "uuid": "dcf2c8c0-701e-4436-a011-d2a11a3daa60",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "64": {
+            "annotation": "",
+            "content_id": "Cut1",
+            "errors": null,
+            "id": 64,
+            "input_connections": {
+                "input": {
+                    "id": 61,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Cut",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 6142.533627137775,
+                "top": 1461.9383327331986
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "Cut1",
+            "tool_state": "{\"columnList\": \"c1\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.2",
+            "type": "tool",
+            "uuid": "19a6fb39-8450-4522-9506-1e949d4d77ae",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "65": {
+            "annotation": "",
+            "content_id": "__FILTER_FROM_FILE__",
+            "errors": null,
+            "id": 65,
+            "input_connections": {
+                "how|filter_source": {
+                    "id": 63,
+                    "output_name": "out_file1"
+                },
+                "input": {
+                    "id": 62,
+                    "output_name": "outfile"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Filter collection",
+                    "name": "how"
+                }
+            ],
+            "label": null,
+            "name": "Filter collection",
+            "outputs": [
+                {
+                    "name": "output_filtered",
+                    "type": "input"
+                },
+                {
+                    "name": "output_discarded",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 6426.952512798887,
+                "top": 862.9319508365453
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput_discarded": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_discarded"
+                }
+            },
+            "tool_id": "__FILTER_FROM_FILE__",
+            "tool_state": "{\"how\": {\"how_filter\": \"remove_if_absent\", \"__current_case__\": 0, \"filter_source\": {\"__class__\": \"ConnectedValue\"}}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "5f95ec61-9d83-4286-a899-3a9efc66ad72",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "66": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/rnateam/mafft/rbc_mafft/7.526+galaxy1",
+            "errors": null,
+            "id": 66,
             "input_connections": {
                 "input|batches_0|inputs": {
-                    "id": 38,
-                    "output_name": "outfile"
-                },
-                "when": {
-                    "id": 11,
-                    "output_name": "output_param_boolean"
+                    "id": 65,
+                    "output_name": "output_filtered"
                 }
             },
             "inputs": [],
@@ -2048,8 +3376,8 @@
                 }
             ],
             "position": {
-                "left": 4146.950961736724,
-                "top": 263.3305934704922
+                "left": 6675.289632288887,
+                "top": 887.6559968693706
             },
             "post_job_actions": {
                 "RenameDatasetActionoutputAlignment": {
@@ -2060,88 +3388,152 @@
                     "output_name": "outputAlignment"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/rnateam/mafft/rbc_mafft/7.520+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/rnateam/mafft/rbc_mafft/7.526+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "bf28a8cff401",
+                "changeset_revision": "1233363389c1",
                 "name": "mafft",
                 "owner": "rnateam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"datatype_selection\": {\"datatype\": \"--nuc\", \"__current_case__\": 1, \"scoring_matrix\": {\"type\": \"--kimura\", \"__current_case__\": 0, \"coefficient\": \"200\"}, \"fmodel\": false, \"gap_costs\": {\"use_defaults\": \"yes\", \"__current_case__\": 0}}, \"flavour\": {\"type\": \"mafft-fftns\", \"__current_case__\": 2}, \"input\": {\"mapping\": \"implicit\", \"__current_case__\": 0, \"batches\": [{\"__index__\": 0, \"inputs\": {\"__class__\": \"ConnectedValue\"}}]}, \"outputFormat\": \"\", \"reorder\": false, \"treeout\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "7.520+galaxy0",
+            "tool_state": "{\"anysymbol\": false, \"datatype_selection\": {\"datatype\": \"--nuc\", \"__current_case__\": 1, \"scoring_matrix\": {\"type\": \"--kimura\", \"__current_case__\": 0, \"coefficient\": \"200\"}, \"fmodel\": false, \"gap_costs\": {\"use_defaults\": \"yes\", \"__current_case__\": 0}}, \"flavour\": {\"type\": \"mafft-fftns\", \"__current_case__\": 2}, \"input\": {\"mapping\": \"implicit\", \"__current_case__\": 0, \"batches\": [{\"__index__\": 0, \"inputs\": {\"__class__\": \"RuntimeValue\"}}]}, \"outputFormat\": \"\", \"reorder\": false, \"treeout\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "7.526+galaxy1",
             "type": "tool",
-            "uuid": "86f16717-083c-4cee-ac15-3620bf04c5c8",
-            "when": "$(inputs.when)",
+            "uuid": "455f3576-0bd8-4ce4-8447-a332cb3afa15",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "Multiple sequence alignments per segment",
                     "output_name": "outputAlignment",
-                    "uuid": "8e954c40-3cc3-4dca-ae9d-b6f71b96d524"
+                    "uuid": "8096c238-9150-4e22-b22b-23e54548aae7"
                 }
             ]
         },
-        "40": {
+        "67": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+            "content_id": "__FILTER_FROM_FILE__",
             "errors": null,
-            "id": 40,
+            "id": 67,
             "input_connections": {
-                "style_cond|type_cond|default_value": {
-                    "id": 38,
-                    "output_name": "outfile"
+                "how|filter_source": {
+                    "id": 64,
+                    "output_name": "out_file1"
                 },
-                "style_cond|type_cond|pick_from_0|value": {
-                    "id": 39,
+                "input": {
+                    "id": 66,
                     "output_name": "outputAlignment"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Filter collection",
+                    "name": "how"
+                }
+            ],
             "label": null,
-            "name": "Pick parameter value",
+            "name": "Filter collection",
             "outputs": [
                 {
-                    "name": "data_param",
+                    "name": "output_filtered",
+                    "type": "input"
+                },
+                {
+                    "name": "output_discarded",
                     "type": "input"
                 }
             ],
             "position": {
-                "left": 4355.300937322661,
-                "top": 453.4472621716641
+                "left": 6665.63955411044,
+                "top": 1243.184488419405
             },
             "post_job_actions": {
-                "HideDatasetActiondata_param": {
+                "HideDatasetActionoutput_discarded": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
-                    "output_name": "data_param"
+                    "output_name": "output_discarded"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
-            "tool_shed_repository": {
-                "changeset_revision": "b19e21af9c52",
-                "name": "pick_value",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"style_cond\": {\"pick_style\": \"first_or_default\", \"__current_case__\": 1, \"type_cond\": {\"param_type\": \"data\", \"__current_case__\": 4, \"pick_from\": [{\"__index__\": 0, \"value\": {\"__class__\": \"ConnectedValue\"}}], \"default_value\": {\"__class__\": \"ConnectedValue\"}}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.2.0",
+            "tool_id": "__FILTER_FROM_FILE__",
+            "tool_state": "{\"how\": {\"how_filter\": \"remove_if_absent\", \"__current_case__\": 0, \"filter_source\": {\"__class__\": \"ConnectedValue\"}}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "e29dfb1e-10d1-4d6c-b57a-1a1354aed811",
+            "uuid": "c3e5b24f-84bd-4959-b7b8-d23a6cd62132",
             "when": null,
             "workflow_outputs": []
         },
-        "41": {
+        "68": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/iqtree/iqtree/2.3.3+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snipit/snipit/1.6+galaxy0",
             "errors": null,
-            "id": 41,
+            "id": 68,
+            "input_connections": {
+                "alignment": {
+                    "id": 66,
+                    "output_name": "outputAlignment"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool snipit",
+                    "name": "alignment"
+                }
+            ],
+            "label": null,
+            "name": "snipit",
+            "outputs": [
+                {
+                    "name": "snp_plot",
+                    "type": "png"
+                }
+            ],
+            "position": {
+                "left": 7055.894053308929,
+                "top": 1037.4228360311404
+            },
+            "post_job_actions": {
+                "RenameDatasetActionsnp_plot": {
+                    "action_arguments": {
+                        "newname": "Snipit plots per segment"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "snp_plot"
+                },
+                "TagDatasetActionsnp_plot": {
+                    "action_arguments": {
+                        "tags": "\u2b50"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "snp_plot"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snipit/snipit/1.6+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "877e80114d25",
+                "name": "snipit",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"alignment\": {\"__class__\": \"RuntimeValue\"}, \"dims\": {\"width\": \"0.0\", \"height\": \"0.0\", \"size_option\": \"\"}, \"mode\": {\"sequence_type\": \"nt\", \"__current_case__\": 0, \"ref\": {\"select\": \"first\", \"__current_case__\": 0}, \"colouring\": {\"palette\": \"classic\", \"__current_case__\": 1}}, \"plot\": {\"format\": \"png\", \"__current_case__\": 2, \"transparent_background\": false}, \"pos_restrict\": {\"show_indels\": false, \"ambig_mode\": \"snps\", \"include_positions\": [], \"exclude_positions\": []}, \"style\": {\"labels\": {\"choose\": \"\", \"__current_case__\": 0}, \"position_labels\": true, \"sort\": {\"order\": \"--sort-by-mutation-number\", \"__current_case__\": 2, \"high_to_low\": false}, \"flip_vertical\": false}, \"write_snps\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.6+galaxy0",
+            "type": "tool",
+            "uuid": "97024266-6fe4-4a95-9029-6bac3669abaa",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Snipit plots per segment",
+                    "output_name": "snp_plot",
+                    "uuid": "eece53fd-563d-46a8-8a54-70036f67fd4a"
+                }
+            ]
+        },
+        "69": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/iqtree/iqtree/2.4.0+galaxy0",
+            "errors": null,
+            "id": 69,
             "input_connections": {
                 "general_options|s": {
-                    "id": 40,
-                    "output_name": "data_param"
-                },
-                "when": {
-                    "id": 10,
-                    "output_name": "output_param_boolean"
+                    "id": 67,
+                    "output_name": "output_filtered"
                 }
             },
             "inputs": [
@@ -2183,8 +3575,8 @@
                 }
             ],
             "position": {
-                "left": 4658.398071254695,
-                "top": 154.6799234732899
+                "left": 7056.189534632637,
+                "top": 39.95604569749632
             },
             "post_job_actions": {
                 "HideDatasetActionbionj": {
@@ -2220,103 +3612,46 @@
                 },
                 "TagDatasetActioniqtree": {
                     "action_arguments": {
-                        "tags": "\ud83c\udf1f"
+                        "tags": "\u2b50"
                     },
                     "action_type": "TagDatasetAction",
                     "output_name": "iqtree"
+                },
+                "TagDatasetActionmldist": {
+                    "action_arguments": {
+                        "tags": "\u2b50"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "mldist"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/iqtree/iqtree/2.3.3+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/iqtree/iqtree/2.4.0+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "70acec670c30",
+                "changeset_revision": "6bbd30d58cf4",
                 "name": "iqtree",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"bootstrap_parameters\": {\"ultrafast_bootstrap\": {\"ufboot\": null, \"ufjack\": null, \"jack_prop\": null, \"boot_trees\": false, \"wbtl\": false, \"nmax\": \"1000\", \"bcor\": \"0.99\", \"nstep\": \"100\", \"beps\": \"0.5\", \"sampling\": null, \"bnni\": false}, \"nonparametric_bootstrap\": {\"boot\": null, \"jack\": null, \"jack_prop\": null, \"bcon\": null, \"bonly\": null, \"tbe\": false}}, \"general_options\": {\"s\": {\"__class__\": \"ConnectedValue\"}, \"o\": null, \"short_alignments\": false, \"seqtype\": \"DNA\", \"t\": {\"__class__\": \"RuntimeValue\"}, \"seed\": null, \"keep_ident\": false, \"epsilon\": null, \"safe\": false}, \"likelihood_mapping\": {\"lmap\": null, \"lmclust\": {\"__class__\": \"RuntimeValue\"}, \"quartetlh\": false}, \"miscellaneous_options\": {\"fconst\": null}, \"modelling_parameters\": {\"automatic_model\": {\"cond_model\": {\"opt_custommodel\": \"true\", \"__current_case__\": 0, \"m\": null}, \"merge_strategy\": {\"merge\": \"none\", \"__current_case__\": 0}, \"mset\": null, \"msub\": \"nuclear\", \"mfreq\": null, \"mrate\": null, \"cmin\": \"2\", \"cmax\": \"10\", \"merit\": \"AIC\", \"mtree\": false, \"madd\": null, \"mdef\": {\"__class__\": \"RuntimeValue\"}, \"modelomatic\": false}, \"specifying_substitution\": {\"mix_opt\": false}, \"rate_heterogeneity\": {\"alpha_min\": null, \"gamma_median\": false, \"i\": null, \"opt_gamma_inv\": false, \"rate\": false, \"mlrate\": false}, \"partition_model\": {\"model_selection\": {\"model\": \"none\", \"__current_case__\": 0}}, \"site_specific_frequency\": {\"tree_freq\": {\"__class__\": \"RuntimeValue\"}, \"site_freq\": null, \"freq_max\": false}}, \"time_tree\": {\"date_source\": {\"select_source\": \"none\", \"__current_case__\": 0}, \"date_tip\": null, \"date_root\": null, \"date_ci\": null, \"clock_sd\": null, \"date_no_outgroup\": false, \"date_outlier\": null, \"date_options\": null}, \"tree_parameters\": {\"tree_search\": {\"n\": null, \"ninit\": \"100\", \"ntop\": \"20\", \"nbest\": \"5\", \"nstop\": \"100\", \"radius\": \"6\", \"perturb\": \"0.5\", \"allnni\": false, \"tree_fix\": false, \"g\": {\"__class__\": \"RuntimeValue\"}, \"fast\": false, \"polytomy\": false, \"treels\": false, \"show_lh\": false, \"terrace\": false}, \"single_branch\": {\"alrt\": null, \"abayes\": false, \"lbp\": null}, \"tree_topology\": {\"trees\": {\"__class__\": \"RuntimeValue\"}, \"test\": null, \"test_weight\": false, \"test_au\": false}, \"constructing_consensus\": {\"contree\": false, \"connet\": false, \"sup_min\": \"0.0\", \"burnin\": null, \"support\": {\"__class__\": \"RuntimeValue\"}, \"suptag\": null}, \"computing_robinson_foulds\": {\"tree_dist_all\": false, \"tree_dist\": {\"__class__\": \"RuntimeValue\"}, \"tree_dist2\": {\"__class__\": \"RuntimeValue\"}}, \"generating_random\": {\"r\": null, \"rand\": null, \"branch_min\": null, \"branch_mean\": null, \"branch_max\": null}, \"ancestral_state\": {\"ancestral\": false, \"asr_min\": null}, \"symmetry_test\": {\"symtest\": false, \"symtest_remove_bad\": false, \"symtest_remove_good\": false, \"symtest_type\": null, \"symtest_pval\": null, \"symtest_keep_zero\": false}, \"concordance_factor\": {\"gcf\": {\"__class__\": \"RuntimeValue\"}, \"df_tree\": false, \"scf\": null, \"cf_verbose\": false, \"cf_quartet\": false}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.3.3+galaxy0",
+            "tool_state": "{\"bootstrap_parameters\": {\"ultrafast_bootstrap\": {\"ufboot\": null, \"ufjack\": null, \"jack_prop\": null, \"boot_trees\": false, \"wbtl\": false, \"nmax\": \"1000\", \"bcor\": \"0.99\", \"nstep\": \"100\", \"beps\": \"0.5\", \"sampling\": null, \"bnni\": false}, \"nonparametric_bootstrap\": {\"boot\": null, \"jack\": null, \"jack_prop\": null, \"bcon\": null, \"bonly\": null, \"tbe\": false}}, \"general_options\": {\"s\": {\"__class__\": \"RuntimeValue\"}, \"o\": null, \"short_alignments\": false, \"seqtype\": \"DNA\", \"t\": {\"__class__\": \"RuntimeValue\"}, \"seed\": null, \"keep_ident\": false, \"epsilon\": null, \"safe\": false}, \"likelihood_mapping\": {\"lmap\": null, \"lmclust\": {\"__class__\": \"RuntimeValue\"}, \"quartetlh\": false}, \"miscellaneous_options\": {\"fconst\": null, \"blmin\": null, \"blmax\": null}, \"modelling_parameters\": {\"automatic_model\": {\"cond_model\": {\"opt_custommodel\": \"true\", \"__current_case__\": 0, \"m\": null}, \"merge_strategy\": {\"merge\": \"none\", \"__current_case__\": 0}, \"mset\": null, \"msub\": \"nuclear\", \"mfreq\": null, \"mrate\": null, \"cmin\": \"2\", \"cmax\": \"10\", \"merit\": \"AIC\", \"mtree\": false, \"madd\": null, \"mdef\": {\"__class__\": \"RuntimeValue\"}, \"modelomatic\": false}, \"specifying_substitution\": {\"mix_opt\": false}, \"rate_heterogeneity\": {\"alpha_min\": null, \"gamma_median\": false, \"i\": null, \"opt_gamma_inv\": false, \"rate\": false, \"mlrate\": false}, \"partition_model\": {\"model_selection\": {\"model\": \"none\", \"__current_case__\": 0}}, \"site_specific_frequency\": {\"tree_freq\": {\"__class__\": \"RuntimeValue\"}, \"site_freq\": null, \"freq_max\": false}}, \"time_tree\": {\"date_source\": {\"select_source\": \"none\", \"__current_case__\": 0}, \"date_tip\": null, \"date_root\": null, \"date_ci\": null, \"clock_sd\": null, \"date_no_outgroup\": false, \"date_outlier\": null, \"date_options\": null}, \"tree_parameters\": {\"tree_search\": {\"n\": null, \"ninit\": \"100\", \"ntop\": \"20\", \"nbest\": \"5\", \"nstop\": \"100\", \"radius\": \"6\", \"perturb\": \"0.5\", \"allnni\": false, \"tree_fix\": false, \"g\": {\"__class__\": \"RuntimeValue\"}, \"fast\": false, \"polytomy\": false, \"treels\": false, \"show_lh\": false, \"terrace\": false}, \"single_branch\": {\"alrt\": null, \"abayes\": false, \"lbp\": null}, \"tree_topology\": {\"trees\": {\"__class__\": \"RuntimeValue\"}, \"test\": null, \"test_weight\": false, \"test_au\": false}, \"constructing_consensus\": {\"contree\": false, \"connet\": false, \"sup_min\": \"0.0\", \"burnin\": null, \"support\": {\"__class__\": \"RuntimeValue\"}, \"suptag\": null}, \"computing_robinson_foulds\": {\"tree_dist_all\": false, \"tree_dist\": {\"__class__\": \"RuntimeValue\"}, \"tree_dist2\": {\"__class__\": \"RuntimeValue\"}}, \"generating_random\": {\"r\": null, \"rand\": null, \"branch_min\": null, \"branch_mean\": null, \"branch_max\": null}, \"ancestral_state\": {\"ancestral\": false, \"asr_min\": null}, \"symmetry_test\": {\"symtest\": false, \"symtest_remove_bad\": false, \"symtest_remove_good\": false, \"symtest_type\": null, \"symtest_pval\": null, \"symtest_keep_zero\": false}, \"concordance_factor\": {\"gcf\": {\"__class__\": \"RuntimeValue\"}, \"df_tree\": false, \"scf\": null, \"cf_verbose\": false, \"cf_quartet\": false}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.4.0+galaxy0",
             "type": "tool",
-            "uuid": "a4745843-80b5-4017-94f3-4ed895e3d08c",
-            "when": "$(inputs.when)",
+            "uuid": "e7955eb4-bbeb-4572-9f15-d7c3a33b7e02",
+            "when": null,
             "workflow_outputs": [
                 {
                     "label": "IQ-Tree per-segment ML tree",
                     "output_name": "treefile",
-                    "uuid": "08ab78b7-2612-4315-ab3a-fb2588c82172"
-                },
-                {
-                    "label": "IQ-Tree per-segment ML distance matrix",
-                    "output_name": "mldist",
-                    "uuid": "c5d752a6-d45f-46ad-a7fd-600b28ad5454"
+                    "uuid": "9a4a039a-1899-41d8-92cf-758be2211523"
                 },
                 {
                     "label": "IQ-Tree per-segment report",
                     "output_name": "iqtree",
-                    "uuid": "b8fc5bb9-c8dc-4db1-be8c-69de315bff49"
-                }
-            ]
-        },
-        "42": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/snipit/snipit/1.2+galaxy0",
-            "errors": null,
-            "id": 42,
-            "input_connections": {
-                "alignment": {
-                    "id": 40,
-                    "output_name": "data_param"
+                    "uuid": "2768bd7f-fb74-444d-bfa6-090d4dbca22a"
                 },
-                "when": {
-                    "id": 11,
-                    "output_name": "output_param_boolean"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "snipit",
-            "outputs": [
                 {
-                    "name": "snp_plot",
-                    "type": "png"
-                }
-            ],
-            "position": {
-                "left": 4656.336680310707,
-                "top": 1184.260547419398
-            },
-            "post_job_actions": {
-                "RenameDatasetActionsnp_plot": {
-                    "action_arguments": {
-                        "newname": "Snipit plots per segment"
-                    },
-                    "action_type": "RenameDatasetAction",
-                    "output_name": "snp_plot"
-                },
-                "TagDatasetActionsnp_plot": {
-                    "action_arguments": {
-                        "tags": "\ud83c\udf1f"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "snp_plot"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/snipit/snipit/1.2+galaxy0",
-            "tool_shed_repository": {
-                "changeset_revision": "92b9fd5f1f9f",
-                "name": "snipit",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"alignment\": {\"__class__\": \"ConnectedValue\"}, \"dims\": {\"width\": \"0.0\", \"height\": \"0.0\", \"size_option\": \"\"}, \"plot\": {\"format\": \"png\", \"__current_case__\": 2, \"transparent_background\": false}, \"pos_restrict\": {\"include_positions\": [], \"exclude_positions\": [], \"exclude_ambig_pos\": false}, \"ref\": {\"select\": \"first\", \"__current_case__\": 0}, \"show_indels\": false, \"style\": {\"labels\": {\"choose\": \"\", \"__current_case__\": 0}, \"colouring\": {\"palette\": \"classic\", \"__current_case__\": 1}, \"sort\": {\"order\": \"--sort-by-mutation-number\", \"__current_case__\": 2, \"high_to_low\": false}, \"flip_vertical\": false}, \"write_snps\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.2+galaxy0",
-            "type": "tool",
-            "uuid": "bb67a577-8d17-48bc-a966-d678b0d82bc2",
-            "when": "$(inputs.when)",
-            "workflow_outputs": [
-                {
-                    "label": "Snipit plots per segment",
-                    "output_name": "snp_plot",
-                    "uuid": "ff202345-aa4f-426f-aaf1-46208d738fcd"
+                    "label": "IQ-Tree per-segment ML distance matrix",
+                    "output_name": "mldist",
+                    "uuid": "347a2034-e19b-45d1-9e0c-fc45cac59f32"
                 }
             ]
         }
@@ -2325,6 +3660,6 @@
         "AIV",
         "virology"
     ],
-    "uuid": "26114133-2c7d-4f90-8f62-0ed5837b5948",
-    "version": 1
+    "uuid": "fb161003-8ad7-4a72-8835-bfd2c9088092",
+    "version": 2
 }

--- a/workflows/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.ga
+++ b/workflows/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping.ga
@@ -1,6 +1,6 @@
 {
     "a_galaxy_workflow": "true",
-    "annotation": "Influenza A isolate subtyping and consensus sequence generation",
+    "annotation": "This workflow performs subtyping and consensus sequence generation for batches of Illumina PE sequenced Influenza A isolates.",
     "comments": [
         {
             "child_steps": [


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [X] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [X] License permits unrestricted use (educational + commercial)
* [X] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [X] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [X] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [X] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [X] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [X] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [X] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [X] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [X] Changelog contains appropriate entries
* [X] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
