### PR TITLE
VGP 8 - fix busco bug and gfa reconciliation

### DIFF
--- a/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/CHANGELOG.md
+++ b/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.6] - 2025-05-09
+
+### Changes
+
+- Fix bug in the previous release where busco parameters were not connecting properly
+- Fix bug where the graph reconciliation where not using the right gfa input, causing to loose some graph informations.  
+
 ## [1.5] - 2025-04-14
 
 ### Automatic update

--- a/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml
+++ b/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml
@@ -31,11 +31,13 @@
     "Reconciliated Scaffolds: gfa":
       asserts:
         has_n_lines:
-          n: 168
-    'Reconciliated Scaffolds: fasta':
+          n: 172
+    "Reconciliated Scaffolds: fasta":
       asserts:
         has_n_lines:
-          n: 166
+          n: 83
+    Suffixed AGP:
+      asserts:
         has_text:
           text: "scaffold_53.hap1"
     Busco Summary:

--- a/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.ga
+++ b/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.ga
@@ -15,6 +15,7 @@
     ],
     "format-version": "0.1",
     "license": "CC-BY-4.0",
+    "release": "1.6",
     "name": "Scaffolding with Hi-C data VGP8",
     "report": {
         "markdown": "# Workflow Execution Report\n\nTime workflow was invoked\n\n```galaxy\ninvocation_time()\n```\n\n```galaxy\ngenerate_galaxy_version()\n```\n\n\n## BUSCO results (Vertebrata database)\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Busco Summary image\")\n```\n\n\n## Assembly statistics\n\n\n```galaxy\nhistory_dataset_as_table(output=\"clean_stats\")\n```\n\n\n## Nx and Size plots\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Nx Plot\")\n```\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Size Plot\")\n```\n\n## PretextMap\n\n### Before Scaffolding\n\n\r\n```galaxy\nhistory_dataset_as_image(output=\"Pretext Map Before HiC scaffolding\")\n```\r\n\n\n### After Scaffolding\r\n```galaxy\nhistory_dataset_as_image(output=\"Pretext Map After HiC scaffolding\")\n```\r\n\n\n\n\n## Current Workflow\n```galaxy\nworkflow_display()\n```\n"
@@ -72,13 +73,7 @@
             "type": "parameter_input",
             "uuid": "3495a63c-bcd5-45fa-b327-ed7ec0234e78",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "ca2753c2-3d46-434a-a49c-770c1871e770"
-                }
-            ]
+            "workflow_outputs": []
         },
         "2": {
             "annotation": "",
@@ -132,13 +127,7 @@
             "type": "parameter_input",
             "uuid": "68c2f24e-7f3f-40f9-b0dc-bbdd9ca46874",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "1e577916-551b-49be-8a67-c8dac1cb466a"
-                }
-            ]
+            "workflow_outputs": []
         },
         "4": {
             "annotation": "Select the database to use for Busco lineage. ",
@@ -165,13 +154,7 @@
             "type": "parameter_input",
             "uuid": "1f4997fc-1880-4416-8857-2a63d3501a6c",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "786bae3b-6e91-432d-be15-29104c3f563f"
-                }
-            ]
+            "workflow_outputs": []
         },
         "5": {
             "annotation": "Taxonomic lineage for the organism being assembled for Busco analysis.\n",
@@ -198,13 +181,7 @@
             "type": "parameter_input",
             "uuid": "b45e6bda-be0e-45e7-a9b1-17325a08dd76",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "aebb9bb9-7420-4001-ab79-5a48e461152e"
-                }
-            ]
+            "workflow_outputs": []
         },
         "6": {
             "annotation": "Restriction enzymes used in preparation of Hi-C libraries.",
@@ -231,13 +208,7 @@
             "type": "parameter_input",
             "uuid": "b899a210-60c2-4e9e-8a34-e1bc82ef373d",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "2dbf4781-1db4-4b00-9675-f44dbe8e07ae"
-                }
-            ]
+            "workflow_outputs": []
         },
         "7": {
             "annotation": "Estimated genome size from contiging workflow.",
@@ -803,11 +774,6 @@
                     "label": "s1 Trimmed Hi-C data",
                     "output_name": "Trimmed Hi-C data",
                     "uuid": "bfee12c8-1715-48ad-a35b-d938e9038c87"
-                },
-                {
-                    "label": null,
-                    "output_name": "2:output",
-                    "uuid": "be38218d-57c8-4977-a0f4-42e1d30d8b1b"
                 }
             ]
         },
@@ -1000,7 +966,13 @@
             "type": "tool",
             "uuid": "4d5d4a06-e906-4c73-8159-050d49158dd3",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": "Suffixed AGP",
+                    "output_name": "outfile",
+                    "uuid": "bad93ed2-474b-4d14-900e-697e9c5f6325"
+                }
+            ]
         },
         "15": {
             "annotation": "",
@@ -1061,7 +1033,7 @@
             "id": 16,
             "input_connections": {
                 "input_file": {
-                    "id": 8,
+                    "id": 0,
                     "output_name": "output"
                 },
                 "mode_condition|agp_to_path": {
@@ -1125,7 +1097,7 @@
             "id": 17,
             "input_connections": {
                 "input_file": {
-                    "id": 8,
+                    "id": 0,
                     "output_name": "output"
                 },
                 "mode_condition|agp_to_path": {
@@ -1460,6 +1432,10 @@
             "errors": null,
             "id": 23,
             "input_connections": {
+                "cached_db": {
+                    "id": 4,
+                    "output_name": "output"
+                },
                 "input": {
                     "id": 19,
                     "output_name": "output"
@@ -1542,7 +1518,7 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"adv\": {\"evalue\": \"0.001\", \"limit\": \"3\", \"contig_break\": \"10\"}, \"busco_mode\": {\"mode\": \"geno\", \"__current_case__\": 0, \"use_augustus\": {\"use_augustus_selector\": \"metaeuk\", \"__current_case__\": 0}}, \"cached_db\": null, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineage\": {\"lineage_mode\": \"select_lineage\", \"__current_case__\": 1, \"lineage_dataset\": {\"__class__\": \"ConnectedValue\"}}, \"lineage_conditional\": {\"__current_case__\": 0, \"cached_db\": {\"__class__\": \"ConnectedValue\"}, \"selector\": \"cached\"}, \"outputs\": [\"short_summary\", \"missing\", \"image\", \"gff\"], \"test\": null, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"adv\": {\"evalue\": \"0.001\", \"limit\": \"3\", \"contig_break\": \"10\"}, \"busco_mode\": {\"mode\": \"geno\", \"__current_case__\": 0, \"use_augustus\": {\"use_augustus_selector\": \"metaeuk\", \"__current_case__\": 0}}, \"cached_db\": {\"__class__\": \"ConnectedValue\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineage\": {\"lineage_mode\": \"select_lineage\", \"__current_case__\": 1, \"lineage_dataset\": {\"__class__\": \"ConnectedValue\"}}, \"outputs\": [\"short_summary\", \"missing\", \"image\", \"gff\"], \"test\": null, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_version": "5.8.0+galaxy1",
             "type": "tool",
             "uuid": "c30b907f-05c9-4709-a939-b66f52daf6e4",
@@ -2475,7 +2451,6 @@
     "tags": [
         "VGP_curated"
     ],
-    "uuid": "a1c23a5e-156a-4ebc-8146-8a7dfc17ae53",
-    "version": 1,
-    "release": "1.5"
+    "uuid": "9e5c9e21-8f4c-478c-a73e-153e65a49155",
+    "version": 2
 }


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
