### PR TITLE
Updating workflows/genome-assembly/bacterial-genome-assembly from 1.1.5 to 1.1.6

### DIFF
--- a/workflows/genome-assembly/bacterial-genome-assembly/CHANGELOG.md
+++ b/workflows/genome-assembly/bacterial-genome-assembly/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
-## [1.1.6] - 2025-04-14
+## [1.1.6] - 2025-05-14
 
 ### Automatic update
 - `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0`
 - `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0`
+
+### Manual update
+- Changes output name/tag for Tooldistillator
+- Fixes syntax and parameter errors
+- Changes QUAST parameters: --min-contig `0` and --contig-thresholds `0,200,500,1000`
+- Adds Checkm2
+
 
 ## [1.1.5] - 2024-11-18
 

--- a/workflows/genome-assembly/bacterial-genome-assembly/CHANGELOG.md
+++ b/workflows/genome-assembly/bacterial-genome-assembly/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Changes output name/tag for Tooldistillator
 - Fixes syntax and parameter errors
 - Changes QUAST parameters: --min-contig `0` and --contig-thresholds `0,200,500,1000`
-- Adds Checkm2
+- Adds Checkm2 to predict the completeness and contamination
 
 
 ## [1.1.5] - 2024-11-18

--- a/workflows/genome-assembly/bacterial-genome-assembly/CHANGELOG.md
+++ b/workflows/genome-assembly/bacterial-genome-assembly/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.6] - 2025-04-14
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0`
+
 ## [1.1.5] - 2024-11-18
 
 ### Automatic update

--- a/workflows/genome-assembly/bacterial-genome-assembly/README.md
+++ b/workflows/genome-assembly/bacterial-genome-assembly/README.md
@@ -1,9 +1,10 @@
-# Bacterial genome assembly workflow for paired end data (v1.0)
+# Bacterial genome assembly workflow for paired end data (v1.1.6)
 
 This workflow uses paired-end illumina trimmed reads fastq(.gz) files and executes the following steps:
 1. Assembly raw reads to a final contig fasta file 
     - **Shovill**
 2. Quality control of the assembly
+    - **Checkm2** to predict the completeness and contamination
     - **Quast**
     - **Bandage** to plot assembly graph
     - **Refseqmasher** to identify the closed reference genome
@@ -21,8 +22,9 @@ This workflow uses paired-end illumina trimmed reads fastq(.gz) files and execut
     - Mapped read on assembly in bam format
     - Graph assembly in gfa format
 2. Quality of Assembly:
+    - Expected completeness and contamination report
     - Assembly report
     - Assembly Graph
     - Tabular result of closed reference genome
 3. Aggregating outputs
-    - JSON file with information about the outputs of **Shovill**, **Quast**, **Bandage**, **Refseqmasher**
+    - JSON file with information about the outputs of **Shovill**, **Checkm2**, **Quast**, **Bandage**, **Refseqmasher**

--- a/workflows/genome-assembly/bacterial-genome-assembly/bacterial_genome_assembly-tests.yml
+++ b/workflows/genome-assembly/bacterial-genome-assembly/bacterial_genome_assembly-tests.yml
@@ -21,6 +21,12 @@
       asserts:
         has_text:
           text: ">contig00001"
+    checkm2_quality_report:
+      asserts:
+        has_text:
+          text: "Completeness"
+        has_n_columns:
+          n: 14
     quast_report_tabular:
       asserts:
         has_n_columns:
@@ -43,7 +49,7 @@
           text: "Total length orphaned nodes (bp):"
         has_n_columns:
           n: 2
-    tooldistillator_summarize:
+    tooldistillator_summarize_assembly:
       asserts:
         has_text:
           text: "\"Assembly\": \"shovill_contigs_fasta\""
@@ -51,3 +57,5 @@
           text: "Enterococcus faecalis EnGen0295"
         has_text:
           text: "bandage_plot_path"
+        has_text:
+          text: "Contamination"

--- a/workflows/genome-assembly/bacterial-genome-assembly/bacterial_genome_assembly-tests.yml
+++ b/workflows/genome-assembly/bacterial-genome-assembly/bacterial_genome_assembly-tests.yml
@@ -26,7 +26,7 @@
         has_text:
           text: "Completeness"
         has_n_columns:
-          n: 14
+          n: 15
     quast_report_tabular:
       asserts:
         has_n_columns:

--- a/workflows/genome-assembly/bacterial-genome-assembly/bacterial_genome_assembly.ga
+++ b/workflows/genome-assembly/bacterial-genome-assembly/bacterial_genome_assembly.ga
@@ -47,7 +47,7 @@
             "outputs": [],
             "position": {
                 "left": 0,
-                "top": 26.85905752718789
+                "top": 285.67293735007604
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"format\": [\"fastq\", \"fastq.gz\", \"fastqsanger\", \"fastqsanger.gz\"], \"tag\": \"\"}",
@@ -74,7 +74,7 @@
             "outputs": [],
             "position": {
                 "left": 1.5420743426057233,
-                "top": 179.85816302215434
+                "top": 438.6720428450425
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"format\": [\"fastq\", \"fastq.gz\", \"fastqsanger\", \"fastqsanger.gz\"], \"tag\": \"\"}",
@@ -131,7 +131,7 @@
             ],
             "position": {
                 "left": 308.4719663659007,
-                "top": 131.00139799356907
+                "top": 389.81527781645724
             },
             "post_job_actions": {
                 "ChangeDatatypeActionbamfiles": {
@@ -212,9 +212,9 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "shovill_contigs_fasta",
-                    "output_name": "contigs",
-                    "uuid": "c74a1bd3-1a9e-45c2-aa00-4c42a6269eee"
+                    "label": "shovill_alignment_bam",
+                    "output_name": "bamfiles",
+                    "uuid": "8cbb3659-4de3-4c4f-b15d-c44dd5b5ccfa"
                 },
                 {
                     "label": "shovill_contigs_graph",
@@ -222,14 +222,14 @@
                     "uuid": "d368ce7d-6123-436e-a566-a7ae0f56234d"
                 },
                 {
-                    "label": "shovill_alignment_bam",
-                    "output_name": "bamfiles",
-                    "uuid": "8cbb3659-4de3-4c4f-b15d-c44dd5b5ccfa"
-                },
-                {
                     "label": "shovill_logfile",
                     "output_name": "shovill_std_log",
                     "uuid": "3b25ebd4-8348-43ac-afdc-870e292d420e"
+                },
+                {
+                    "label": "shovill_contigs_fasta",
+                    "output_name": "contigs",
+                    "uuid": "c74a1bd3-1a9e-45c2-aa00-4c42a6269eee"
                 }
             ]
         },
@@ -274,8 +274,8 @@
                 }
             ],
             "position": {
-                "left": 583.5485996614345,
-                "top": 0
+                "left": 641.3441207119594,
+                "top": 250.760691414806
             },
             "post_job_actions": {
                 "RenameDatasetActionlog": {
@@ -342,22 +342,12 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"advanced\": {\"contig_thresholds\": \"0,1000\", \"strict_NA\": false, \"extensive_mis_size\": \"1000\", \"scaffold_gap_max_size\": \"1000\", \"unaligned_part_size\": \"500\", \"skip_unaligned_mis_contigs\": true, \"fragmented_max_indent\": null, \"report_all_metrics\": false, \"x_for_Nx\": \"90\"}, \"alignments\": {\"use_all_alignments\": false, \"min_alignment\": \"65\", \"ambiguity_usage\": \"one\", \"ambiguity_score\": \"0.99\", \"fragmented\": false, \"upper_bound_assembly\": false, \"upper_bound_min_con\": null, \"local_mis_size\": \"200\"}, \"assembly\": {\"type\": \"genome\", \"__current_case__\": 0, \"ref\": {\"use_ref\": \"false\", \"__current_case__\": 1, \"est_ref_size\": null}, \"orga_type\": \"\", \"min_identity\": \"95.0\"}, \"genes\": {\"gene_finding\": {\"tool\": \"none\", \"__current_case__\": 0}, \"rna_finding\": false, \"conserved_genes_finding\": true}, \"large\": false, \"min_contig\": \"500\", \"mode\": {\"mode\": \"individual\", \"__current_case__\": 0, \"in\": {\"custom\": \"false\", \"__current_case__\": 1, \"inputs\": {\"__class__\": \"ConnectedValue\"}}, \"reads\": {\"reads_option\": \"paired\", \"__current_case__\": 2, \"input_1\": {\"__class__\": \"ConnectedValue\"}, \"input_2\": {\"__class__\": \"ConnectedValue\"}}}, \"output_files\": [\"html\", \"pdf\", \"tabular\", \"log\", \"summary\", \"krona\"], \"split_scaffolds\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"advanced\": {\"contig_thresholds\": \"0,200,500,1000\", \"strict_NA\": false, \"extensive_mis_size\": \"1000\", \"scaffold_gap_max_size\": \"1000\", \"unaligned_part_size\": \"500\", \"skip_unaligned_mis_contigs\": true, \"fragmented_max_indent\": null, \"report_all_metrics\": false, \"x_for_Nx\": \"90\"}, \"alignments\": {\"use_all_alignments\": false, \"min_alignment\": \"65\", \"ambiguity_usage\": \"one\", \"ambiguity_score\": \"0.99\", \"fragmented\": false, \"upper_bound_assembly\": false, \"upper_bound_min_con\": null, \"local_mis_size\": \"200\"}, \"assembly\": {\"type\": \"genome\", \"__current_case__\": 0, \"ref\": {\"use_ref\": \"false\", \"__current_case__\": 1, \"est_ref_size\": null}, \"orga_type\": \"\", \"min_identity\": \"95.0\"}, \"genes\": {\"gene_finding\": {\"tool\": \"none\", \"__current_case__\": 0}, \"rna_finding\": false, \"conserved_genes_finding\": true}, \"large\": false, \"min_contig\": \"0\", \"mode\": {\"mode\": \"individual\", \"__current_case__\": 0, \"in\": {\"custom\": \"false\", \"__current_case__\": 1, \"inputs\": {\"__class__\": \"ConnectedValue\"}}, \"reads\": {\"reads_option\": \"paired\", \"__current_case__\": 2, \"input_1\": {\"__class__\": \"ConnectedValue\"}, \"input_2\": {\"__class__\": \"ConnectedValue\"}}}, \"output_files\": [\"html\", \"pdf\", \"tabular\", \"log\", \"summary\", \"krona\"], \"split_scaffolds\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_version": "5.3.0+galaxy0",
             "type": "tool",
             "uuid": "94a29697-b779-4cf4-a25c-c59f7f88325c",
             "when": null,
             "workflow_outputs": [
-                {
-                    "label": "quast_log",
-                    "output_name": "log",
-                    "uuid": "eadbce9e-d43b-43b1-9704-cae70da20521"
-                },
-                {
-                    "label": "quast_report_pdf",
-                    "output_name": "report_pdf",
-                    "uuid": "7477d62e-ff9f-4fca-8318-dbd876805655"
-                },
                 {
                     "label": "quast_report_tabular",
                     "output_name": "report_tabular",
@@ -367,14 +357,135 @@
                     "label": "quast_report_html",
                     "output_name": "report_html",
                     "uuid": "4169fc6b-c47e-4994-b44e-ca62e804f902"
+                },
+                {
+                    "label": "quast_report_pdf",
+                    "output_name": "report_pdf",
+                    "uuid": "7477d62e-ff9f-4fca-8318-dbd876805655"
+                },
+                {
+                    "label": "quast_log",
+                    "output_name": "log",
+                    "uuid": "eadbce9e-d43b-43b1-9704-cae70da20521"
                 }
             ]
         },
         "4": {
+            "annotation": "Checkm2 to predict the completeness and contamination in an assembly",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/checkm2/checkm2/1.0.2+galaxy1",
+            "errors": null,
+            "id": 4,
+            "input_connections": {
+                "input": {
+                    "id": 2,
+                    "output_name": "contigs"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool checkm2",
+                    "name": "input"
+                }
+            ],
+            "label": "checkm2_quality",
+            "name": "checkm2",
+            "outputs": [
+                {
+                    "name": "protein_files",
+                    "type": "input"
+                },
+                {
+                    "name": "diamond_files",
+                    "type": "input"
+                },
+                {
+                    "name": "quality",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 931.097614765965,
+                "top": 0
+            },
+            "post_job_actions": {
+                "RenameDatasetActiondiamond_files": {
+                    "action_arguments": {
+                        "newname": "checkm2_diamond_files"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "diamond_files"
+                },
+                "RenameDatasetActionprotein_files": {
+                    "action_arguments": {
+                        "newname": "checkm2_protein_files"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "protein_files"
+                },
+                "RenameDatasetActionquality": {
+                    "action_arguments": {
+                        "newname": "checkm2_quality_report"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "quality"
+                },
+                "TagDatasetActiondiamond_files": {
+                    "action_arguments": {
+                        "tags": "checkm2_diamond_files"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "diamond_files"
+                },
+                "TagDatasetActionprotein_files": {
+                    "action_arguments": {
+                        "tags": "checkm2_protein_files"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "protein_files"
+                },
+                "TagDatasetActionquality": {
+                    "action_arguments": {
+                        "tags": "checkm2_quality_report"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "quality"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/checkm2/checkm2/1.0.2+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "66acaec9f386",
+                "name": "checkm2",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"database\": \"1.0.2\", \"genes\": false, \"input\": {\"__class__\": \"RuntimeValue\"}, \"model\": \"--allmodels\", \"ttable\": \"11\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.2+galaxy1",
+            "type": "tool",
+            "uuid": "bc17d89d-9cea-43d2-948f-208c380a689c",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "checkm2_protein_files",
+                    "output_name": "protein_files",
+                    "uuid": "b820d312-75e1-4c16-9a5c-703fa942ba40"
+                },
+                {
+                    "label": "checkm2_quality_report",
+                    "output_name": "quality",
+                    "uuid": "10bcd570-32a2-4b17-995a-ad3f77f87ed6"
+                },
+                {
+                    "label": "checkm2_diamond_files",
+                    "output_name": "diamond_files",
+                    "uuid": "13455415-cadb-499c-8a62-d03b979ca791"
+                }
+            ]
+        },
+        "5": {
             "annotation": "refseqmasher_genome, search close reference genome in refseq database",
             "content_id": "toolshed.g2.bx.psu.edu/repos/nml/refseq_masher/refseq_masher_matches/0.1.2",
             "errors": null,
-            "id": 4,
+            "id": 5,
             "input_connections": {
                 "input|fasta": {
                     "id": 2,
@@ -397,7 +508,7 @@
             ],
             "position": {
                 "left": 793.6819614778408,
-                "top": 329.4499969482422
+                "top": 588.2638767711303
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput_path_tab": {
@@ -435,11 +546,11 @@
                 }
             ]
         },
-        "5": {
+        "6": {
             "annotation": "bandage_contig_graph_stats",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bandage/bandage_info/2022.09+galaxy2",
             "errors": null,
-            "id": 5,
+            "id": 6,
             "input_connections": {
                 "input_file": {
                     "id": 2,
@@ -457,7 +568,7 @@
             ],
             "position": {
                 "left": 771.3861542615132,
-                "top": 516.142295707301
+                "top": 774.9561755301891
             },
             "post_job_actions": {
                 "RenameDatasetActionoutfile": {
@@ -495,11 +606,11 @@
                 }
             ]
         },
-        "6": {
+        "7": {
             "annotation": "bandage_contig_graph_plot",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bandage/bandage_image/2022.09+galaxy4",
             "errors": null,
-            "id": 6,
+            "id": 7,
             "input_connections": {
                 "input_file": {
                     "id": 2,
@@ -517,7 +628,7 @@
             ],
             "position": {
                 "left": 769.9687076931637,
-                "top": 740.2606081887517
+                "top": 999.0744880116399
             },
             "post_job_actions": {
                 "RenameDatasetActionoutfile": {
@@ -555,11 +666,56 @@
                 }
             ]
         },
-        "7": {
+        "8": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+            "errors": null,
+            "id": 8,
+            "input_connections": {
+                "input_list": {
+                    "id": 4,
+                    "output_name": "diamond_files"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Collapse Collection",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1229.574610906845,
+                "top": 178.7195901961486
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+            "tool_shed_repository": {
+                "changeset_revision": "90981f86000f",
+                "name": "collapse_collections",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"filename\": {\"add_name\": false, \"__current_case__\": 1}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "5.1.0",
+            "type": "tool",
+            "uuid": "bc6d941a-f912-4e20-af39-8bec966a4242",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "9": {
             "annotation": "ToolDistillator extracts results from tools and creates a JSON file for each tool",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0",
             "errors": null,
-            "id": 7,
+            "id": 9,
             "input_connections": {
                 "tool_section|tools_0|select_tool|bam_file_path": {
                     "id": 2,
@@ -582,16 +738,24 @@
                     "output_name": "report_html"
                 },
                 "tool_section|tools_2|select_tool|input": {
-                    "id": 4,
+                    "id": 5,
                     "output_name": "output_path_tab"
                 },
                 "tool_section|tools_3|select_tool|bandage_plot_path": {
-                    "id": 6,
+                    "id": 7,
                     "output_name": "outfile"
                 },
                 "tool_section|tools_3|select_tool|input": {
-                    "id": 5,
+                    "id": 6,
                     "output_name": "outfile"
+                },
+                "tool_section|tools_4|select_tool|diamond_results_path": {
+                    "id": 8,
+                    "output_name": "output"
+                },
+                "tool_section|tools_4|select_tool|input": {
+                    "id": 4,
+                    "output_name": "quality"
                 }
             },
             "inputs": [],
@@ -604,20 +768,20 @@
                 }
             ],
             "position": {
-                "left": 1299.389187169496,
-                "top": 264.0158282844628
+                "left": 1568.174293876626,
+                "top": 205.64727095267924
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput_json": {
                     "action_arguments": {
-                        "newname": "tooldistillator_results"
+                        "newname": "tooldistillator_results_assembly"
                     },
                     "action_type": "RenameDatasetAction",
                     "output_name": "output_json"
                 },
                 "TagDatasetActionoutput_json": {
                     "action_arguments": {
-                        "tags": "tooldistillator_results"
+                        "tags": "tooldistillator_results_assembly"
                     },
                     "action_type": "TagDatasetAction",
                     "output_name": "output_json"
@@ -630,27 +794,27 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"log\": false, \"tool_section\": {\"tools\": [{\"__index__\": 0, \"select_tool\": {\"tool_list\": \"shovill\", \"__current_case__\": 20, \"input\": {\"__class__\": \"ConnectedValue\"}, \"contig_graph_path\": {\"__class__\": \"ConnectedValue\"}, \"bam_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 1, \"select_tool\": {\"tool_list\": \"quast\", \"__current_case__\": 17, \"input\": {\"__class__\": \"ConnectedValue\"}, \"quast_html_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 2, \"select_tool\": {\"tool_list\": \"refseqmasher\", \"__current_case__\": 19, \"input\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 3, \"select_tool\": {\"tool_list\": \"bandage\", \"__current_case__\": 3, \"input\": {\"__class__\": \"ConnectedValue\"}, \"bandage_plot_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"log\": false, \"tool_section\": {\"tools\": [{\"__index__\": 0, \"select_tool\": {\"tool_list\": \"shovill\", \"__current_case__\": 20, \"input\": {\"__class__\": \"ConnectedValue\"}, \"contig_graph_path\": {\"__class__\": \"ConnectedValue\"}, \"bam_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": null}}, {\"__index__\": 1, \"select_tool\": {\"tool_list\": \"quast\", \"__current_case__\": 17, \"input\": {\"__class__\": \"ConnectedValue\"}, \"quast_html_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": null}}, {\"__index__\": 2, \"select_tool\": {\"tool_list\": \"refseqmasher\", \"__current_case__\": 19, \"input\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": null}}, {\"__index__\": 3, \"select_tool\": {\"tool_list\": \"bandage\", \"__current_case__\": 3, \"input\": {\"__class__\": \"ConnectedValue\"}, \"bandage_plot_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": null}}, {\"__index__\": 4, \"select_tool\": {\"tool_list\": \"checkm2\", \"__current_case__\": 6, \"input\": {\"__class__\": \"ConnectedValue\"}, \"diamond_results_path\": {\"__class__\": \"ConnectedValue\"}, \"protein_zip_path\": {\"__class__\": \"RuntimeValue\"}, \"checkm2_log_path\": {\"__class__\": \"RuntimeValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": null}}]}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.9.2+galaxy0",
             "type": "tool",
             "uuid": "b6156c8e-5048-41e3-90d9-f9302734c3d1",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "tooldistillator_results",
+                    "label": "tooldistillator_results_assembly",
                     "output_name": "output_json",
-                    "uuid": "6f9bffbd-5b92-47ee-9d52-5846a7db2a4a"
+                    "uuid": "b24e9f04-9398-4bdd-8697-fd44ad8129b6"
                 }
             ]
         },
-        "8": {
+        "10": {
             "annotation": "ToolDistillator summarize groups all JSON file into a unique JSON file",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0",
             "errors": null,
-            "id": 8,
+            "id": 10,
             "input_connections": {
                 "summarize_data": {
-                    "id": 7,
+                    "id": 9,
                     "output_name": "output_json"
                 }
             },
@@ -664,20 +828,20 @@
                 }
             ],
             "position": {
-                "left": 1646.4377091829172,
-                "top": 358.6654042662252
+                "left": 1982.4254762388387,
+                "top": 583.880964993853
             },
             "post_job_actions": {
                 "RenameDatasetActionsummary_json": {
                     "action_arguments": {
-                        "newname": "tooldistillator_summarize"
+                        "newname": "tooldistillator_summarize_assembly"
                     },
                     "action_type": "RenameDatasetAction",
                     "output_name": "summary_json"
                 },
                 "TagDatasetActionsummary_json": {
                     "action_arguments": {
-                        "tags": "tooldistillator_summarize"
+                        "tags": "tooldistillator_summarize_assembly"
                     },
                     "action_type": "TagDatasetAction",
                     "output_name": "summary_json"
@@ -697,9 +861,9 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "tooldistillator_summarize",
+                    "label": "tooldistillator_summarize_assembly",
                     "output_name": "summary_json",
-                    "uuid": "9097e16d-ace5-47f5-9af5-7eb3b13b91d2"
+                    "uuid": "dd58ac41-dd1b-4bac-84d5-2f594660ce2b"
                 }
             ]
         }

--- a/workflows/genome-assembly/bacterial-genome-assembly/bacterial_genome_assembly.ga
+++ b/workflows/genome-assembly/bacterial-genome-assembly/bacterial_genome_assembly.ga
@@ -1,6 +1,7 @@
 {
     "a_galaxy_workflow": "true",
     "annotation": "Assembly of bacterial paired-end short read data with generation of quality metrics and reports",
+    "comments": [],
     "creator": [
         {
             "class": "Organization",
@@ -26,7 +27,6 @@
         }
     ],
     "format-version": "0.1",
-    "release": "1.1.5",
     "license": "GPL-3.0-or-later",
     "name": "Bacterial Genome Assembly using Shovill",
     "steps": {
@@ -557,7 +557,7 @@
         },
         "7": {
             "annotation": "ToolDistillator extracts results from tools and creates a JSON file for each tool",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0",
             "errors": null,
             "id": 7,
             "input_connections": {
@@ -623,15 +623,15 @@
                     "output_name": "output_json"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "ea93df4b3df2",
+                "changeset_revision": "66617be450bd",
                 "name": "tooldistillator",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"log\": false, \"tool_section\": {\"tools\": [{\"__index__\": 0, \"select_tool\": {\"tool_list\": \"shovill\", \"__current_case__\": 19, \"input\": {\"__class__\": \"ConnectedValue\"}, \"contig_graph_path\": {\"__class__\": \"ConnectedValue\"}, \"bam_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 1, \"select_tool\": {\"tool_list\": \"quast\", \"__current_case__\": 16, \"input\": {\"__class__\": \"ConnectedValue\"}, \"quast_html_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 2, \"select_tool\": {\"tool_list\": \"refseqmasher\", \"__current_case__\": 18, \"input\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 3, \"select_tool\": {\"tool_list\": \"bandage\", \"__current_case__\": 3, \"input\": {\"__class__\": \"ConnectedValue\"}, \"bandage_plot_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.9.1+galaxy1",
+            "tool_state": "{\"log\": false, \"tool_section\": {\"tools\": [{\"__index__\": 0, \"select_tool\": {\"tool_list\": \"shovill\", \"__current_case__\": 20, \"input\": {\"__class__\": \"ConnectedValue\"}, \"contig_graph_path\": {\"__class__\": \"ConnectedValue\"}, \"bam_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 1, \"select_tool\": {\"tool_list\": \"quast\", \"__current_case__\": 17, \"input\": {\"__class__\": \"ConnectedValue\"}, \"quast_html_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 2, \"select_tool\": {\"tool_list\": \"refseqmasher\", \"__current_case__\": 19, \"input\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}, {\"__index__\": 3, \"select_tool\": {\"tool_list\": \"bandage\", \"__current_case__\": 3, \"input\": {\"__class__\": \"ConnectedValue\"}, \"bandage_plot_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"true\", \"__current_case__\": 0, \"analysis_software_version\": null}, \"reference_database_version\": null}}]}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.9.2+galaxy0",
             "type": "tool",
             "uuid": "b6156c8e-5048-41e3-90d9-f9302734c3d1",
             "when": null,
@@ -645,7 +645,7 @@
         },
         "8": {
             "annotation": "ToolDistillator summarize groups all JSON file into a unique JSON file",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0",
             "errors": null,
             "id": 8,
             "input_connections": {
@@ -683,15 +683,15 @@
                     "output_name": "summary_json"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "24eec94e6dfc",
+                "changeset_revision": "07d093aaf3b4",
                 "name": "tooldistillator_summarize",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"summarize_data\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.9.1+galaxy1",
+            "tool_version": "0.9.2+galaxy0",
             "type": "tool",
             "uuid": "3bbe0eba-b6bb-4d43-ab57-2b899b8112ae",
             "when": null,
@@ -713,6 +713,7 @@
         "quality",
         "ABRomics"
     ],
-    "uuid": "bfe7f341-07ef-4bfe-9b50-2bc7628d6c55",
-    "version": 1
+    "uuid": "e4678621-501a-485f-bf93-cb8f5f316bce",
+    "version": 1,
+    "release": "1.1.6"
 }


### PR DESCRIPTION
Hello,

This code (close https://github.com/galaxyproject/iwc/pull/796):
-  Changes the ToolDistillator wrapper version:
    - `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.1+galaxy1` to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0`
    - `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.1+galaxy1` to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0`
- Changes the output name/tag of Tooldistillator to tooldistillator_[results|summarize]_assembly
- Fixes syntax and parameter errors
- Changes Quast parameters: `--min-contig 0` and `--contig-thresholds 0,200,500,1000`
- Adds Checkm2 (`toolshed.g2.bx.psu.edu/repos/iuc/checkm2/checkm2/1.0.2+galaxy1`) to predict the completeness and contamination in an assembly

Thanks 😃