### PR TITLE
Standardize terminology to 'workflow's

### DIFF
--- a/website/pages/about.vue
+++ b/website/pages/about.vue
@@ -7,9 +7,9 @@
         </h1>
 
         <p class="text-lg text-gray-700 leading-relaxed mb-6">
-            The Galaxy Workflows Library is a curated collection of ready-to-use, open-source analysis workflows
-            designed to help researchers make progress quickly and reliably. Each workflow comes with sample datasets,
-            clear documentation, and links to training materials to streamline learning and application.
+            The Galaxy Workflow Library is a curated collection of ready-to-use, open-source analysis workflows designed
+            to help researchers make progress quickly and reliably. Each workflow comes with sample datasets, clear
+            documentation, and links to training materials to streamline learning and application.
         </p>
 
         <p class="text-lg text-gray-700 leading-relaxed mb-10">
@@ -76,9 +76,9 @@
                 <div class="md:w-1/2">
                     <h2 class="text-3xl md:text-4xl font-bold mb-8 text-center">Join the community</h2>
                     <p class="text-lg text-gray-700 mb-4">
-                        The Galaxy Workflows Library is an open, collaborative project, and we welcome contributions
-                        from the community. Whether you want to enhance existing workflows, report issues, or contribute
-                        new workflows, your input is invaluable.
+                        The Galaxy Workflow Library is an open, collaborative project, and we welcome contributions from
+                        the community. Whether you want to enhance existing workflows, report issues, or contribute new
+                        workflows, your input is invaluable.
                     </p>
                     <p class="text-lg text-gray-700">
                         Have questions or feedback? Connect via
@@ -138,16 +138,16 @@ const baseUrl = config.appUrl || (process.client ? window.location.origin : "htt
 
 // Add SEO meta tags using the useSeoMeta composable
 useSeoMeta({
-    title: "About the Galaxy Workflows Library",
+    title: "About the Galaxy Workflow Library",
     description:
         "Learn about the IWC curated collection of peer-reviewed, ready-to-use Galaxy workflows for scientific analysis",
-    ogTitle: "About the Galaxy Workflows Library",
+    ogTitle: "About the Galaxy Workflow Library",
     ogDescription:
         "Discover a curated collection of ready-to-use, peer-reviewed Galaxy workflows for scientific analysis",
     ogImage: `${baseUrl}/iwc_logo.png`,
     ogType: "website",
     twitterCard: "summary",
-    twitterTitle: "About the Galaxy Workflows Library",
+    twitterTitle: "About the Galaxy Workflow Library",
     twitterDescription:
         "Discover a curated collection of ready-to-use, peer-reviewed Galaxy workflows for scientific analysis",
     twitterImage: `${baseUrl}/iwc_logo.png`,

--- a/website/pages/about.vue
+++ b/website/pages/about.vue
@@ -78,7 +78,7 @@
                     <p class="text-lg text-gray-700 mb-4">
                         The Galaxy Workflows Library is an open, collaborative project, and we welcome contributions
                         from the community. Whether you want to enhance existing workflows, report issues, or contribute
-                        new pipelines, your input is invaluable.
+                        new workflows, your input is invaluable.
                     </p>
                     <p class="text-lg text-gray-700">
                         Have questions or feedback? Connect via

--- a/website/pages/index.vue
+++ b/website/pages/index.vue
@@ -164,7 +164,7 @@ function selectWorkflow(workflow: Workflow) {
                     <input
                         v-model="searchQuery"
                         type="text"
-                        placeholder="Search pipelines"
+                        placeholder="Search workflows"
                         class="w-full p-2 mb-2 border rounded-lg" />
                 </div>
                 <Filters />

--- a/website/pages/workflow/[id].vue
+++ b/website/pages/workflow/[id].vue
@@ -7,7 +7,7 @@ import Author from "~/components/Author.vue";
 import { useWorkflowStore } from "~/stores/workflows";
 import { formatDate } from "~/utils/";
 import GalaxyInstanceSelector from "~/components/GalaxyInstanceSelector.vue";
-import { stringify } from 'yaml'
+import { stringify } from "yaml";
 
 const route = useRoute();
 const appConfig = useAppConfig();
@@ -104,11 +104,11 @@ const tools = computed(() => {
 });
 
 const workflow_job_input = computed(() => {
-    const config_init_command = `planemo workflow_job_init ${ workflow?.value?.iwcID }.ga -o ${ workflow?.value?.iwcID }-job.yml`;
+    const config_init_command = `planemo workflow_job_init ${workflow?.value?.iwcID}.ga -o ${workflow?.value?.iwcID}-job.yml`;
     if (!workflow.value || !workflow.value || !workflow.value.workflow_job_input) {
-        return `# config file: ${ workflow?.value?.iwcID }_job.yml file\n${ config_init_command }`;
+        return `# config file: ${workflow?.value?.iwcID}_job.yml file\n${config_init_command}`;
     } else {
-        return `# config file: ${ workflow?.value?.iwcID }_job.yml\n# command: ${ config_init_command }\n${stringify(workflow.value.workflow_job_input)}`;
+        return `# config file: ${workflow?.value?.iwcID}_job.yml\n# command: ${config_init_command}\n${stringify(workflow.value.workflow_job_input)}`;
     }
 });
 
@@ -394,11 +394,13 @@ planemo test {{ workflow?.iwcID }}.ga</code></pre>
                                         </div>
 
                                         <div class="mb-6">
-                                            <h4 class="text-lg font-medium mb-2">
-                                                Step 4: Create workflow job file
-                                            </h4>
-                                            <p class="mb-2 text-sm">Create a workflow job file with your input parameters and update the values to match your environment and run:</p>
-                                            <pre class="p-3 rounded overflow-x-auto"><code>{{ workflow_job_input }}</code></pre>
+                                            <h4 class="text-lg font-medium mb-2">Step 4: Create workflow job file</h4>
+                                            <p class="mb-2 text-sm">
+                                                Create a workflow job file with your input parameters and update the
+                                                values to match your environment and run:
+                                            </p>
+                                            <pre
+                                                class="p-3 rounded overflow-x-auto"><code>{{ workflow_job_input }}</code></pre>
                                         </div>
                                         <div class="mb-6">
                                             <h4 class="text-lg font-medium mb-2">

--- a/website/public/category-descriptions/data-fetching.md
+++ b/website/public/category-descriptions/data-fetching.md
@@ -1,3 +1,3 @@
-Standardized pipelines for retrieving and processing scientific datasets from repositories such as the
+Standardized workflows for retrieving and processing scientific datasets from repositories such as the
 Sequence Read Archive (SRA). These workflows include data validation, format conversion, and quality
 control steps to prepare raw data for downstream computational analysis.

--- a/website/public/category-descriptions/genome-annotation.md
+++ b/website/public/category-descriptions/genome-annotation.md
@@ -1,3 +1,3 @@
-Bioinformatic pipelines for characterizing genomic elements in assembled sequences. These workflows
+Bioinformatic workflows for characterizing genomic elements in assembled sequences. These workflows
 incorporate gene prediction algorithms, homology-based annotation methods, and specialized tools for
 identifying functional elements including protein-coding genes and non-coding RNA transcripts.

--- a/website/public/category-descriptions/microbiome.md
+++ b/website/public/category-descriptions/microbiome.md
@@ -1,3 +1,3 @@
-Sequencing data analysis pipelines for characterizing microbial communities. These workflows include
+Sequencing data analysis workflows for characterizing microbial communities. These workflows include
 methods for taxonomic profiling, pathogen identification, and comparative analysis of microbiome
 composition across different environmental conditions or host phenotypes.

--- a/website/public/category-descriptions/transcriptomics.md
+++ b/website/public/category-descriptions/transcriptomics.md
@@ -1,3 +1,3 @@
-RNA sequencing analysis pipelines for gene expression profiling. These workflows include quality
+RNA sequencing analysis workflows for gene expression profiling. These workflows include quality
 assessment, read alignment, transcript quantification, and statistical methods for differential
 expression analysis applicable to various RNA-seq experimental designs.


### PR DESCRIPTION
Following our discussions, we're standardizing terminology by using 'workflow' instead of 'pipeline' throughout most of the platform. The tagline "Discover and run vetted analysis pipelines on Galaxy" will remain unchanged since it still makes sense, but we'll refer to specific items as workflows everywhere else.