### PR TITLE
VGP Precuration - add coverage gaps and MAPQ filtering

### DIFF
--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/CHANGELOG.md
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### Changes
 - Add a track showing the Gaps in read coverage
-- Expose minimal mapping score parameter for Hi-C alignment
+- Add MAPQ filtering for Hi-C alignment (Now output both filtered and unfiltered PretextMap)
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy2`
+- `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy2`
+- `toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/5.0+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/5.1+galaxy0`
 
 
 ## [1.0beta5] - 2025-05-12

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/CHANGELOG.md
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.0beta6] - 2025-05-12
+## [1.0beta6] - 2025-06-09
 
 ### Changes
 - Add a track showing the Gaps in read coverage

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/CHANGELOG.md
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0beta6] - 2025-05-12
+
+### Changes
+- Add a track showing the Gaps in read coverage
+
+
 ## [1.0beta5] - 2025-05-12
 
 ### Automatic update

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/CHANGELOG.md
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 - Add a track showing the Gaps in read coverage
-- Add MAPQ filtering for Hi-C alignment (Now output both filtered and unfiltered PretextMap)
+- Add MAPQ filtering for Hi-C alignment (Now outputs both filtered and unfiltered PretextMap)
 
 ### Automatic update
 - `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy2`

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/CHANGELOG.md
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 - Add a track showing the Gaps in read coverage
+- Expose minimal mapping score parameter for Hi-C alignment
 
 
 ## [1.0beta5] - 2025-05-12

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/README.md
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/README.md
@@ -13,7 +13,7 @@ This workflow generates Hi-C contact maps for diploid genome assemblies in the P
 6. **Haplotype 2 suffix** This suffix will be added to haplotype 2 scaffold names if you selected to add suffixes to the scaffold names.
 7. **Hi-C reads**  [fastq] Paired Collection containing the Hi-D data
 8. **Do you want to trim the Hi-C data?** If *yes*, remove 5bp at the end of Hi-C reads. Use with Arima Hi-C data if the Hi-C map looks "noisy".
-9. **Minimum Mapping Score** Minimum mapping score to keep for Hi-C alignments. Set to 0 to keep all mapped reads. Default: 20 .
+9. **Minimum Mapping Score** Minimum mapping score to keep for Hi-C alignments in the filtered PretextMap. Set to 0 to keep all mapped reads. Default: 20 .
 10. **Telomere repeat to suit species** Expected value of the repeated sequences in the telomeres. Default value [CCCTAA] is suited to vertebrates.
 11. **PacBio reads** [fastq] Collection of PacBio reads.
 
@@ -27,6 +27,6 @@ This workflow generates Hi-C contact maps for diploid genome assemblies in the P
 5. Gap track [bedgraph] 
 6. Coverage track [bigwig]
 7. Gaps in coverage track [bedgraph]
-7. Pretext Map without tracks [pretext]
-8. Pretext Map with tracks [pretext]
-9. Pretext Snapshot image of the Hi-C contact map [png]
+7. Pretext Map without tracks [pretext], filtered and unfiltered.
+8. Pretext Map with tracks [pretext], filtered and unfiltered.
+9. Pretext Snapshot image of the Hi-C contact map [png], filtered and unfiltered.

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/README.md
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/README.md
@@ -13,8 +13,9 @@ This workflow generates Hi-C contact maps for diploid genome assemblies in the P
 6. **Haplotype 2 suffix** This suffix will be added to haplotype 2 scaffold names if you selected to add suffixes to the scaffold names.
 7. **Hi-C reads**  [fastq] Paired Collection containing the Hi-D data
 8. **Do you want to trim the Hi-C data?** If *yes*, remove 5bp at the end of Hi-C reads. Use with Arima Hi-C data if the Hi-C map looks "noisy".
-9.  **Telomere repeat to suit species** Expected value of the repeated sequences in the telomeres. Default value [CCCTAA] is suited to vertebrates.
-10. **PacBio reads** [fastq] Collection of PacBio reads.
+9. **Minimum Mapping Score** Minimum mapping score to keep for Hi-C alignments. Set to 0 to keep all mapped reads. Default: 20 .
+10. **Telomere repeat to suit species** Expected value of the repeated sequences in the telomeres. Default value [CCCTAA] is suited to vertebrates.
+11. **PacBio reads** [fastq] Collection of PacBio reads.
 
 
 ## Outputs
@@ -25,6 +26,7 @@ This workflow generates Hi-C contact maps for diploid genome assemblies in the P
 4. Telomeres track [bedgraph]
 5. Gap track [bedgraph] 
 6. Coverage track [bigwig]
+7. Gaps in coverage track [bedgraph]
 7. Pretext Map without tracks [pretext]
 8. Pretext Map with tracks [pretext]
 9. Pretext Snapshot image of the Hi-C contact map [png]

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation-tests.yml
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation-tests.yml
@@ -136,4 +136,7 @@
         has_size:
           value : 1600000
           delta: 500000
-
+    Coverage Gaps Track:
+      asserts:
+        has_text:
+          text: "scaffold_10.H1	0	8456	200"

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation-tests.yml
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation-tests.yml
@@ -107,6 +107,7 @@
     First Haplotype suffix: H1
     Second Haplotype suffix: H2
     Do you want to trim the Hi-C data?: true
+    Minimum Mapping Score: 20
     Telomere repeat to suit species: CCCTAA
   outputs:
     Assembly for curation:

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation-tests.yml
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation-tests.yml
@@ -18,10 +18,10 @@
           elements:
           - identifier: forward
             class: File
-            path: https://zenodo.org/records/14230702/files/HiC%20forward.fastqsanger.gz
+            location: https://zenodo.org/records/14230702/files/HiC%20forward.fastqsanger.gz
           - identifier: reverse
             class: File
-            path: https://zenodo.org/records/14230702/files/HiC%20reverse.fastqsanger.gz
+            location: https://zenodo.org/records/14230702/files/HiC%20reverse.fastqsanger.gz
     PacBio reads:
       class: Collection
       collection_type: list
@@ -91,10 +91,10 @@
           elements:
           - identifier: forward
             class: File
-            path: https://zenodo.org/records/14230702/files/HiC%20forward.fastqsanger.gz
+            location: https://zenodo.org/records/14230702/files/HiC%20forward.fastqsanger.gz
           - identifier: reverse
             class: File
-            path: https://zenodo.org/records/14230702/files/HiC%20reverse.fastqsanger.gz
+            location: https://zenodo.org/records/14230702/files/HiC%20reverse.fastqsanger.gz
     PacBio reads:
       class: Collection
       collection_type: list

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation-tests.yml
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation-tests.yml
@@ -18,10 +18,10 @@
           elements:
           - identifier: forward
             class: File
-            location: https://zenodo.org/records/14230702/files/HiC%20forward.fastqsanger.gz
+            path: https://zenodo.org/records/14230702/files/HiC%20forward.fastqsanger.gz
           - identifier: reverse
             class: File
-            location: https://zenodo.org/records/14230702/files/HiC%20reverse.fastqsanger.gz
+            path: https://zenodo.org/records/14230702/files/HiC%20reverse.fastqsanger.gz
     PacBio reads:
       class: Collection
       collection_type: list
@@ -34,8 +34,8 @@
     First Haplotype suffix: H1
     Second Haplotype suffix: H2
     Do you want to trim the Hi-C data?: true
-    Minimum Mapping Score: 20
     Telomere repeat to suit species: CCCTAA
+    Minimum Mapping Quality: 20
   outputs:
     Assembly for curation:
       asserts:
@@ -70,12 +70,13 @@
     Pretext All tracks:
       asserts:
         has_size:
+          value : 870000
+          delta: 50000
+    Pretext All tracks - Multimapping:
+      asserts:
+        has_size:
           value : 1700000
           delta: 500000
-    Coverage Gaps Track:
-      asserts:
-        has_text:
-          text: "scaffold_10.H1	0	8456	200"
 - doc: Test outline for hi-c-map-for-assembly-manual-curation.ga 2
   job:
     Haplotype 1:
@@ -96,10 +97,10 @@
           elements:
           - identifier: forward
             class: File
-            location: https://zenodo.org/records/14230702/files/HiC%20forward.fastqsanger.gz
+            path: https://zenodo.org/records/14230702/files/HiC%20forward.fastqsanger.gz
           - identifier: reverse
             class: File
-            location: https://zenodo.org/records/14230702/files/HiC%20reverse.fastqsanger.gz
+            path: https://zenodo.org/records/14230702/files/HiC%20reverse.fastqsanger.gz
     PacBio reads:
       class: Collection
       collection_type: list
@@ -112,7 +113,6 @@
     First Haplotype suffix: H1
     Second Haplotype suffix: H2
     Do you want to trim the Hi-C data?: true
-    Minimum Mapping Score: 20
     Telomere repeat to suit species: CCCTAA
   outputs:
     Assembly for curation:
@@ -140,9 +140,10 @@
     Pretext All tracks:
       asserts:
         has_size:
+          value : 860000
+          delta: 50000
+    Pretext All tracks - Multimapping:
+      asserts:
+        has_size:
           value : 1600000
           delta: 500000
-    Coverage Gaps Track:
-      asserts:
-        has_text:
-          text: "scaffold_10.H1	0	38583	200"

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation-tests.yml
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation-tests.yml
@@ -65,12 +65,12 @@
     Merged Hi-C Alignments:
       asserts:
         has_size:
-          value : 50000000
+          value : 37000000
           delta: 5000000
     Pretext All tracks:
       asserts:
         has_size:
-          value : 870000
+          value : 790000
           delta: 50000
     Pretext All tracks - Multimapping:
       asserts:
@@ -135,12 +135,12 @@
     Merged Hi-C Alignments:
       asserts:
         has_size:
-          value : 50000000
+          value : 37000000
           delta: 5000000
     Pretext All tracks:
       asserts:
         has_size:
-          value : 860000
+          value : 780000
           delta: 50000
     Pretext All tracks - Multimapping:
       asserts:

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation-tests.yml
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation-tests.yml
@@ -34,6 +34,7 @@
     First Haplotype suffix: H1
     Second Haplotype suffix: H2
     Do you want to trim the Hi-C data?: true
+    Minimum Mapping Score: 20
     Telomere repeat to suit species: CCCTAA
   outputs:
     Assembly for curation:
@@ -71,6 +72,10 @@
         has_size:
           value : 1700000
           delta: 500000
+    Coverage Gaps Track:
+      asserts:
+        has_text:
+          text: "scaffold_10.H1	0	8456	200"
 - doc: Test outline for hi-c-map-for-assembly-manual-curation.ga 2
   job:
     Haplotype 1:
@@ -140,4 +145,4 @@
     Coverage Gaps Track:
       asserts:
         has_text:
-          text: "scaffold_10.H1	0	8456	200"
+          text: "scaffold_10.H1	0	38583	200"

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.ga
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.ga
@@ -4,28 +4,6 @@
     "comments": [
         {
             "child_steps": [
-                11,
-                12,
-                14,
-                15
-            ],
-            "color": "blue",
-            "data": {
-                "title": "Merge Haplotypes"
-            },
-            "id": 0,
-            "position": [
-                474.0963016672636,
-                52.046510239528516
-            ],
-            "size": [
-                1283,
-                769
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
                 33,
                 26,
                 28,
@@ -51,25 +29,81 @@
         },
         {
             "child_steps": [
-                13,
-                19,
-                23,
-                24,
-                27,
-                29
+                11,
+                12,
+                14,
+                15
             ],
-            "color": "green",
+            "color": "blue",
             "data": {
-                "title": "Coverage"
+                "title": "Merge Haplotypes"
             },
-            "id": 5,
+            "id": 0,
             "position": [
-                2327.5,
-                1440.7000000000003
+                474.0963016672636,
+                52.046510239528516
             ],
             "size": [
-                1404,
-                466
+                1283,
+                769
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                16
+            ],
+            "color": "yellow",
+            "data": {
+                "title": "Trim and align Hi-C reads"
+            },
+            "id": 1,
+            "position": [
+                1064.1,
+                870.5
+            ],
+            "size": [
+                1159,
+                746
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                20
+            ],
+            "color": "red",
+            "data": {
+                "title": "Generate Hi-C map"
+            },
+            "id": 2,
+            "position": [
+                2345.1,
+                510.70000000000005
+            ],
+            "size": [
+                779.6,
+                512.7
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                17,
+                21
+            ],
+            "color": "turquoise",
+            "data": {
+                "title": "Gaps"
+            },
+            "id": 3,
+            "position": [
+                2453.2,
+                242.5999999999999
+            ],
+            "size": [
+                541.9,
+                212.5
             ],
             "type": "frame"
         },
@@ -96,59 +130,25 @@
         },
         {
             "child_steps": [
-                17,
-                21
+                13,
+                19,
+                23,
+                24,
+                27,
+                29
             ],
-            "color": "turquoise",
+            "color": "green",
             "data": {
-                "title": "Gaps"
+                "title": "Coverage"
             },
-            "id": 3,
+            "id": 5,
             "position": [
-                2453.2,
-                242.5999999999999
+                2327.5,
+                1440.7000000000003
             ],
             "size": [
-                541.9,
-                212.5
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                20
-            ],
-            "color": "red",
-            "data": {
-                "title": "Generate Hi-C map"
-            },
-            "id": 2,
-            "position": [
-                2345.1,
-                510.70000000000005
-            ],
-            "size": [
-                779.6,
-                512.7
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                16
-            ],
-            "color": "yellow",
-            "data": {
-                "title": "Trim and align Hi-C reads"
-            },
-            "id": 1,
-            "position": [
-                1064.1,
-                870.5
-            ],
-            "size": [
-                1159,
-                746
+                1404,
+                466
             ],
             "type": "frame"
         }
@@ -398,10 +398,10 @@
             "inputs": [
                 {
                     "description": "Minimum mapping score to keep for Hi-C alignments. Set to 0 to keep all mapped reads. Default: 20 ",
-                    "name": "Minimum Mapping Score"
+                    "name": "Minimum Mapping Quality"
                 }
             ],
-            "label": "Minimum Mapping Score",
+            "label": "Minimum Mapping Quality",
             "name": "Input parameter",
             "outputs": [],
             "position": {
@@ -1476,11 +1476,6 @@
                     "input_subworkflow_step_id": 1,
                     "output_name": "output"
                 },
-                "Minimum mapping score": {
-                    "id": 8,
-                    "input_subworkflow_step_id": 3,
-                    "output_name": "output"
-                },
                 "Reference": {
                     "id": 15,
                     "input_subworkflow_step_id": 0,
@@ -1597,46 +1592,13 @@
                         "type": "parameter_input",
                         "uuid": "6d1391db-7fef-4b5c-a236-26016d6d0aab",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": null,
-                                "output_name": "output",
-                                "uuid": "d6264a89-b887-4548-8fc0-fcd7564fdb9f"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
                     "3": {
                         "annotation": "",
-                        "content_id": null,
-                        "errors": null,
-                        "id": 3,
-                        "input_connections": {},
-                        "inputs": [
-                            {
-                                "description": "",
-                                "name": "Minimum mapping score"
-                            }
-                        ],
-                        "label": "Minimum mapping score",
-                        "name": "Input parameter",
-                        "outputs": [],
-                        "position": {
-                            "left": 319.7530758621395,
-                            "top": 454.2246120603114
-                        },
-                        "tool_id": null,
-                        "tool_state": "{\"validators\": [{\"min\": null, \"max\": null, \"negate\": false, \"type\": \"in_range\"}], \"parameter_type\": \"integer\", \"optional\": false}",
-                        "tool_version": null,
-                        "type": "parameter_input",
-                        "uuid": "9aafb613-39db-4a89-b9b7-585a1adbc7d3",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "4": {
-                        "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/5.0+galaxy0",
                         "errors": null,
-                        "id": 4,
+                        "id": 3,
                         "input_connections": {
                             "library|input_1": {
                                 "id": 1,
@@ -1721,14 +1683,14 @@
                             }
                         ]
                     },
-                    "5": {
+                    "4": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
                         "errors": null,
-                        "id": 5,
+                        "id": 4,
                         "input_connections": {
                             "style_cond|type_cond|pick_from_0|value": {
-                                "id": 4,
+                                "id": 3,
                                 "output_name": "out_pairs"
                             },
                             "style_cond|type_cond|pick_from_1|value": {
@@ -1770,18 +1732,14 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "6": {
+                    "5": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bwa_mem2/bwa_mem2/2.2.1+galaxy4",
                         "errors": null,
-                        "id": 6,
+                        "id": 5,
                         "input_connections": {
-                            "analysis_type|io_options|T": {
-                                "id": 3,
-                                "output_name": "output"
-                            },
                             "fastq_input|fastq_input1": {
-                                "id": 5,
+                                "id": 4,
                                 "output_name": "data_param"
                             },
                             "reference_source|ref_file": {
@@ -1799,8 +1757,8 @@
                             }
                         ],
                         "position": {
-                            "left": 1591.62890625,
-                            "top": 61.06640625
+                            "left": 1591.9221620025578,
+                            "top": 60.765218695600495
                         },
                         "post_job_actions": {
                             "HideDatasetActionbam_output": {
@@ -1823,7 +1781,7 @@
                             "owner": "iuc",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"analysis_type\": {\"analysis_type_selector\": \"full\", \"__current_case__\": 4, \"algorithmic_options\": {\"algorithmic_options_selector\": \"set\", \"__current_case__\": 0, \"k\": \"19\", \"w\": \"100\", \"d\": \"100\", \"r\": \"1.5\", \"y\": \"20\", \"c\": \"500\", \"D\": \"0.5\", \"W\": \"0\", \"m\": \"50\", \"S\": true, \"P\": true, \"e\": false}, \"scoring_options\": {\"scoring_options_selector\": \"do_not_set\", \"__current_case__\": 1}, \"io_options\": {\"io_options_selector\": \"set\", \"__current_case__\": 0, \"five\": true, \"q\": false, \"T\": {\"__class__\": \"ConnectedValue\"}, \"h\": \"5\", \"a\": false, \"C\": false, \"V\": false, \"Y\": false, \"M\": false, \"K\": null}}, \"fastq_input\": {\"fastq_input_selector\": \"paired_collection\", \"__current_case__\": 2, \"fastq_input1\": {\"__class__\": \"ConnectedValue\"}, \"iset_stats\": null}, \"output_sort\": \"coordinate\", \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"ConnectedValue\"}}, \"rg\": {\"rg_selector\": \"set_id_auto\", \"__current_case__\": 2}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_state": "{\"analysis_type\": {\"analysis_type_selector\": \"full\", \"__current_case__\": 4, \"algorithmic_options\": {\"algorithmic_options_selector\": \"set\", \"__current_case__\": 0, \"k\": \"19\", \"w\": \"100\", \"d\": \"100\", \"r\": \"1.5\", \"y\": \"20\", \"c\": \"500\", \"D\": \"0.5\", \"W\": \"0\", \"m\": \"50\", \"S\": true, \"P\": true, \"e\": false}, \"scoring_options\": {\"scoring_options_selector\": \"do_not_set\", \"__current_case__\": 1}, \"io_options\": {\"io_options_selector\": \"set\", \"__current_case__\": 0, \"five\": true, \"q\": false, \"T\": \"20\", \"h\": \"5\", \"a\": false, \"C\": false, \"V\": false, \"Y\": false, \"M\": false, \"K\": null}}, \"fastq_input\": {\"fastq_input_selector\": \"paired_collection\", \"__current_case__\": 2, \"fastq_input1\": {\"__class__\": \"RuntimeValue\"}, \"iset_stats\": null}, \"output_sort\": \"coordinate\", \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"RuntimeValue\"}}, \"rg\": {\"rg_selector\": \"set_id_auto\", \"__current_case__\": 2}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
                         "tool_version": "2.2.1+galaxy4",
                         "type": "tool",
                         "uuid": "45d2eaea-40f9-461e-bfb0-cadd9b9738b8",
@@ -1836,14 +1794,14 @@
                             }
                         ]
                     },
-                    "7": {
+                    "6": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_merge/samtools_merge/1.20+galaxy2",
                         "errors": null,
-                        "id": 7,
+                        "id": 6,
                         "input_connections": {
                             "bamfiles": {
-                                "id": 6,
+                                "id": 5,
                                 "output_name": "bam_output"
                             }
                         },
@@ -1857,8 +1815,8 @@
                             }
                         ],
                         "position": {
-                            "left": 1967.3515625,
-                            "top": 53.55859375
+                            "left": 1967.612923245418,
+                            "top": 53.2777484153639
                         },
                         "post_job_actions": {
                             "TagDatasetActionoutput": {
@@ -1891,7 +1849,7 @@
                     }
                 },
                 "tags": [],
-                "uuid": "7764a62d-4be3-48d3-b683-bfbc74d54cee"
+                "uuid": "d03cced9-fa15-49c9-a7e4-279b4aabfc40"
             },
             "tool_id": null,
             "type": "subworkflow",
@@ -2087,6 +2045,10 @@
                 "input": {
                     "id": 16,
                     "output_name": "Merged Hi-C Alignments"
+                },
+                "map_qual": {
+                    "id": 8,
+                    "output_name": "output"
                 }
             },
             "inputs": [],
@@ -2123,7 +2085,7 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filter\": {\"filter_type\": \"\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"map_qual\": \"0\", \"sorting\": {\"sortby\": \"length\", \"__current_case__\": 1, \"sortorder\": \"descend\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"filter\": {\"filter_type\": \"\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"map_qual\": {\"__class__\": \"ConnectedValue\"}, \"sorting\": {\"sortby\": \"length\", \"__current_case__\": 1, \"sortorder\": \"descend\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.1.9+galaxy1",
             "type": "tool",
             "uuid": "2bc11d1e-ba89-4a9c-80c9-2b83aa638457",
@@ -2963,6 +2925,6 @@
         }
     },
     "tags": [],
-    "uuid": "a4b559bf-cffc-4032-8fc5-05fbe4e5842f",
-    "version": 2
+    "uuid": "c0f69aad-73a0-4a34-9535-6fe188f9250c",
+    "version": 3
 }

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.ga
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.ga
@@ -4,10 +4,10 @@
     "comments": [
         {
             "child_steps": [
-                10,
                 11,
-                13,
-                14
+                12,
+                14,
+                15
             ],
             "color": "blue",
             "data": {
@@ -15,8 +15,8 @@
             },
             "id": 0,
             "position": [
-                474.0963016672637,
-                52.0465102395286
+                474.0963016672636,
+                52.046510239528516
             ],
             "size": [
                 1283,
@@ -26,71 +26,13 @@
         },
         {
             "child_steps": [
-                15
-            ],
-            "color": "yellow",
-            "data": {
-                "title": "Trim and align Hi-C reads"
-            },
-            "id": 1,
-            "position": [
-                1064.1,
-                870.5
-            ],
-            "size": [
-                1169,
-                516
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                19
-            ],
-            "color": "red",
-            "data": {
-                "title": "Generate Hi-C map"
-            },
-            "id": 2,
-            "position": [
-                2345.1,
-                510.7
-            ],
-            "size": [
-                779.6,
-                512.7
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                16,
-                20
-            ],
-            "color": "turquoise",
-            "data": {
-                "title": "Gaps"
-            },
-            "id": 3,
-            "position": [
-                2453.2,
-                242.6
-            ],
-            "size": [
-                541.9,
-                212.5
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                32,
                 33,
-                25,
-                27,
-                29,
+                26,
+                28,
                 30,
-                31
+                31,
+                32,
+                34
             ],
             "color": "orange",
             "data": {
@@ -99,7 +41,7 @@
             "id": 6,
             "position": [
                 3280.2418890772274,
-                675.3465102395286
+                675.3465102395285
             ],
             "size": [
                 1284,
@@ -109,12 +51,12 @@
         },
         {
             "child_steps": [
-                12,
-                18,
-                22,
+                13,
+                19,
                 23,
-                26,
-                28
+                24,
+                27,
+                29
             ],
             "color": "green",
             "data": {
@@ -123,7 +65,7 @@
             "id": 5,
             "position": [
                 2327.5,
-                1440.7
+                1440.7000000000003
             ],
             "size": [
                 1404,
@@ -133,9 +75,9 @@
         },
         {
             "child_steps": [
-                17,
-                21,
-                24
+                18,
+                22,
+                25
             ],
             "color": "lime",
             "data": {
@@ -149,6 +91,64 @@
             "size": [
                 761,
                 296
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                17,
+                21
+            ],
+            "color": "turquoise",
+            "data": {
+                "title": "Gaps"
+            },
+            "id": 3,
+            "position": [
+                2453.2,
+                242.5999999999999
+            ],
+            "size": [
+                541.9,
+                212.5
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                20
+            ],
+            "color": "red",
+            "data": {
+                "title": "Generate Hi-C map"
+            },
+            "id": 2,
+            "position": [
+                2345.1,
+                510.70000000000005
+            ],
+            "size": [
+                779.6,
+                512.7
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                16
+            ],
+            "color": "yellow",
+            "data": {
+                "title": "Trim and align Hi-C reads"
+            },
+            "id": 1,
+            "position": [
+                1064.1,
+                870.5
+            ],
+            "size": [
+                1159,
+                746
             ],
             "type": "frame"
         }
@@ -243,7 +243,7 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 85.328125,
+                "left": 85.32812500000001,
                 "top": 209.84375
             },
             "tool_id": null,
@@ -270,8 +270,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 116.71484375,
-                "top": 307.75
+                "left": 126.16035849292534,
+                "top": 310.43309384096546
             },
             "tool_id": null,
             "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
@@ -297,8 +297,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 174.0230592554534,
-                "top": 443.5895298364112
+                "left": 176.27674150664734,
+                "top": 435.65593992735546
             },
             "tool_id": null,
             "tool_state": "{\"default\": \"H1\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
@@ -324,8 +324,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 198.0053528860768,
-                "top": 544.1169319728217
+                "left": 216.8962099291657,
+                "top": 543.7431063618276
             },
             "tool_id": null,
             "tool_state": "{\"default\": \"H2\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
@@ -351,11 +351,11 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "left": 687.5609479061047,
-                "top": 1098.5247481034376
+                "left": 261.4017978836978,
+                "top": 665.0032711690706
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list:paired\"}",
+            "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list:paired\", \"fields\": null}",
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "42ec35b8-88d2-4390-a134-8fbd25142973",
@@ -378,8 +378,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 779.5413920910493,
-                "top": 1254.7391397096321
+                "left": 300.690496895607,
+                "top": 744.3491373675718
             },
             "tool_id": null,
             "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
@@ -390,29 +390,29 @@
             "workflow_outputs": []
         },
         "8": {
-            "annotation": "The default value is set for vertebrate genomes (CCCTAA).",
+            "annotation": "Minimum mapping score to keep for Hi-C alignments. Set to 0 to keep all mapped reads. Default: 20 ",
             "content_id": null,
             "errors": null,
             "id": 8,
             "input_connections": {},
             "inputs": [
                 {
-                    "description": "The default value is set for vertebrate genomes (CCCTAA).",
-                    "name": "Telomere repeat to suit species"
+                    "description": "Minimum mapping score to keep for Hi-C alignments. Set to 0 to keep all mapped reads. Default: 20 ",
+                    "name": "Minimum Mapping Score"
                 }
             ],
-            "label": "Telomere repeat to suit species",
+            "label": "Minimum Mapping Score",
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 1127.579183251202,
-                "top": 1612.5640291499033
+                "left": 365.7420201961709,
+                "top": 859.8954745516637
             },
             "tool_id": null,
-            "tool_state": "{\"default\": \"CCCTAA\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_state": "{\"default\": 20, \"validators\": [{\"min\": null, \"max\": null, \"negate\": false, \"type\": \"in_range\"}], \"parameter_type\": \"integer\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "84c91e14-1709-4602-8771-eea1dadf471b",
+            "uuid": "cd8cc71f-d3b4-4251-8078-e6fad5337261",
             "when": null,
             "workflow_outputs": []
         },
@@ -432,11 +432,11 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "left": 1178.4254094663186,
-                "top": 1721.1680883755375
+                "left": 444.8837556725949,
+                "top": 997.5722290906092
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"format\": [\"fastq.gz\"], \"tag\": null, \"collection_type\": \"list\"}",
+            "tool_state": "{\"optional\": false, \"format\": [\"fastq.gz\"], \"tag\": null, \"collection_type\": \"list\", \"fields\": null}",
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "8bc4fc4e-1a1a-43e8-b4bc-5115fefb541d",
@@ -444,10 +444,37 @@
             "workflow_outputs": []
         },
         "10": {
+            "annotation": "The default value is set for vertebrate genomes (CCCTAA).",
+            "content_id": null,
+            "errors": null,
+            "id": 10,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "The default value is set for vertebrate genomes (CCCTAA).",
+                    "name": "Telomere repeat to suit species"
+                }
+            ],
+            "label": "Telomere repeat to suit species",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 521.4650504859165,
+                "top": 1108.2406055983104
+            },
+            "tool_id": null,
+            "tool_state": "{\"default\": \"CCCTAA\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "84c91e14-1709-4602-8771-eea1dadf471b",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "11": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
             "errors": null,
-            "id": 10,
+            "id": 11,
             "input_connections": {
                 "input_param_type|input_param": {
                     "id": 1,
@@ -488,9 +515,9 @@
             "when": null,
             "workflow_outputs": []
         },
-        "11": {
+        "12": {
             "annotation": "",
-            "id": 11,
+            "id": 12,
             "input_connections": {
                 "Do you want to add suffixes to the scaffold names?": {
                     "id": 3,
@@ -1042,11 +1069,11 @@
             "when": "$(inputs.when)",
             "workflow_outputs": []
         },
-        "12": {
+        "13": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy0",
             "errors": null,
-            "id": 12,
+            "id": 13,
             "input_connections": {
                 "inputs": {
                     "id": 9,
@@ -1064,7 +1091,7 @@
             ],
             "position": {
                 "left": 2356.894328752512,
-                "top": 1516.7790596653556
+                "top": 1516.7790596653554
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -1087,9 +1114,9 @@
             "when": null,
             "workflow_outputs": []
         },
-        "13": {
+        "14": {
             "annotation": "",
-            "id": 13,
+            "id": 14,
             "input_connections": {
                 "Do you want to add suffixes to the scaffold names?": {
                     "id": 3,
@@ -1107,7 +1134,7 @@
                     "output_name": "output"
                 },
                 "when": {
-                    "id": 10,
+                    "id": 11,
                     "output_name": "output_param_boolean"
                 }
             },
@@ -1117,7 +1144,7 @@
             "outputs": [],
             "position": {
                 "left": 939.9147328570097,
-                "top": 499.1465562420046
+                "top": 499.14655624200464
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -1371,18 +1398,18 @@
             "when": "$(inputs.when)",
             "workflow_outputs": []
         },
-        "14": {
+        "15": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
             "errors": null,
-            "id": 14,
+            "id": 15,
             "input_connections": {
                 "style_cond|type_cond|pick_from_0|value": {
-                    "id": 11,
+                    "id": 12,
                     "output_name": "Merged Haplotypes"
                 },
                 "style_cond|type_cond|pick_from_1|value": {
-                    "id": 13,
+                    "id": 14,
                     "output_name": "Processed Hap1"
                 }
             },
@@ -1435,9 +1462,9 @@
                 }
             ]
         },
-        "15": {
+        "16": {
             "annotation": "",
-            "id": 15,
+            "id": 16,
             "input_connections": {
                 "Do you want to trim the Hi-C data?": {
                     "id": 7,
@@ -1449,8 +1476,13 @@
                     "input_subworkflow_step_id": 1,
                     "output_name": "output"
                 },
+                "Minimum mapping score": {
+                    "id": 8,
+                    "input_subworkflow_step_id": 3,
+                    "output_name": "output"
+                },
                 "Reference": {
-                    "id": 14,
+                    "id": 15,
                     "input_subworkflow_step_id": 0,
                     "output_name": "data_param"
                 }
@@ -1460,8 +1492,8 @@
             "name": "Trim and Align Hi-C paired collection",
             "outputs": [],
             "position": {
-                "left": 1538.40234375,
-                "top": 971.40625
+                "left": 1555.996393837426,
+                "top": 937.8045862614099
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -1533,7 +1565,7 @@
                             "top": 159.35032776516732
                         },
                         "tool_id": null,
-                        "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list:paired\"}",
+                        "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list:paired\", \"fields\": null}",
                         "tool_version": null,
                         "type": "data_collection_input",
                         "uuid": "a381377e-3cd7-4ed0-b7ed-8f5ddcedcb6e",
@@ -1569,15 +1601,42 @@
                             {
                                 "label": null,
                                 "output_name": "output",
-                                "uuid": "6d9fa96c-c50e-4a0d-9fda-084a3a73f09a"
+                                "uuid": "d6264a89-b887-4548-8fc0-fcd7564fdb9f"
                             }
                         ]
                     },
                     "3": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/5.0+galaxy0",
+                        "content_id": null,
                         "errors": null,
                         "id": 3,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Minimum mapping score"
+                            }
+                        ],
+                        "label": "Minimum mapping score",
+                        "name": "Input parameter",
+                        "outputs": [],
+                        "position": {
+                            "left": 319.7530758621395,
+                            "top": 454.2246120603114
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"validators\": [{\"min\": null, \"max\": null, \"negate\": false, \"type\": \"in_range\"}], \"parameter_type\": \"integer\", \"optional\": false}",
+                        "tool_version": null,
+                        "type": "parameter_input",
+                        "uuid": "9aafb613-39db-4a89-b9b7-585a1adbc7d3",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "4": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/5.0+galaxy0",
+                        "errors": null,
+                        "id": 4,
                         "input_connections": {
                             "library|input_1": {
                                 "id": 1,
@@ -1662,14 +1721,14 @@
                             }
                         ]
                     },
-                    "4": {
+                    "5": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
                         "errors": null,
-                        "id": 4,
+                        "id": 5,
                         "input_connections": {
                             "style_cond|type_cond|pick_from_0|value": {
-                                "id": 3,
+                                "id": 4,
                                 "output_name": "out_pairs"
                             },
                             "style_cond|type_cond|pick_from_1|value": {
@@ -1711,14 +1770,18 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "5": {
+                    "6": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bwa_mem2/bwa_mem2/2.2.1+galaxy4",
                         "errors": null,
-                        "id": 5,
+                        "id": 6,
                         "input_connections": {
+                            "analysis_type|io_options|T": {
+                                "id": 3,
+                                "output_name": "output"
+                            },
                             "fastq_input|fastq_input1": {
-                                "id": 4,
+                                "id": 5,
                                 "output_name": "data_param"
                             },
                             "reference_source|ref_file": {
@@ -1760,7 +1823,7 @@
                             "owner": "iuc",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"analysis_type\": {\"analysis_type_selector\": \"full\", \"__current_case__\": 4, \"algorithmic_options\": {\"algorithmic_options_selector\": \"set\", \"__current_case__\": 0, \"k\": \"19\", \"w\": \"100\", \"d\": \"100\", \"r\": \"1.5\", \"y\": \"20\", \"c\": \"500\", \"D\": \"0.5\", \"W\": \"0\", \"m\": \"50\", \"S\": true, \"P\": true, \"e\": false}, \"scoring_options\": {\"scoring_options_selector\": \"do_not_set\", \"__current_case__\": 1}, \"io_options\": {\"io_options_selector\": \"set\", \"__current_case__\": 0, \"five\": true, \"q\": false, \"T\": \"20\", \"h\": \"5\", \"a\": false, \"C\": false, \"V\": false, \"Y\": false, \"M\": false, \"K\": null}}, \"fastq_input\": {\"fastq_input_selector\": \"paired_collection\", \"__current_case__\": 2, \"fastq_input1\": {\"__class__\": \"ConnectedValue\"}, \"iset_stats\": null}, \"output_sort\": \"coordinate\", \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"ConnectedValue\"}}, \"rg\": {\"rg_selector\": \"set_id_auto\", \"__current_case__\": 2}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_state": "{\"analysis_type\": {\"analysis_type_selector\": \"full\", \"__current_case__\": 4, \"algorithmic_options\": {\"algorithmic_options_selector\": \"set\", \"__current_case__\": 0, \"k\": \"19\", \"w\": \"100\", \"d\": \"100\", \"r\": \"1.5\", \"y\": \"20\", \"c\": \"500\", \"D\": \"0.5\", \"W\": \"0\", \"m\": \"50\", \"S\": true, \"P\": true, \"e\": false}, \"scoring_options\": {\"scoring_options_selector\": \"do_not_set\", \"__current_case__\": 1}, \"io_options\": {\"io_options_selector\": \"set\", \"__current_case__\": 0, \"five\": true, \"q\": false, \"T\": {\"__class__\": \"ConnectedValue\"}, \"h\": \"5\", \"a\": false, \"C\": false, \"V\": false, \"Y\": false, \"M\": false, \"K\": null}}, \"fastq_input\": {\"fastq_input_selector\": \"paired_collection\", \"__current_case__\": 2, \"fastq_input1\": {\"__class__\": \"ConnectedValue\"}, \"iset_stats\": null}, \"output_sort\": \"coordinate\", \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"ConnectedValue\"}}, \"rg\": {\"rg_selector\": \"set_id_auto\", \"__current_case__\": 2}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
                         "tool_version": "2.2.1+galaxy4",
                         "type": "tool",
                         "uuid": "45d2eaea-40f9-461e-bfb0-cadd9b9738b8",
@@ -1773,14 +1836,14 @@
                             }
                         ]
                     },
-                    "6": {
+                    "7": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_merge/samtools_merge/1.20+galaxy2",
                         "errors": null,
-                        "id": 6,
+                        "id": 7,
                         "input_connections": {
                             "bamfiles": {
-                                "id": 5,
+                                "id": 6,
                                 "output_name": "bam_output"
                             }
                         },
@@ -1828,7 +1891,7 @@
                     }
                 },
                 "tags": [],
-                "uuid": "3e8637be-b30e-46b5-9a4e-3260a96e2ff2"
+                "uuid": "7764a62d-4be3-48d3-b683-bfbc74d54cee"
             },
             "tool_id": null,
             "type": "subworkflow",
@@ -1842,14 +1905,14 @@
                 }
             ]
         },
-        "16": {
+        "17": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/gfastats/gfastats/1.3.11+galaxy0",
             "errors": null,
-            "id": 16,
+            "id": 17,
             "input_connections": {
                 "input_file": {
-                    "id": 14,
+                    "id": 15,
                     "output_name": "data_param"
                 }
             },
@@ -1864,7 +1927,7 @@
             ],
             "position": {
                 "left": 2492.7240786856064,
-                "top": 297.13681251689746
+                "top": 297.1368125168974
             },
             "post_job_actions": {
                 "ChangeDatatypeActionstats": {
@@ -1909,18 +1972,18 @@
                 }
             ]
         },
-        "17": {
+        "18": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/seqtk/seqtk_telo/1.4+galaxy0",
             "errors": null,
-            "id": 17,
+            "id": 18,
             "input_connections": {
                 "in_file": {
-                    "id": 14,
+                    "id": 15,
                     "output_name": "data_param"
                 },
                 "m": {
-                    "id": 8,
+                    "id": 10,
                     "output_name": "output"
                 }
             },
@@ -1966,18 +2029,18 @@
                 }
             ]
         },
-        "18": {
+        "19": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/minimap2/minimap2/2.28+galaxy1",
             "errors": null,
-            "id": 18,
+            "id": 19,
             "input_connections": {
                 "fastq_input|fastq_input1": {
-                    "id": 12,
+                    "id": 13,
                     "output_name": "out_file1"
                 },
                 "reference_source|ref_file": {
-                    "id": 14,
+                    "id": 15,
                     "output_name": "data_param"
                 }
             },
@@ -1992,7 +2055,7 @@
             ],
             "position": {
                 "left": 2639.198250085289,
-                "top": 1490.7904718948823
+                "top": 1490.7904718948826
             },
             "post_job_actions": {
                 "HideDatasetActionalignment_output": {
@@ -2015,14 +2078,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "19": {
+        "20": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_map/pretext_map/0.1.9+galaxy1",
             "errors": null,
-            "id": 19,
+            "id": 20,
             "input_connections": {
                 "input": {
-                    "id": 15,
+                    "id": 16,
                     "output_name": "Merged Hi-C Alignments"
                 }
             },
@@ -2037,7 +2100,7 @@
             ],
             "position": {
                 "left": 2601.097112975265,
-                "top": 669.1121887201404
+                "top": 669.1121887201402
             },
             "post_job_actions": {
                 "HideDatasetActionpretext_map_out": {
@@ -2067,14 +2130,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "20": {
+        "21": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.1",
             "errors": null,
-            "id": 20,
+            "id": 21,
             "input_connections": {
                 "input": {
-                    "id": 16,
+                    "id": 17,
                     "output_name": "stats"
                 }
             },
@@ -2089,7 +2152,7 @@
             ],
             "position": {
                 "left": 2725.029875401758,
-                "top": 299.28710899735614
+                "top": 299.2871089973562
             },
             "post_job_actions": {
                 "ChangeDatatypeActionout_file1": {
@@ -2134,14 +2197,14 @@
                 }
             ]
         },
-        "21": {
+        "22": {
             "annotation": "",
             "content_id": "Cut1",
             "errors": null,
-            "id": 21,
+            "id": 22,
             "input_connections": {
                 "input": {
-                    "id": 17,
+                    "id": 18,
                     "output_name": "default"
                 }
             },
@@ -2173,14 +2236,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "22": {
+        "23": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.5.4+galaxy0",
             "errors": null,
-            "id": 22,
+            "id": 23,
             "input_connections": {
                 "bamInput": {
-                    "id": 18,
+                    "id": 19,
                     "output_name": "alignment_output"
                 }
             },
@@ -2233,14 +2296,14 @@
                 }
             ]
         },
-        "23": {
+        "24": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.31.1",
             "errors": null,
-            "id": 23,
+            "id": 24,
             "input_connections": {
                 "input_type|input": {
-                    "id": 18,
+                    "id": 19,
                     "output_name": "alignment_output"
                 }
             },
@@ -2255,7 +2318,7 @@
             ],
             "position": {
                 "left": 2906.9391779139696,
-                "top": 1734.9133309458432
+                "top": 1734.9133309458434
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -2278,14 +2341,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "24": {
+        "25": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.1",
             "errors": null,
-            "id": 24,
+            "id": 25,
             "input_connections": {
                 "input": {
-                    "id": 21,
+                    "id": 22,
                     "output_name": "out_file1"
                 }
             },
@@ -2345,18 +2408,18 @@
                 }
             ]
         },
-        "25": {
+        "26": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
             "errors": null,
-            "id": 25,
+            "id": 26,
             "input_connections": {
                 "input": {
-                    "id": 22,
+                    "id": 23,
                     "output_name": "outFileName"
                 },
                 "pretext": {
-                    "id": 19,
+                    "id": 20,
                     "output_name": "pretext_map_out"
                 }
             },
@@ -2394,14 +2457,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "26": {
+        "27": {
             "annotation": "",
             "content_id": "Filter1",
             "errors": null,
-            "id": 26,
+            "id": 27,
             "input_connections": {
                 "input": {
-                    "id": 23,
+                    "id": 24,
                     "output_name": "output"
                 }
             },
@@ -2416,7 +2479,7 @@
             ],
             "position": {
                 "left": 3198.2881192327804,
-                "top": 1721.1968191007911
+                "top": 1721.1968191007913
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -2433,14 +2496,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "27": {
+        "28": {
             "annotation": "",
             "content_id": "param_value_from_file",
             "errors": null,
-            "id": 27,
+            "id": 28,
             "input_connections": {
                 "input1": {
-                    "id": 24,
+                    "id": 25,
                     "output_name": "out_file1"
                 }
             },
@@ -2455,7 +2518,7 @@
             ],
             "position": {
                 "left": 3292.4213617861824,
-                "top": 882.3815353604188
+                "top": 882.3815353604186
             },
             "post_job_actions": {
                 "HideDatasetActiontext_param": {
@@ -2472,14 +2535,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "28": {
+        "29": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_column/9.5+galaxy0",
             "errors": null,
-            "id": 28,
+            "id": 29,
             "input_connections": {
                 "infile": {
-                    "id": 26,
+                    "id": 27,
                     "output_name": "out_file1"
                 }
             },
@@ -2539,14 +2602,14 @@
                 }
             ]
         },
-        "29": {
+        "30": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
             "errors": null,
-            "id": 29,
+            "id": 30,
             "input_connections": {
                 "input_param_type|input_param": {
-                    "id": 27,
+                    "id": 28,
                     "output_name": "text_param"
                 }
             },
@@ -2561,7 +2624,7 @@
             ],
             "position": {
                 "left": 3509.54306962867,
-                "top": 721.4609757332718
+                "top": 721.4609757332719
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_param_boolean": {
@@ -2584,22 +2647,22 @@
             "when": null,
             "workflow_outputs": []
         },
-        "30": {
+        "31": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
             "errors": null,
-            "id": 30,
+            "id": 31,
             "input_connections": {
                 "input": {
-                    "id": 24,
+                    "id": 25,
                     "output_name": "out_file1"
                 },
                 "pretext": {
-                    "id": 25,
+                    "id": 26,
                     "output_name": "graph_out"
                 },
                 "when": {
-                    "id": 29,
+                    "id": 30,
                     "output_name": "output_param_boolean"
                 }
             },
@@ -2613,8 +2676,8 @@
                 }
             ],
             "position": {
-                "left": 3637.1485454767576,
-                "top": 875.4121893744119
+                "left": 3660.1814328860523,
+                "top": 912.5512612563051
             },
             "post_job_actions": {
                 "HideDatasetActiongraph_out": {
@@ -2637,18 +2700,18 @@
             "when": "$(inputs.when)",
             "workflow_outputs": []
         },
-        "31": {
+        "32": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
             "errors": null,
-            "id": 31,
+            "id": 32,
             "input_connections": {
                 "style_cond|type_cond|pick_from_0|value": {
-                    "id": 30,
+                    "id": 31,
                     "output_name": "graph_out"
                 },
                 "style_cond|type_cond|pick_from_1|value": {
-                    "id": 25,
+                    "id": 26,
                     "output_name": "graph_out"
                 }
             },
@@ -2686,18 +2749,18 @@
             "when": null,
             "workflow_outputs": []
         },
-        "32": {
+        "33": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
             "errors": null,
-            "id": 32,
+            "id": 33,
             "input_connections": {
                 "input": {
-                    "id": 20,
+                    "id": 21,
                     "output_name": "out_file1"
                 },
                 "pretext": {
-                    "id": 31,
+                    "id": 32,
                     "output_name": "data_param"
                 }
             },
@@ -2735,18 +2798,18 @@
             "when": null,
             "workflow_outputs": []
         },
-        "33": {
+        "34": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
             "errors": null,
-            "id": 33,
+            "id": 34,
             "input_connections": {
                 "input": {
-                    "id": 28,
+                    "id": 29,
                     "output_name": "outfile"
                 },
                 "pretext": {
-                    "id": 32,
+                    "id": 33,
                     "output_name": "graph_out"
                 }
             },
@@ -2799,14 +2862,14 @@
                 }
             ]
         },
-        "34": {
+        "35": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_snapshot/pretext_snapshot/0.0.4+galaxy0",
             "errors": null,
-            "id": 34,
+            "id": 35,
             "input_connections": {
                 "input": {
-                    "id": 33,
+                    "id": 34,
                     "output_name": "graph_out"
                 }
             },
@@ -2821,7 +2884,7 @@
             ],
             "position": {
                 "left": 4668.760553276812,
-                "top": 906.4862147981122
+                "top": 906.4862147981121
             },
             "post_job_actions": {
                 "HideDatasetActionpretext_snap_out": {
@@ -2844,14 +2907,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "35": {
+        "36": {
             "annotation": "",
             "content_id": "__EXTRACT_DATASET__",
             "errors": null,
-            "id": 35,
+            "id": 36,
             "input_connections": {
                 "input": {
-                    "id": 34,
+                    "id": 35,
                     "output_name": "pretext_snap_out"
                 }
             },
@@ -2886,7 +2949,7 @@
             },
             "tool_id": "__EXTRACT_DATASET__",
             "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"which\": {\"which_dataset\": \"first\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.1",
+            "tool_version": "1.0.2",
             "type": "tool",
             "uuid": "1a9ded49-abf8-425f-b4a2-abcbcb537aa0",
             "when": null,
@@ -2900,6 +2963,6 @@
         }
     },
     "tags": [],
-    "uuid": "ed69401d-d823-4efc-a42b-b145bd8c7900",
+    "uuid": "a4b559bf-cffc-4032-8fc5-05fbe4e5842f",
     "version": 2
 }

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.ga
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.ga
@@ -4,26 +4,27 @@
     "comments": [
         {
             "child_steps": [
+                20,
+                27,
                 33,
-                26,
-                28,
-                30,
-                31,
-                32,
-                34
+                35,
+                37,
+                39,
+                41,
+                43
             ],
-            "color": "orange",
+            "color": "none",
             "data": {
-                "title": "Add tracks to the Hi-C map"
+                "title": "Generate Pretext Maps and Tracks - Multimapping"
             },
-            "id": 6,
+            "id": 5,
             "position": [
-                3280.2418890772274,
-                675.3465102395285
+                3275.4,
+                0
             ],
             "size": [
-                1284,
-                722
+                2005.3,
+                725
             ],
             "type": "frame"
         },
@@ -41,11 +42,104 @@
             "id": 0,
             "position": [
                 474.0963016672636,
-                52.046510239528516
+                167.44651023952852
             ],
             "size": [
                 1283,
                 769
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                13,
+                19,
+                24,
+                25,
+                29,
+                31
+            ],
+            "color": "green",
+            "data": {
+                "title": "Coverage"
+            },
+            "id": 4,
+            "position": [
+                2327.5,
+                1556.1000000000004
+            ],
+            "size": [
+                1404,
+                466
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                17,
+                22
+            ],
+            "color": "turquoise",
+            "data": {
+                "title": "Gaps"
+            },
+            "id": 2,
+            "position": [
+                2512.4,
+                686.5
+            ],
+            "size": [
+                541.9,
+                212.5
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                18,
+                23,
+                26
+            ],
+            "color": "lime",
+            "data": {
+                "title": "Telomeres"
+            },
+            "id": 3,
+            "position": [
+                2358.4,
+                1205.4
+            ],
+            "size": [
+                761,
+                296
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                21,
+                28,
+                30,
+                32,
+                34,
+                36,
+                38,
+                40,
+                42,
+                44
+            ],
+            "color": "orange",
+            "data": {
+                "title": "Add tracks to the Hi-C map - MAPQ filtering"
+            },
+            "id": 6,
+            "position": [
+                3280.2418890772274,
+                790.7465102395284
+            ],
+            "size": [
+                1988,
+                739
             ],
             "type": "frame"
         },
@@ -59,96 +153,12 @@
             },
             "id": 1,
             "position": [
-                1064.1,
-                870.5
+                1400,
+                1062.7
             ],
             "size": [
-                1159,
-                746
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                20
-            ],
-            "color": "red",
-            "data": {
-                "title": "Generate Hi-C map"
-            },
-            "id": 2,
-            "position": [
-                2345.1,
-                510.70000000000005
-            ],
-            "size": [
-                779.6,
-                512.7
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                17,
-                21
-            ],
-            "color": "turquoise",
-            "data": {
-                "title": "Gaps"
-            },
-            "id": 3,
-            "position": [
-                2453.2,
-                242.5999999999999
-            ],
-            "size": [
-                541.9,
-                212.5
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                18,
-                22,
-                25
-            ],
-            "color": "lime",
-            "data": {
-                "title": "Telomeres"
-            },
-            "id": 4,
-            "position": [
-                2358.4,
-                1090
-            ],
-            "size": [
-                761,
-                296
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                13,
-                19,
-                23,
-                24,
-                27,
-                29
-            ],
-            "color": "green",
-            "data": {
-                "title": "Coverage"
-            },
-            "id": 5,
-            "position": [
-                2327.5,
-                1440.7000000000003
-            ],
-            "size": [
-                1404,
-                466
+                638,
+                465
             ],
             "type": "frame"
         }
@@ -190,7 +200,7 @@
             "outputs": [],
             "position": {
                 "left": 0,
-                "top": 0
+                "top": 115.4
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
@@ -217,7 +227,7 @@
             "outputs": [],
             "position": {
                 "left": 38.015625,
-                "top": 96.875
+                "top": 212.275
             },
             "tool_id": null,
             "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
@@ -225,7 +235,13 @@
             "type": "parameter_input",
             "uuid": "697b66dc-1c0f-40d7-9d03-51318db580f1",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "038747d0-14e8-43cd-94eb-1aaf8fb63518"
+                }
+            ]
         },
         "2": {
             "annotation": "Assembly for Haplotype 2. If \"Will you use a second haplotype?\" is set to \"no\", use haplotype 1 here. ",
@@ -244,7 +260,7 @@
             "outputs": [],
             "position": {
                 "left": 85.32812500000001,
-                "top": 209.84375
+                "top": 325.24375
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
@@ -271,7 +287,7 @@
             "outputs": [],
             "position": {
                 "left": 126.16035849292534,
-                "top": 310.43309384096546
+                "top": 425.8330938409655
             },
             "tool_id": null,
             "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
@@ -279,7 +295,13 @@
             "type": "parameter_input",
             "uuid": "742c987a-a4b8-4208-918a-cfb4bd55cd66",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "2fcf29b7-37d3-4c58-8140-21cabb541389"
+                }
+            ]
         },
         "4": {
             "annotation": "Suffix added to scaffolds belonging to haplotype 1.",
@@ -298,7 +320,7 @@
             "outputs": [],
             "position": {
                 "left": 176.27674150664734,
-                "top": 435.65593992735546
+                "top": 551.0559399273554
             },
             "tool_id": null,
             "tool_state": "{\"default\": \"H1\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
@@ -306,7 +328,13 @@
             "type": "parameter_input",
             "uuid": "f61b5666-fa76-4892-9b1d-d31979bc5a44",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "2fc68d1e-1183-4b4c-9cd9-202d87ca7d4d"
+                }
+            ]
         },
         "5": {
             "annotation": "Suffix added to contigs belonging to haplotype 2.",
@@ -325,7 +353,7 @@
             "outputs": [],
             "position": {
                 "left": 216.8962099291657,
-                "top": 543.7431063618276
+                "top": 659.1431063618276
             },
             "tool_id": null,
             "tool_state": "{\"default\": \"H2\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
@@ -333,7 +361,13 @@
             "type": "parameter_input",
             "uuid": "294ab686-1b84-4a79-aa5c-10553af61911",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "3bd7d1c8-ba70-467c-a803-3928aba936af"
+                }
+            ]
         },
         "6": {
             "annotation": "Paired Collection containing the Hi-C reads. ",
@@ -352,7 +386,7 @@
             "outputs": [],
             "position": {
                 "left": 261.4017978836978,
-                "top": 665.0032711690706
+                "top": 780.4032711690705
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list:paired\", \"fields\": null}",
@@ -379,7 +413,7 @@
             "outputs": [],
             "position": {
                 "left": 300.690496895607,
-                "top": 744.3491373675718
+                "top": 859.7491373675717
             },
             "tool_id": null,
             "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
@@ -387,17 +421,23 @@
             "type": "parameter_input",
             "uuid": "6d1391db-7fef-4b5c-a236-26016d6d0aab",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "3f4de6d0-9d6c-4503-8b08-1802c9239d05"
+                }
+            ]
         },
         "8": {
-            "annotation": "Minimum mapping score to keep for Hi-C alignments. Set to 0 to keep all mapped reads. Default: 20 ",
+            "annotation": "Minimum mapping score to keep for Hi-C alignments for the quality filtered PretextMap. Set to 0 to keep all mapped reads. Default: 20 ",
             "content_id": null,
             "errors": null,
             "id": 8,
             "input_connections": {},
             "inputs": [
                 {
-                    "description": "Minimum mapping score to keep for Hi-C alignments. Set to 0 to keep all mapped reads. Default: 20 ",
+                    "description": "Minimum mapping score to keep for Hi-C alignments for the quality filtered PretextMap. Set to 0 to keep all mapped reads. Default: 20 ",
                     "name": "Minimum Mapping Quality"
                 }
             ],
@@ -406,7 +446,7 @@
             "outputs": [],
             "position": {
                 "left": 365.7420201961709,
-                "top": 859.8954745516637
+                "top": 975.2954745516637
             },
             "tool_id": null,
             "tool_state": "{\"default\": 20, \"validators\": [{\"min\": null, \"max\": null, \"negate\": false, \"type\": \"in_range\"}], \"parameter_type\": \"integer\", \"optional\": false}",
@@ -414,7 +454,13 @@
             "type": "parameter_input",
             "uuid": "cd8cc71f-d3b4-4251-8078-e6fad5337261",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "21454f4f-02e1-44b1-9f9a-57471bd1bd26"
+                }
+            ]
         },
         "9": {
             "annotation": "",
@@ -433,7 +479,7 @@
             "outputs": [],
             "position": {
                 "left": 444.8837556725949,
-                "top": 997.5722290906092
+                "top": 1112.9722290906093
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"format\": [\"fastq.gz\"], \"tag\": null, \"collection_type\": \"list\", \"fields\": null}",
@@ -460,7 +506,7 @@
             "outputs": [],
             "position": {
                 "left": 521.4650504859165,
-                "top": 1108.2406055983104
+                "top": 1223.6406055983105
             },
             "tool_id": null,
             "tool_state": "{\"default\": \"CCCTAA\", \"validators\": [], \"parameter_type\": \"text\", \"optional\": true}",
@@ -468,7 +514,13 @@
             "type": "parameter_input",
             "uuid": "84c91e14-1709-4602-8771-eea1dadf471b",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "26a0eb22-3009-488c-a79f-a9375a67afb5"
+                }
+            ]
         },
         "11": {
             "annotation": "",
@@ -492,7 +544,7 @@
             ],
             "position": {
                 "left": 645.0946591345934,
-                "top": 641.569655470159
+                "top": 756.969655470159
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_param_boolean": {
@@ -555,7 +607,7 @@
             "outputs": [],
             "position": {
                 "left": 936.515625,
-                "top": 95.3125
+                "top": 210.7125
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -820,7 +872,7 @@
                     },
                     "7": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy0",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy2",
                         "errors": null,
                         "id": 7,
                         "input_connections": {
@@ -851,15 +903,15 @@
                             "top": 65.28236324842067
                         },
                         "post_job_actions": {},
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy0",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy2",
                         "tool_shed_repository": {
-                            "changeset_revision": "6073bb457ec0",
+                            "changeset_revision": "c41d78ae5fee",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
                         "tool_state": "{\"infile\": {\"__class__\": \"ConnectedValue\"}, \"replacements\": [{\"__index__\": 0, \"find_pattern\": \">.+$\", \"replace_pattern\": {\"__class__\": \"ConnectedValue\"}, \"sed_options\": null}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "9.5+galaxy0",
+                        "tool_version": "9.5+galaxy2",
                         "type": "tool",
                         "uuid": "0d494264-b35e-4084-b8b8-f4bacd1bc3d0",
                         "when": "$(inputs.when)",
@@ -867,7 +919,7 @@
                     },
                     "8": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy0",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy2",
                         "errors": null,
                         "id": 8,
                         "input_connections": {
@@ -898,15 +950,15 @@
                             "top": 294.29634625957476
                         },
                         "post_job_actions": {},
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy0",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy2",
                         "tool_shed_repository": {
-                            "changeset_revision": "6073bb457ec0",
+                            "changeset_revision": "c41d78ae5fee",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
                         "tool_state": "{\"infile\": {\"__class__\": \"ConnectedValue\"}, \"replacements\": [{\"__index__\": 0, \"find_pattern\": \">.+$\", \"replace_pattern\": {\"__class__\": \"ConnectedValue\"}, \"sed_options\": null}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "9.5+galaxy0",
+                        "tool_version": "9.5+galaxy2",
                         "type": "tool",
                         "uuid": "5d369c5c-05fc-4477-897a-42b948900499",
                         "when": "$(inputs.when)",
@@ -1012,7 +1064,7 @@
                     },
                     "11": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy0",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy2",
                         "errors": null,
                         "id": 11,
                         "input_connections": {
@@ -1039,15 +1091,15 @@
                             "top": 246.32152277721676
                         },
                         "post_job_actions": {},
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy0",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy2",
                         "tool_shed_repository": {
-                            "changeset_revision": "6073bb457ec0",
+                            "changeset_revision": "c41d78ae5fee",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
                         "tool_state": "{\"inputs\": {\"__class__\": \"ConnectedValue\"}, \"queries\": [{\"__index__\": 0, \"inputs2\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "9.5+galaxy0",
+                        "tool_version": "9.5+galaxy2",
                         "type": "tool",
                         "uuid": "b2f8c163-76e4-4e8e-bcf6-56c69b322e6f",
                         "when": null,
@@ -1061,17 +1113,33 @@
                     }
                 },
                 "tags": [],
-                "uuid": "3dffa796-83c2-4a31-9947-1b01e0fe992a"
+                "uuid": "8fb65374-0776-4aa9-80d8-eb0b8c69f274"
             },
             "tool_id": null,
             "type": "subworkflow",
             "uuid": "e3fb5fbc-543e-405a-aa5d-0c4f512abd61",
             "when": "$(inputs.when)",
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "4:output",
+                    "uuid": "86c286ff-c6d8-4d33-b77b-dbe42ab8e719"
+                },
+                {
+                    "label": null,
+                    "output_name": "3:output",
+                    "uuid": "98b1800d-89cf-4949-a020-c10c9294cc5a"
+                },
+                {
+                    "label": null,
+                    "output_name": "2:output",
+                    "uuid": "6d10f1d1-43f5-4aed-ab57-6b3e6cceb047"
+                }
+            ]
         },
         "13": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy2",
             "errors": null,
             "id": 13,
             "input_connections": {
@@ -1091,7 +1159,7 @@
             ],
             "position": {
                 "left": 2356.894328752512,
-                "top": 1516.7790596653554
+                "top": 1632.1790596653555
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -1100,15 +1168,15 @@
                     "output_name": "out_file1"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy2",
             "tool_shed_repository": {
-                "changeset_revision": "6073bb457ec0",
+                "changeset_revision": "c41d78ae5fee",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"inputs\": {\"__class__\": \"ConnectedValue\"}, \"queries\": [], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "9.5+galaxy0",
+            "tool_version": "9.5+galaxy2",
             "type": "tool",
             "uuid": "6bbe7bd6-0d08-431f-bcb4-ae5e264ce3c8",
             "when": null,
@@ -1144,7 +1212,7 @@
             "outputs": [],
             "position": {
                 "left": 939.9147328570097,
-                "top": 499.14655624200464
+                "top": 614.5465562420046
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -1294,7 +1362,7 @@
                     },
                     "4": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy0",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy2",
                         "errors": null,
                         "id": 4,
                         "input_connections": {
@@ -1325,15 +1393,15 @@
                             "top": 117.72698978106516
                         },
                         "post_job_actions": {},
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy0",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy2",
                         "tool_shed_repository": {
-                            "changeset_revision": "6073bb457ec0",
+                            "changeset_revision": "c41d78ae5fee",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
                         "tool_state": "{\"infile\": {\"__class__\": \"ConnectedValue\"}, \"replacements\": [{\"__index__\": 0, \"find_pattern\": \">.+$\", \"replace_pattern\": {\"__class__\": \"ConnectedValue\"}, \"sed_options\": null}], \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "9.5+galaxy0",
+                        "tool_version": "9.5+galaxy2",
                         "type": "tool",
                         "uuid": "035ade88-6466-4cfd-bff6-fe954f352772",
                         "when": "$(inputs.when)",
@@ -1390,13 +1458,24 @@
                     }
                 },
                 "tags": [],
-                "uuid": "53fc877b-7090-4cd6-a64a-33b4c3b19751"
+                "uuid": "c32e34b2-4390-4bf2-9048-411280d63ddd"
             },
             "tool_id": null,
             "type": "subworkflow",
             "uuid": "963aaf4e-14cf-449b-99b5-f3693b8b19b6",
             "when": "$(inputs.when)",
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "2:output",
+                    "uuid": "89d22fb4-c323-4503-95de-036cde575848"
+                },
+                {
+                    "label": null,
+                    "output_name": "1:output",
+                    "uuid": "e3ad90c8-bcfe-48b8-b444-73349e005043"
+                }
+            ]
         },
         "15": {
             "annotation": "",
@@ -1424,7 +1503,7 @@
             ],
             "position": {
                 "left": 1298.4073811566127,
-                "top": 372.38788984421603
+                "top": 487.787889844216
             },
             "post_job_actions": {
                 "RenameDatasetActiondata_param": {
@@ -1487,8 +1566,8 @@
             "name": "Trim and Align Hi-C paired collection",
             "outputs": [],
             "position": {
-                "left": 1555.996393837426,
-                "top": 937.8045862614099
+                "left": 1597.540057940126,
+                "top": 1125.0787431885797
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -1592,11 +1671,17 @@
                         "type": "parameter_input",
                         "uuid": "6d1391db-7fef-4b5c-a236-26016d6d0aab",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "d99e7786-a87f-4601-afa7-c17ce13d67ea"
+                            }
+                        ]
                     },
                     "3": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/5.0+galaxy0",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/5.1+galaxy0",
                         "errors": null,
                         "id": 3,
                         "input_connections": {
@@ -1663,15 +1748,15 @@
                                 "output_name": "report"
                             }
                         },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/5.0+galaxy0",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/5.1+galaxy0",
                         "tool_shed_repository": {
-                            "changeset_revision": "c0b2c2e39c9c",
+                            "changeset_revision": "80766b36005d",
                             "name": "cutadapt",
                             "owner": "lparsons",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
                         "tool_state": "{\"adapter_options\": {\"action\": \"trim\", \"error_rate\": \"0.1\", \"no_indels\": false, \"times\": \"1\", \"overlap\": \"3\", \"match_read_wildcards\": false, \"no_match_adapter_wildcards\": true, \"revcomp\": false}, \"filter_options\": {\"discard_trimmed\": false, \"discard_untrimmed\": false, \"minimum_length\": \"1\", \"minimum_length2\": null, \"maximum_length\": null, \"maximum_length2\": null, \"max_n\": null, \"max_expected_errors\": null, \"max_average_error_rate\": null, \"discard_casava\": false, \"pair_filter\": \"any\"}, \"library\": {\"type\": \"paired_collection\", \"__current_case__\": 2, \"input_1\": {\"__class__\": \"ConnectedValue\"}, \"r1\": {\"adapters\": [], \"front_adapters\": [], \"anywhere_adapters\": []}, \"r2\": {\"adapters2\": [], \"front_adapters2\": [], \"anywhere_adapters2\": []}, \"pair_adapters\": false}, \"other_trimming_options\": {\"cut\": \"5\", \"cut2\": \"5\", \"quality_cutoff\": \"0\", \"quality_cutoff2\": \"\", \"nextseq_trim\": \"0\", \"trim_n\": false, \"poly_a\": false, \"shorten_options\": {\"shorten_values\": \"False\", \"__current_case__\": 1}, \"shorten_options_r2\": {\"shorten_values_r2\": \"False\", \"__current_case__\": 1}}, \"output_selector\": [\"report\"], \"read_mod_options\": {\"strip_suffix\": null, \"length_tag\": null, \"rename\": null, \"zero_cap\": false}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-                        "tool_version": "5.0+galaxy0",
+                        "tool_version": "5.1+galaxy0",
                         "type": "tool",
                         "uuid": "15c5cc40-ce0a-4e29-a891-87f55bf2bd6b",
                         "when": "$(inputs.when)",
@@ -1781,7 +1866,7 @@
                             "owner": "iuc",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"analysis_type\": {\"analysis_type_selector\": \"full\", \"__current_case__\": 4, \"algorithmic_options\": {\"algorithmic_options_selector\": \"set\", \"__current_case__\": 0, \"k\": \"19\", \"w\": \"100\", \"d\": \"100\", \"r\": \"1.5\", \"y\": \"20\", \"c\": \"500\", \"D\": \"0.5\", \"W\": \"0\", \"m\": \"50\", \"S\": true, \"P\": true, \"e\": false}, \"scoring_options\": {\"scoring_options_selector\": \"do_not_set\", \"__current_case__\": 1}, \"io_options\": {\"io_options_selector\": \"set\", \"__current_case__\": 0, \"five\": true, \"q\": false, \"T\": \"20\", \"h\": \"5\", \"a\": false, \"C\": false, \"V\": false, \"Y\": false, \"M\": false, \"K\": null}}, \"fastq_input\": {\"fastq_input_selector\": \"paired_collection\", \"__current_case__\": 2, \"fastq_input1\": {\"__class__\": \"RuntimeValue\"}, \"iset_stats\": null}, \"output_sort\": \"coordinate\", \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"RuntimeValue\"}}, \"rg\": {\"rg_selector\": \"set_id_auto\", \"__current_case__\": 2}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_state": "{\"analysis_type\": {\"analysis_type_selector\": \"full\", \"__current_case__\": 4, \"algorithmic_options\": {\"algorithmic_options_selector\": \"set\", \"__current_case__\": 0, \"k\": \"19\", \"w\": \"100\", \"d\": \"100\", \"r\": \"1.5\", \"y\": \"20\", \"c\": \"500\", \"D\": \"0.5\", \"W\": \"0\", \"m\": \"50\", \"S\": true, \"P\": true, \"e\": false}, \"scoring_options\": {\"scoring_options_selector\": \"do_not_set\", \"__current_case__\": 1}, \"io_options\": {\"io_options_selector\": \"set\", \"__current_case__\": 0, \"five\": true, \"q\": false, \"T\": \"30\", \"h\": \"5\", \"a\": false, \"C\": false, \"V\": false, \"Y\": false, \"M\": false, \"K\": null}}, \"fastq_input\": {\"fastq_input_selector\": \"paired_collection\", \"__current_case__\": 2, \"fastq_input1\": {\"__class__\": \"ConnectedValue\"}, \"iset_stats\": null}, \"output_sort\": \"coordinate\", \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"ConnectedValue\"}}, \"rg\": {\"rg_selector\": \"set_id_auto\", \"__current_case__\": 2}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
                         "tool_version": "2.2.1+galaxy4",
                         "type": "tool",
                         "uuid": "45d2eaea-40f9-461e-bfb0-cadd9b9738b8",
@@ -1849,13 +1934,18 @@
                     }
                 },
                 "tags": [],
-                "uuid": "d03cced9-fa15-49c9-a7e4-279b4aabfc40"
+                "uuid": "52451b6f-5046-4926-b61e-a16cae121c1e"
             },
             "tool_id": null,
             "type": "subworkflow",
             "uuid": "79dfffd9-d4af-4391-af9f-03dbf9ac79d0",
             "when": null,
             "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "2:output",
+                    "uuid": "58f24505-5542-4b48-ac5d-c8db126fea46"
+                },
                 {
                     "label": "Merged Hi-C Alignments",
                     "output_name": "Merged Hi-C Alignments",
@@ -1884,8 +1974,8 @@
                 }
             ],
             "position": {
-                "left": 2492.7240786856064,
-                "top": 297.1368125168974
+                "left": 2551.9898452940315,
+                "top": 740.9619820593626
             },
             "post_job_actions": {
                 "ChangeDatatypeActionstats": {
@@ -1956,7 +2046,7 @@
             ],
             "position": {
                 "left": 2398.405341156259,
-                "top": 1132.104273047803
+                "top": 1247.504273047803
             },
             "post_job_actions": {
                 "RenameDatasetActiondefault": {
@@ -2013,7 +2103,7 @@
             ],
             "position": {
                 "left": 2639.198250085289,
-                "top": 1490.7904718948826
+                "top": 1606.1904718948826
             },
             "post_job_actions": {
                 "HideDatasetActionalignment_output": {
@@ -2045,14 +2135,10 @@
                 "input": {
                     "id": 16,
                     "output_name": "Merged Hi-C Alignments"
-                },
-                "map_qual": {
-                    "id": 8,
-                    "output_name": "output"
                 }
             },
             "inputs": [],
-            "label": null,
+            "label": "PretextMap - Multimapping",
             "name": "PretextMap",
             "outputs": [
                 {
@@ -2061,8 +2147,8 @@
                 }
             ],
             "position": {
-                "left": 2601.097112975265,
-                "top": 669.1121887201402
+                "left": 3370.9952336142264,
+                "top": 144.557699587695
             },
             "post_job_actions": {
                 "HideDatasetActionpretext_map_out": {
@@ -2085,18 +2171,74 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filter\": {\"filter_type\": \"\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"map_qual\": {\"__class__\": \"ConnectedValue\"}, \"sorting\": {\"sortby\": \"length\", \"__current_case__\": 1, \"sortorder\": \"descend\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"filter\": {\"filter_type\": \"\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"map_qual\": \"0\", \"sorting\": {\"sortby\": \"length\", \"__current_case__\": 1, \"sortorder\": \"descend\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.1.9+galaxy1",
+            "type": "tool",
+            "uuid": "b7934163-451f-4cab-9f11-2b88bc88f535",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "21": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_map/pretext_map/0.1.9+galaxy1",
+            "errors": null,
+            "id": 21,
+            "input_connections": {
+                "input": {
+                    "id": 16,
+                    "output_name": "Merged Hi-C Alignments"
+                },
+                "map_qual": {
+                    "id": 8,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "PretextMap",
+            "outputs": [
+                {
+                    "name": "pretext_map_out",
+                    "type": "pretext"
+                }
+            ],
+            "position": {
+                "left": 3353.607342220995,
+                "top": 880.3563795914976
+            },
+            "post_job_actions": {
+                "HideDatasetActionpretext_map_out": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "pretext_map_out"
+                },
+                "TagDatasetActionpretext_map_out": {
+                    "action_arguments": {
+                        "tags": "haps_pretext"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "pretext_map_out"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_map/pretext_map/0.1.9+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "c6cec5ab35c1",
+                "name": "pretext_map",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"filter\": {\"filter_type\": \"\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"map_qual\": {\"__class__\": \"ConnectedValue\"}, \"sorting\": {\"sortby\": \"length\", \"__current_case__\": 1, \"sortorder\": \"descend\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.1.9+galaxy1",
             "type": "tool",
             "uuid": "2bc11d1e-ba89-4a9c-80c9-2b83aa638457",
             "when": null,
             "workflow_outputs": []
         },
-        "21": {
+        "22": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.1",
             "errors": null,
-            "id": 21,
+            "id": 22,
             "input_connections": {
                 "input": {
                     "id": 17,
@@ -2113,8 +2255,8 @@
                 }
             ],
             "position": {
-                "left": 2725.029875401758,
-                "top": 299.2871089973562
+                "left": 2784.295642010183,
+                "top": 743.1122785398214
             },
             "post_job_actions": {
                 "ChangeDatatypeActionout_file1": {
@@ -2159,11 +2301,11 @@
                 }
             ]
         },
-        "22": {
+        "23": {
             "annotation": "",
             "content_id": "Cut1",
             "errors": null,
-            "id": 22,
+            "id": 23,
             "input_connections": {
                 "input": {
                     "id": 18,
@@ -2181,7 +2323,7 @@
             ],
             "position": {
                 "left": 2629.361425631686,
-                "top": 1274.4689499625679
+                "top": 1389.868949962568
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -2198,11 +2340,11 @@
             "when": null,
             "workflow_outputs": []
         },
-        "23": {
+        "24": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/deeptools_bam_coverage/deeptools_bam_coverage/3.5.4+galaxy0",
             "errors": null,
-            "id": 23,
+            "id": 24,
             "input_connections": {
                 "bamInput": {
                     "id": 19,
@@ -2220,7 +2362,7 @@
             ],
             "position": {
                 "left": 2885.1534846304676,
-                "top": 1514.2252407486453
+                "top": 1629.6252407486454
             },
             "post_job_actions": {
                 "RenameDatasetActionoutFileName": {
@@ -2258,11 +2400,11 @@
                 }
             ]
         },
-        "24": {
+        "25": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.31.1",
             "errors": null,
-            "id": 24,
+            "id": 25,
             "input_connections": {
                 "input_type|input": {
                     "id": 19,
@@ -2280,7 +2422,7 @@
             ],
             "position": {
                 "left": 2906.9391779139696,
-                "top": 1734.9133309458434
+                "top": 1850.3133309458435
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -2303,14 +2445,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "25": {
+        "26": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.1",
             "errors": null,
-            "id": 25,
+            "id": 26,
             "input_connections": {
                 "input": {
-                    "id": 22,
+                    "id": 23,
                     "output_name": "out_file1"
                 }
             },
@@ -2325,7 +2467,7 @@
             ],
             "position": {
                 "left": 2859.108556796333,
-                "top": 1138.8469397334848
+                "top": 1254.2469397334849
             },
             "post_job_actions": {
                 "ChangeDatatypeActionout_file1": {
@@ -2370,18 +2512,67 @@
                 }
             ]
         },
-        "26": {
+        "27": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
             "errors": null,
-            "id": 26,
+            "id": 27,
             "input_connections": {
                 "input": {
-                    "id": 23,
+                    "id": 24,
                     "output_name": "outFileName"
                 },
                 "pretext": {
                     "id": 20,
+                    "output_name": "pretext_map_out"
+                }
+            },
+            "inputs": [],
+            "label": "Add Coverage Track - Multimapping",
+            "name": "Pretextgraph",
+            "outputs": [
+                {
+                    "name": "graph_out",
+                    "type": "pretext"
+                }
+            ],
+            "position": {
+                "left": 3549.2636643840265,
+                "top": 416.46282504028386
+            },
+            "post_job_actions": {
+                "HideDatasetActiongraph_out": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "graph_out"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "408ece2e4647",
+                "name": "pretext_graph",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"name\": \"coverage\", \"pretext\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.7+galaxy0",
+            "type": "tool",
+            "uuid": "fd4f30e5-128b-4a4d-b9f6-2239323f99da",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "28": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
+            "errors": null,
+            "id": 28,
+            "input_connections": {
+                "input": {
+                    "id": 24,
+                    "output_name": "outFileName"
+                },
+                "pretext": {
+                    "id": 21,
                     "output_name": "pretext_map_out"
                 }
             },
@@ -2395,8 +2586,8 @@
                 }
             ],
             "position": {
-                "left": 3306.7639798679484,
-                "top": 1132.5738565753659
+                "left": 3707.655157116074,
+                "top": 1307.9771772016468
             },
             "post_job_actions": {
                 "HideDatasetActiongraph_out": {
@@ -2419,14 +2610,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "27": {
+        "29": {
             "annotation": "",
             "content_id": "Filter1",
             "errors": null,
-            "id": 27,
+            "id": 29,
             "input_connections": {
                 "input": {
-                    "id": 24,
+                    "id": 25,
                     "output_name": "output"
                 }
             },
@@ -2441,7 +2632,7 @@
             ],
             "position": {
                 "left": 3198.2881192327804,
-                "top": 1721.1968191007913
+                "top": 1836.5968191007914
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -2458,14 +2649,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "28": {
+        "30": {
             "annotation": "",
             "content_id": "param_value_from_file",
             "errors": null,
-            "id": 28,
+            "id": 30,
             "input_connections": {
                 "input1": {
-                    "id": 25,
+                    "id": 26,
                     "output_name": "out_file1"
                 }
             },
@@ -2479,8 +2670,8 @@
                 }
             ],
             "position": {
-                "left": 3292.4213617861824,
-                "top": 882.3815353604186
+                "left": 3477.874990595526,
+                "top": 1144.6177361702207
             },
             "post_job_actions": {
                 "HideDatasetActiontext_param": {
@@ -2497,14 +2688,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "29": {
+        "31": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_column/9.5+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_column/9.5+galaxy2",
             "errors": null,
-            "id": 29,
+            "id": 31,
             "input_connections": {
                 "infile": {
-                    "id": 27,
+                    "id": 29,
                     "output_name": "out_file1"
                 }
             },
@@ -2519,7 +2710,7 @@
             ],
             "position": {
                 "left": 3474.5953629815754,
-                "top": 1664.7241919135736
+                "top": 1780.1241919135737
             },
             "post_job_actions": {
                 "ChangeDatatypeActionoutfile": {
@@ -2544,15 +2735,15 @@
                     "output_name": "outfile"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_column/9.5+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_column/9.5+galaxy2",
             "tool_shed_repository": {
-                "changeset_revision": "6073bb457ec0",
+                "changeset_revision": "c41d78ae5fee",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"infile\": {\"__class__\": \"ConnectedValue\"}, \"replacements\": [{\"__index__\": 0, \"column\": \"4\", \"find_pattern\": \"0\", \"replace_pattern\": \"200\"}], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "9.5+galaxy0",
+            "tool_version": "9.5+galaxy2",
             "type": "tool",
             "uuid": "2ab27d7d-7c5b-4c87-939a-41c1a1e6abbf",
             "when": null,
@@ -2564,14 +2755,14 @@
                 }
             ]
         },
-        "30": {
+        "32": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
             "errors": null,
-            "id": 30,
+            "id": 32,
             "input_connections": {
                 "input_param_type|input_param": {
-                    "id": 28,
+                    "id": 30,
                     "output_name": "text_param"
                 }
             },
@@ -2585,8 +2776,8 @@
                 }
             ],
             "position": {
-                "left": 3509.54306962867,
-                "top": 721.4609757332719
+                "left": 3691.0850358282346,
+                "top": 866.6417409855811
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_param_boolean": {
@@ -2609,22 +2800,75 @@
             "when": null,
             "workflow_outputs": []
         },
-        "31": {
+        "33": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
             "errors": null,
-            "id": 31,
+            "id": 33,
             "input_connections": {
                 "input": {
-                    "id": 25,
+                    "id": 26,
                     "output_name": "out_file1"
                 },
                 "pretext": {
-                    "id": 26,
+                    "id": 27,
                     "output_name": "graph_out"
                 },
                 "when": {
-                    "id": 30,
+                    "id": 32,
+                    "output_name": "output_param_boolean"
+                }
+            },
+            "inputs": [],
+            "label": "Add telomere track - Multimapping",
+            "name": "Pretextgraph",
+            "outputs": [
+                {
+                    "name": "graph_out",
+                    "type": "pretext"
+                }
+            ],
+            "position": {
+                "left": 3949.0082783811126,
+                "top": 298.87445975969626
+            },
+            "post_job_actions": {
+                "HideDatasetActiongraph_out": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "graph_out"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "408ece2e4647",
+                "name": "pretext_graph",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"name\": \"telomeres_gap_format\", \"pretext\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.7+galaxy0",
+            "type": "tool",
+            "uuid": "61bff42d-b896-4f18-990e-e677a5a8f39f",
+            "when": "$(inputs.when)",
+            "workflow_outputs": []
+        },
+        "34": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
+            "errors": null,
+            "id": 34,
+            "input_connections": {
+                "input": {
+                    "id": 26,
+                    "output_name": "out_file1"
+                },
+                "pretext": {
+                    "id": 28,
+                    "output_name": "graph_out"
+                },
+                "when": {
+                    "id": 32,
                     "output_name": "output_param_boolean"
                 }
             },
@@ -2638,8 +2882,8 @@
                 }
             ],
             "position": {
-                "left": 3660.1814328860523,
-                "top": 912.5512612563051
+                "left": 3910.779584724609,
+                "top": 1048.9668742469053
             },
             "post_job_actions": {
                 "HideDatasetActiongraph_out": {
@@ -2662,18 +2906,18 @@
             "when": "$(inputs.when)",
             "workflow_outputs": []
         },
-        "32": {
+        "35": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
             "errors": null,
-            "id": 32,
+            "id": 35,
             "input_connections": {
                 "style_cond|type_cond|pick_from_0|value": {
-                    "id": 31,
+                    "id": 33,
                     "output_name": "graph_out"
                 },
                 "style_cond|type_cond|pick_from_1|value": {
-                    "id": 26,
+                    "id": 27,
                     "output_name": "graph_out"
                 }
             },
@@ -2687,8 +2931,57 @@
                 }
             ],
             "position": {
-                "left": 3844.028000653102,
-                "top": 1169.0989361540105
+                "left": 4126.056868934076,
+                "top": 561.0565921352818
+            },
+            "post_job_actions": {
+                "HideDatasetActiondata_param": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "data_param"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+            "tool_shed_repository": {
+                "changeset_revision": "b19e21af9c52",
+                "name": "pick_value",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"style_cond\": {\"pick_style\": \"first\", \"__current_case__\": 0, \"type_cond\": {\"param_type\": \"data\", \"__current_case__\": 4, \"pick_from\": [{\"__index__\": 0, \"value\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"value\": {\"__class__\": \"ConnectedValue\"}}]}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.2.0",
+            "type": "tool",
+            "uuid": "d2892664-3fbc-46b8-958e-a4cd47f6e4be",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "36": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+            "errors": null,
+            "id": 36,
+            "input_connections": {
+                "style_cond|type_cond|pick_from_0|value": {
+                    "id": 34,
+                    "output_name": "graph_out"
+                },
+                "style_cond|type_cond|pick_from_1|value": {
+                    "id": 28,
+                    "output_name": "graph_out"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Pick parameter value",
+            "outputs": [
+                {
+                    "name": "data_param",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 4102.413170404999,
+                "top": 1297.0586810772634
             },
             "post_job_actions": {
                 "HideDatasetActiondata_param": {
@@ -2711,18 +3004,67 @@
             "when": null,
             "workflow_outputs": []
         },
-        "33": {
+        "37": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
             "errors": null,
-            "id": 33,
+            "id": 37,
             "input_connections": {
                 "input": {
-                    "id": 21,
+                    "id": 22,
                     "output_name": "out_file1"
                 },
                 "pretext": {
-                    "id": 32,
+                    "id": 35,
+                    "output_name": "data_param"
+                }
+            },
+            "inputs": [],
+            "label": "Add gaps track - Multimapping",
+            "name": "Pretextgraph",
+            "outputs": [
+                {
+                    "name": "graph_out",
+                    "type": "pretext"
+                }
+            ],
+            "position": {
+                "left": 4288.5402108439575,
+                "top": 185.52777582009148
+            },
+            "post_job_actions": {
+                "HideDatasetActiongraph_out": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "graph_out"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "408ece2e4647",
+                "name": "pretext_graph",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"name\": \"gaps\", \"pretext\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.7+galaxy0",
+            "type": "tool",
+            "uuid": "d1ff78bd-39bb-49b6-956f-873f02e58e3d",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "38": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
+            "errors": null,
+            "id": 38,
+            "input_connections": {
+                "input": {
+                    "id": 22,
+                    "output_name": "out_file1"
+                },
+                "pretext": {
+                    "id": 36,
                     "output_name": "data_param"
                 }
             },
@@ -2736,8 +3078,8 @@
                 }
             ],
             "position": {
-                "left": 4017.4437557219244,
-                "top": 793.0850663744293
+                "left": 4274.294629892429,
+                "top": 921.7543802740746
             },
             "post_job_actions": {
                 "HideDatasetActiongraph_out": {
@@ -2760,23 +3102,23 @@
             "when": null,
             "workflow_outputs": []
         },
-        "34": {
+        "39": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
             "errors": null,
-            "id": 34,
+            "id": 39,
             "input_connections": {
                 "input": {
-                    "id": 29,
+                    "id": 31,
                     "output_name": "outfile"
                 },
                 "pretext": {
-                    "id": 33,
+                    "id": 37,
                     "output_name": "graph_out"
                 }
             },
             "inputs": [],
-            "label": "Add gaps track 2",
+            "label": "Add coverage gaps track - Multimapping",
             "name": "Pretextgraph",
             "outputs": [
                 {
@@ -2785,8 +3127,72 @@
                 }
             ],
             "position": {
-                "left": 4312.327243855107,
-                "top": 1057.925420993275
+                "left": 4480.067810292072,
+                "top": 459.3007418876366
+            },
+            "post_job_actions": {
+                "RenameDatasetActiongraph_out": {
+                    "action_arguments": {
+                        "newname": "Pretext All tracks - Multimapping"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "graph_out"
+                },
+                "TagDatasetActiongraph_out": {
+                    "action_arguments": {
+                        "tags": "pretext_all_tracks_multimapping"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "graph_out"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "408ece2e4647",
+                "name": "pretext_graph",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"name\": \"coverage_gaps\", \"pretext\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.7+galaxy0",
+            "type": "tool",
+            "uuid": "cc0f0fe6-c04c-4e43-b631-cf9afefc2637",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Pretext All tracks - Multimapping",
+                    "output_name": "graph_out",
+                    "uuid": "1afe620e-1908-481c-9665-cc72f3fbf5ec"
+                }
+            ]
+        },
+        "40": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
+            "errors": null,
+            "id": 40,
+            "input_connections": {
+                "input": {
+                    "id": 31,
+                    "output_name": "outfile"
+                },
+                "pretext": {
+                    "id": 38,
+                    "output_name": "graph_out"
+                }
+            },
+            "inputs": [],
+            "label": "Add coverage gaps track",
+            "name": "Pretextgraph",
+            "outputs": [
+                {
+                    "name": "graph_out",
+                    "type": "pretext"
+                }
+            ],
+            "position": {
+                "left": 4465.816184498399,
+                "top": 1226.245672538225
             },
             "post_job_actions": {
                 "RenameDatasetActiongraph_out": {
@@ -2824,14 +3230,14 @@
                 }
             ]
         },
-        "35": {
+        "41": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_snapshot/pretext_snapshot/0.0.4+galaxy0",
             "errors": null,
-            "id": 35,
+            "id": 41,
             "input_connections": {
                 "input": {
-                    "id": 34,
+                    "id": 39,
                     "output_name": "graph_out"
                 }
             },
@@ -2845,8 +3251,53 @@
                 }
             ],
             "position": {
-                "left": 4668.760553276812,
-                "top": 906.4862147981121
+                "left": 4707.733088040826,
+                "top": 271.4179807582111
+            },
+            "post_job_actions": {
+                "HideDatasetActionpretext_snap_out": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "pretext_snap_out"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_snapshot/pretext_snapshot/0.0.4+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "26f2fe7e53a1",
+                "name": "pretext_snapshot",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"colormap\": \"5\", \"formats\": {\"outformat\": \"png\", \"__current_case__\": 0}, \"grid\": {\"showGrid\": \"yes\", \"__current_case__\": 0, \"gridsize\": \"1\", \"gridcolor\": \"black\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"mintexels\": \"64\", \"resolution\": \"2000\", \"sequencenames\": false, \"sequences\": \"=full\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.4+galaxy0",
+            "type": "tool",
+            "uuid": "f453794e-4045-4602-9f49-26abf7f1426f",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "42": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_snapshot/pretext_snapshot/0.0.4+galaxy0",
+            "errors": null,
+            "id": 42,
+            "input_connections": {
+                "input": {
+                    "id": 40,
+                    "output_name": "graph_out"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Pretext Snapshot",
+            "outputs": [
+                {
+                    "name": "pretext_snap_out",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 4669.504394384322,
+                "top": 1021.5103952454199
             },
             "post_job_actions": {
                 "HideDatasetActionpretext_snap_out": {
@@ -2869,14 +3320,68 @@
             "when": null,
             "workflow_outputs": []
         },
-        "36": {
+        "43": {
             "annotation": "",
             "content_id": "__EXTRACT_DATASET__",
             "errors": null,
-            "id": 36,
+            "id": 43,
             "input_connections": {
                 "input": {
-                    "id": 35,
+                    "id": 41,
+                    "output_name": "pretext_snap_out"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Extract dataset",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "data"
+                }
+            ],
+            "position": {
+                "left": 4993.521430750214,
+                "top": 164.92362513081983
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "Pretext Snapshot With tracks - Multimapping"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                },
+                "TagDatasetActionoutput": {
+                    "action_arguments": {
+                        "tags": "pretext_img_multimapping"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__EXTRACT_DATASET__",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"which\": {\"which_dataset\": \"first\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.2",
+            "type": "tool",
+            "uuid": "7815d57b-da36-42a2-b25c-4cf3dbf89c69",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Pretext Snapshot With tracks - Multimapping",
+                    "output_name": "output",
+                    "uuid": "70a9b730-a184-47e3-ad69-de0034bf35ed"
+                }
+            ]
+        },
+        "44": {
+            "annotation": "",
+            "content_id": "__EXTRACT_DATASET__",
+            "errors": null,
+            "id": 44,
+            "input_connections": {
+                "input": {
+                    "id": 42,
                     "output_name": "pretext_snap_out"
                 }
             },
@@ -2891,7 +3396,7 @@
             ],
             "position": {
                 "left": 4955.29273709371,
-                "top": 799.6160396180287
+                "top": 915.0160396180287
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -2925,6 +3430,6 @@
         }
     },
     "tags": [],
-    "uuid": "c0f69aad-73a0-4a34-9535-6fe188f9250c",
-    "version": 3
+    "uuid": "34226708-cba3-421c-809f-6ba105b3812c",
+    "version": 4
 }

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.ga
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation.ga
@@ -4,27 +4,6 @@
     "comments": [
         {
             "child_steps": [
-                12,
-                18,
-                22
-            ],
-            "color": "green",
-            "data": {
-                "title": "Coverage"
-            },
-            "id": 5,
-            "position": [
-                2327.5,
-                1440.7
-            ],
-            "size": [
-                833.6,
-                266.8
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
                 10,
                 11,
                 13,
@@ -42,25 +21,6 @@
             "size": [
                 1283,
                 769
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                19
-            ],
-            "color": "red",
-            "data": {
-                "title": "Generate Hi-C map"
-            },
-            "id": 2,
-            "position": [
-                2345.1,
-                510.7
-            ],
-            "size": [
-                779.6,
-                512.7
             ],
             "type": "frame"
         },
@@ -85,46 +45,20 @@
         },
         {
             "child_steps": [
-                24,
-                27,
-                29,
-                25,
-                26,
-                28
+                19
             ],
-            "color": "orange",
+            "color": "red",
             "data": {
-                "title": "Add tracks to the Hi-C map"
+                "title": "Generate Hi-C map"
             },
-            "id": 6,
+            "id": 2,
             "position": [
-                3280.2418890772274,
-                675.3465102395286
+                2345.1,
+                510.7
             ],
             "size": [
-                1284,
-                722
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                17,
-                21,
-                23
-            ],
-            "color": "lime",
-            "data": {
-                "title": "Telomeres"
-            },
-            "id": 4,
-            "position": [
-                2358.4,
-                1090
-            ],
-            "size": [
-                761,
-                296
+                779.6,
+                512.7
             ],
             "type": "frame"
         },
@@ -147,6 +81,76 @@
                 212.5
             ],
             "type": "frame"
+        },
+        {
+            "child_steps": [
+                32,
+                33,
+                25,
+                27,
+                29,
+                30,
+                31
+            ],
+            "color": "orange",
+            "data": {
+                "title": "Add tracks to the Hi-C map"
+            },
+            "id": 6,
+            "position": [
+                3280.2418890772274,
+                675.3465102395286
+            ],
+            "size": [
+                1284,
+                722
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                12,
+                18,
+                22,
+                23,
+                26,
+                28
+            ],
+            "color": "green",
+            "data": {
+                "title": "Coverage"
+            },
+            "id": 5,
+            "position": [
+                2327.5,
+                1440.7
+            ],
+            "size": [
+                1404,
+                466
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                17,
+                21,
+                24
+            ],
+            "color": "lime",
+            "data": {
+                "title": "Telomeres"
+            },
+            "id": 4,
+            "position": [
+                2358.4,
+                1090
+            ],
+            "size": [
+                761,
+                296
+            ],
+            "type": "frame"
         }
     ],
     "creator": [
@@ -163,6 +167,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
+    "release": "1.0beta6",
     "name": "PretextMap Generation from 1 or 2 haplotypes",
     "report": {
         "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
@@ -1401,6 +1406,13 @@
                     },
                     "action_type": "RenameDatasetAction",
                     "output_name": "data_param"
+                },
+                "TagDatasetActiondata_param": {
+                    "action_arguments": {
+                        "tags": "merged_haps"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "data_param"
                 }
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
@@ -1553,7 +1565,13 @@
                         "type": "parameter_input",
                         "uuid": "6d1391db-7fef-4b5c-a236-26016d6d0aab",
                         "when": null,
-                        "workflow_outputs": []
+                        "workflow_outputs": [
+                            {
+                                "label": null,
+                                "output_name": "output",
+                                "uuid": "6d9fa96c-c50e-4a0d-9fda-084a3a73f09a"
+                            }
+                        ]
                     },
                     "3": {
                         "annotation": "",
@@ -2176,8 +2194,8 @@
                 }
             ],
             "position": {
-                "left": 2884.6953419799906,
-                "top": 1513.3107499437622
+                "left": 2885.1534846304676,
+                "top": 1514.2252407486453
             },
             "post_job_actions": {
                 "RenameDatasetActionoutFileName": {
@@ -2217,9 +2235,54 @@
         },
         "23": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.31.1",
             "errors": null,
             "id": 23,
+            "input_connections": {
+                "input_type|input": {
+                    "id": 18,
+                    "output_name": "alignment_output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "bedtools Genome Coverage",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "bedgraph"
+                }
+            ],
+            "position": {
+                "left": 2906.9391779139696,
+                "top": 1734.9133309458432
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bedtools/bedtools_genomecoveragebed/2.31.1",
+            "tool_shed_repository": {
+                "changeset_revision": "2892111d91f8",
+                "name": "bedtools",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"d\": false, \"dz\": false, \"five\": false, \"input_type\": {\"input_type_select\": \"bam\", \"__current_case__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}}, \"report\": {\"report_select\": \"bg\", \"__current_case__\": 0, \"zero_regions\": true, \"scale\": \"1.0\"}, \"split\": false, \"strand\": \"\", \"three\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.31.1",
+            "type": "tool",
+            "uuid": "a7f9f86e-62d7-4b00-a213-7cae0c79289a",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "24": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/column_maker/Add_a_column1/2.1",
+            "errors": null,
+            "id": 24,
             "input_connections": {
                 "input": {
                     "id": 21,
@@ -2282,11 +2345,11 @@
                 }
             ]
         },
-        "24": {
+        "25": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
             "errors": null,
-            "id": 24,
+            "id": 25,
             "input_connections": {
                 "input": {
                     "id": 22,
@@ -2307,8 +2370,8 @@
                 }
             ],
             "position": {
-                "left": 3388.9484898712426,
-                "top": 1090.7908974801026
+                "left": 3306.7639798679484,
+                "top": 1132.5738565753659
             },
             "post_job_actions": {
                 "HideDatasetActiongraph_out": {
@@ -2331,14 +2394,53 @@
             "when": null,
             "workflow_outputs": []
         },
-        "25": {
+        "26": {
+            "annotation": "",
+            "content_id": "Filter1",
+            "errors": null,
+            "id": 26,
+            "input_connections": {
+                "input": {
+                    "id": 23,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Filter",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3198.2881192327804,
+                "top": 1721.1968191007911
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "Filter1",
+            "tool_state": "{\"cond\": \"c4==0\", \"header_lines\": \"0\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.1",
+            "type": "tool",
+            "uuid": "40859e7e-a0df-4b34-860f-8903e046afbd",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "27": {
             "annotation": "",
             "content_id": "param_value_from_file",
             "errors": null,
-            "id": 25,
+            "id": 27,
             "input_connections": {
                 "input1": {
-                    "id": 23,
+                    "id": 24,
                     "output_name": "out_file1"
                 }
             },
@@ -2352,10 +2454,16 @@
                 }
             ],
             "position": {
-                "left": 3351.621091524617,
-                "top": 812.738234663262
+                "left": 3292.4213617861824,
+                "top": 882.3815353604188
             },
-            "post_job_actions": {},
+            "post_job_actions": {
+                "HideDatasetActiontext_param": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "text_param"
+                }
+            },
             "tool_id": "param_value_from_file",
             "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"text\", \"remove_newlines\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.1.0",
@@ -2364,14 +2472,81 @@
             "when": null,
             "workflow_outputs": []
         },
-        "26": {
+        "28": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_column/9.5+galaxy0",
+            "errors": null,
+            "id": 28,
+            "input_connections": {
+                "infile": {
+                    "id": 26,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Replace Text",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3474.5953629815754,
+                "top": 1664.7241919135736
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionoutfile": {
+                    "action_arguments": {
+                        "newtype": "bedgraph"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "outfile"
+                },
+                "RenameDatasetActionoutfile": {
+                    "action_arguments": {
+                        "newname": "Coverage Gaps Track"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "outfile"
+                },
+                "TagDatasetActionoutfile": {
+                    "action_arguments": {
+                        "tags": "coverage_gaps"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_column/9.5+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "6073bb457ec0",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"infile\": {\"__class__\": \"ConnectedValue\"}, \"replacements\": [{\"__index__\": 0, \"column\": \"4\", \"find_pattern\": \"0\", \"replace_pattern\": \"200\"}], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "9.5+galaxy0",
+            "type": "tool",
+            "uuid": "2ab27d7d-7c5b-4c87-939a-41c1a1e6abbf",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Coverage Gaps Track",
+                    "output_name": "outfile",
+                    "uuid": "5fe09aeb-0c9e-4749-8651-d44f7e70630b"
+                }
+            ]
+        },
+        "29": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
             "errors": null,
-            "id": 26,
+            "id": 29,
             "input_connections": {
                 "input_param_type|input_param": {
-                    "id": 25,
+                    "id": 27,
                     "output_name": "text_param"
                 }
             },
@@ -2385,10 +2560,16 @@
                 }
             ],
             "position": {
-                "left": 3603.5625,
-                "top": 708.92578125
+                "left": 3509.54306962867,
+                "top": 721.4609757332718
             },
-            "post_job_actions": {},
+            "post_job_actions": {
+                "HideDatasetActionoutput_param_boolean": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_param_boolean"
+                }
+            },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
             "tool_shed_repository": {
                 "changeset_revision": "5ac8a4bf7a8d",
@@ -2403,22 +2584,22 @@
             "when": null,
             "workflow_outputs": []
         },
-        "27": {
+        "30": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
             "errors": null,
-            "id": 27,
+            "id": 30,
             "input_connections": {
                 "input": {
-                    "id": 23,
+                    "id": 24,
                     "output_name": "out_file1"
                 },
                 "pretext": {
-                    "id": 24,
+                    "id": 25,
                     "output_name": "graph_out"
                 },
                 "when": {
-                    "id": 26,
+                    "id": 29,
                     "output_name": "output_param_boolean"
                 }
             },
@@ -2432,8 +2613,8 @@
                 }
             ],
             "position": {
-                "left": 3834.941818419956,
-                "top": 885.1642650891603
+                "left": 3637.1485454767576,
+                "top": 875.4121893744119
             },
             "post_job_actions": {
                 "HideDatasetActiongraph_out": {
@@ -2456,18 +2637,18 @@
             "when": "$(inputs.when)",
             "workflow_outputs": []
         },
-        "28": {
+        "31": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
             "errors": null,
-            "id": 28,
+            "id": 31,
             "input_connections": {
                 "style_cond|type_cond|pick_from_0|value": {
-                    "id": 27,
+                    "id": 30,
                     "output_name": "graph_out"
                 },
                 "style_cond|type_cond|pick_from_1|value": {
-                    "id": 24,
+                    "id": 25,
                     "output_name": "graph_out"
                 }
             },
@@ -2481,10 +2662,16 @@
                 }
             ],
             "position": {
-                "left": 4043.910071373994,
-                "top": 1122.4406478960802
+                "left": 3844.028000653102,
+                "top": 1169.0989361540105
             },
-            "post_job_actions": {},
+            "post_job_actions": {
+                "HideDatasetActiondata_param": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "data_param"
+                }
+            },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
             "tool_shed_repository": {
                 "changeset_revision": "b19e21af9c52",
@@ -2499,18 +2686,18 @@
             "when": null,
             "workflow_outputs": []
         },
-        "29": {
+        "32": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
             "errors": null,
-            "id": 29,
+            "id": 32,
             "input_connections": {
                 "input": {
                     "id": 20,
                     "output_name": "out_file1"
                 },
                 "pretext": {
-                    "id": 28,
+                    "id": 31,
                     "output_name": "data_param"
                 }
             },
@@ -2524,8 +2711,57 @@
                 }
             ],
             "position": {
-                "left": 4277.91619203177,
-                "top": 724.1405868265828
+                "left": 4017.4437557219244,
+                "top": 793.0850663744293
+            },
+            "post_job_actions": {
+                "HideDatasetActiongraph_out": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "graph_out"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "408ece2e4647",
+                "name": "pretext_graph",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"name\": \"gaps\", \"pretext\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.7+galaxy0",
+            "type": "tool",
+            "uuid": "cdf721aa-3c39-4d9d-8bd6-704f391a0cca",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "33": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_graph/pretext_graph/0.0.7+galaxy0",
+            "errors": null,
+            "id": 33,
+            "input_connections": {
+                "input": {
+                    "id": 28,
+                    "output_name": "outfile"
+                },
+                "pretext": {
+                    "id": 32,
+                    "output_name": "graph_out"
+                }
+            },
+            "inputs": [],
+            "label": "Add gaps track 2",
+            "name": "Pretextgraph",
+            "outputs": [
+                {
+                    "name": "graph_out",
+                    "type": "pretext"
+                }
+            ],
+            "position": {
+                "left": 4312.327243855107,
+                "top": 1057.925420993275
             },
             "post_job_actions": {
                 "RenameDatasetActiongraph_out": {
@@ -2550,10 +2786,10 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"name\": \"gaps\", \"pretext\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"name\": \"coverage_gaps\", \"pretext\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.0.7+galaxy0",
             "type": "tool",
-            "uuid": "cdf721aa-3c39-4d9d-8bd6-704f391a0cca",
+            "uuid": "a942c184-269c-47f5-8bb3-3643d26c1783",
             "when": null,
             "workflow_outputs": [
                 {
@@ -2563,14 +2799,14 @@
                 }
             ]
         },
-        "30": {
+        "34": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_snapshot/pretext_snapshot/0.0.4+galaxy0",
             "errors": null,
-            "id": 30,
+            "id": 34,
             "input_connections": {
                 "input": {
-                    "id": 29,
+                    "id": 33,
                     "output_name": "graph_out"
                 }
             },
@@ -2608,14 +2844,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "31": {
+        "35": {
             "annotation": "",
             "content_id": "__EXTRACT_DATASET__",
             "errors": null,
-            "id": 31,
+            "id": 35,
             "input_connections": {
                 "input": {
-                    "id": 30,
+                    "id": 34,
                     "output_name": "pretext_snap_out"
                 }
             },
@@ -2664,7 +2900,6 @@
         }
     },
     "tags": [],
-    "uuid": "bd880e6e-0086-4355-98b5-4b0451ddbb3c",
-    "version": 1,
-    "release": "1.0beta5"
+    "uuid": "ed69401d-d823-4efc-a42b-b145bd8c7900",
+    "version": 2
 }


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
