### PR TITLE
Updating workflows/genome-assembly/quality-and-contamination-control from 1.1.8 to 1.1.9

### DIFF
--- a/workflows/genome-assembly/quality-and-contamination-control/CHANGELOG.md
+++ b/workflows/genome-assembly/quality-and-contamination-control/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.9] - 2025-06-16
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.1+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.26.0+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.3+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.3+galaxy0`
+
 ## [1.1.8] - 2025-05-05
 
 ### Automatic update

--- a/workflows/genome-assembly/quality-and-contamination-control/CHANGELOG.md
+++ b/workflows/genome-assembly/quality-and-contamination-control/CHANGELOG.md
@@ -7,6 +7,9 @@
 - `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.3+galaxy0`
 - `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.3+galaxy0`
 
+### Manual update
+- Changes datatype output (fastqsanger.gz) in Zip collection
+
 ## [1.1.8] - 2025-05-05
 
 ### Automatic update

--- a/workflows/genome-assembly/quality-and-contamination-control/README.md
+++ b/workflows/genome-assembly/quality-and-contamination-control/README.md
@@ -1,4 +1,4 @@
-# Quality and Contamination control workflow for paired end data (v1.1.7)
+# Quality and Contamination control workflow for paired end data
 
 This workflow uses paired-end illumina fastq(.gz) files and executes the following steps:
 1. Quality control and trimming

--- a/workflows/genome-assembly/quality-and-contamination-control/quality_and_contamination_control.ga
+++ b/workflows/genome-assembly/quality-and-contamination-control/quality_and_contamination_control.ga
@@ -191,7 +191,7 @@
         },
         "5": {
             "annotation": "fastp_triming, quality analaysis and read cleaning",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.1+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.26.0+galaxy0",
             "errors": null,
             "id": 5,
             "input_connections": {
@@ -312,15 +312,15 @@
                     "output_name": "report_json"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.1+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.26.0+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "25c59c0ceb55",
+                "changeset_revision": "3432a0e49b86",
                 "name": "fastp",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": null, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": null, \"umi_len\": null, \"umi_prefix\": null}, \"cutting_by_quality_options\": {\"cut_by_quality5\": false, \"cut_by_quality3\": false, \"cut_window_size\": null, \"cut_mean_quality\": null}, \"base_correction_options\": {\"correction\": false}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 1, \"paired_input\": {\"__class__\": \"ConnectedValue\"}, \"merge_reads\": {\"merge\": \"\", \"__current_case__\": 1}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": null, \"adapter_sequence2\": null, \"detect_adapter_for_pe\": false}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.24.1+galaxy0",
+            "tool_version": "0.26.0+galaxy0",
             "type": "tool",
             "uuid": "7f405009-2491-4633-b4e1-ca0fdbd8360d",
             "when": null,
@@ -510,7 +510,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/kraken2/kraken2/2.1.3+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "cdee7158adf3",
+                "changeset_revision": "241a78eb2935",
                 "name": "kraken2",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -760,7 +760,7 @@
         },
         "10": {
             "annotation": "ToolDistillator extracts results from tools and creates a JSON file for each tool",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.3+galaxy0",
             "errors": null,
             "id": 10,
             "input_connections": {
@@ -850,15 +850,15 @@
                     "output_name": "output_json"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.3+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "66617be450bd",
+                "changeset_revision": "dfd6fa2637ba",
                 "name": "tooldistillator",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"log\": false, \"tool_section\": {\"tools\": [{\"__index__\": 0, \"select_tool\": {\"tool_list\": \"fastp\", \"__current_case__\": 7, \"input\": {\"__class__\": \"ConnectedValue\"}, \"trimmed_forward_R1_path\": {\"__class__\": \"ConnectedValue\"}, \"trimmed_reverse_R2_path\": {\"__class__\": \"ConnectedValue\"}, \"html_report_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": null}}, {\"__index__\": 1, \"select_tool\": {\"tool_list\": \"kraken2\", \"__current_case__\": 13, \"input\": {\"__class__\": \"ConnectedValue\"}, \"seq_classification_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"select_tool\": {\"tool_list\": \"bracken\", \"__current_case__\": 4, \"input\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}, \"kraken_report_path\": {\"__class__\": \"ConnectedValue\"}, \"threshold\": null, \"read_len\": \"100\", \"level\": \"S\"}}, {\"__index__\": 3, \"select_tool\": {\"tool_list\": \"recentrifuge\", \"__current_case__\": 18, \"input\": {\"__class__\": \"ConnectedValue\"}, \"rcf_stat_path\": {\"__class__\": \"ConnectedValue\"}, \"rcf_html_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}]}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.9.2+galaxy0",
+            "tool_state": "{\"log\": false, \"tool_section\": {\"tools\": [{\"__index__\": 0, \"select_tool\": {\"tool_list\": \"fastp\", \"__current_case__\": 8, \"input\": {\"__class__\": \"ConnectedValue\"}, \"trimmed_forward_R1_path\": {\"__class__\": \"ConnectedValue\"}, \"trimmed_reverse_R2_path\": {\"__class__\": \"ConnectedValue\"}, \"html_report_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": null}}, {\"__index__\": 1, \"select_tool\": {\"tool_list\": \"kraken2\", \"__current_case__\": 14, \"input\": {\"__class__\": \"ConnectedValue\"}, \"seq_classification_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"select_tool\": {\"tool_list\": \"bracken\", \"__current_case__\": 4, \"input\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}, \"kraken_report_path\": {\"__class__\": \"ConnectedValue\"}, \"threshold\": null, \"read_len\": \"100\", \"level\": \"S\"}}, {\"__index__\": 3, \"select_tool\": {\"tool_list\": \"recentrifuge\", \"__current_case__\": 19, \"input\": {\"__class__\": \"ConnectedValue\"}, \"rcf_stat_path\": {\"__class__\": \"ConnectedValue\"}, \"rcf_html_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}]}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.9.3+galaxy0",
             "type": "tool",
             "uuid": "b88b0ffe-f660-43ea-b00a-40ca0087f83f",
             "when": null,
@@ -872,7 +872,7 @@
         },
         "11": {
             "annotation": "ToolDistillator summarize groups all JSON file into a unique JSON file",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.3+galaxy0",
             "errors": null,
             "id": 11,
             "input_connections": {
@@ -910,15 +910,15 @@
                     "output_name": "summary_json"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.3+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "07d093aaf3b4",
+                "changeset_revision": "30a8447539e4",
                 "name": "tooldistillator_summarize",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"summarize_data\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.9.2+galaxy0",
+            "tool_version": "0.9.3+galaxy0",
             "type": "tool",
             "uuid": "fbc8d552-c0b1-426c-b26f-8bfe8371b05e",
             "when": null,
@@ -941,7 +941,7 @@
         "ABRomics",
         "trimming"
     ],
-    "uuid": "1ec260c1-9d52-4c42-819d-54602de4e9c6",
+    "uuid": "132b2ecf-2895-423c-be52-953cfbbcdc2b",
     "version": 1,
-    "release": "1.1.8"
+    "release": "1.1.9"
 }

--- a/workflows/genome-assembly/quality-and-contamination-control/quality_and_contamination_control.ga
+++ b/workflows/genome-assembly/quality-and-contamination-control/quality_and_contamination_control.ga
@@ -167,6 +167,13 @@
                 "top": 55.78334045410156
             },
             "post_job_actions": {
+                "ChangeDatatypeActionoutput": {
+                    "action_arguments": {
+                        "newtype": "fastqsanger.gz"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "output"
+                },
                 "RenameDatasetActionoutput": {
                     "action_arguments": {
                         "newname": "paired_coll"


### PR DESCRIPTION
Hello, 

This code (close #894  ):
- Changes tools version: 
  - `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.24.1+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/0.26.0+galaxy0`
  - `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.2+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/0.9.3+galaxy0`
  - `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.2+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/0.9.3+galaxy0`
- Changes datatype output (`fastqsanger.gz`) in Zip collection: Fastp no longer accepts `fastq.gz` as input file


This workflow uses databases available on http://datacache.galaxyproject.org/.

Thanks :smiley: 