### PR TITLE
Fix helixer version and changelog

### DIFF
--- a/workflows/genome_annotation/annotation-helixer/CHANGELOG.md
+++ b/workflows/genome_annotation/annotation-helixer/CHANGELOG.md
@@ -1,9 +1,18 @@
 # Changelog
 
+## [0.3] - 2025-07-18
+
+### Changed
+
+- `toolshed.g2.bx.psu.edu/repos/iuc/omark/omark/0.3.0+galaxy2` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/omark/omark/0.3.1+galaxy1`
+- `toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/5.8.0+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/5.8.0+galaxy1`
+- Readme has been updated with a better description of the workflow
+- Tests use assertions about output data instead of size comparisons
+
 ## [0.2] - 2025-01-27
 
 ### Automatic update
-- update OMArk and BUSCO version
+- `toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/5.7.1+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/5.8.0+galaxy0`
 
 ## [0.1]
 

--- a/workflows/genome_annotation/annotation-helixer/Galaxy-Workflow-annotation_helixer.ga
+++ b/workflows/genome_annotation/annotation-helixer/Galaxy-Workflow-annotation_helixer.ga
@@ -111,7 +111,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.2",
+    "release": "0.3",
     "name": "Genome annotation with Helixer",
     "report": {
         "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
