### PR TITLE
VGP 0 - expose genetic code parameter for mitohifi

### DIFF
--- a/workflows/VGP-assembly-v2/Mitogenome-assembly-VGP0/Mitogenome-Assembly-VGP0-tests.yml
+++ b/workflows/VGP-assembly-v2/Mitogenome-assembly-VGP0/Mitogenome-Assembly-VGP0-tests.yml
@@ -10,6 +10,7 @@
     Species name (latin name): Theretra latreillii lucasii
     Assembly Name: MW539688
     Email adress: iwc@galaxyproject.org
+    Genetic Code: 2
   outputs:
     "Mitogenome: Contigs Statistics":
       asserts:

--- a/workflows/VGP-assembly-v2/Mitogenome-assembly-VGP0/Mitogenome-Assembly-VGP0.ga
+++ b/workflows/VGP-assembly-v2/Mitogenome-assembly-VGP0/Mitogenome-Assembly-VGP0.ga
@@ -15,7 +15,7 @@
     ],
     "format-version": "0.1",
     "license": "CC-BY-4.0",
-    "release": "0.2.1",
+    "release": "0.2.2",
     "name": "Mitogenome Assembly VGP0",
     "report": {
         "markdown": "Species : \n\n```galaxy\nhistory_dataset_embedded(output=\"Species Name for report\")\n```\n\nAssembly:\n\n\n```galaxy\nhistory_dataset_embedded(output=\"Assembly Name for report\")\n```\n\n\n## Annotation\n\n```galaxy\nhistory_dataset_as_image(output=\"Mitogenome annotation: Image\")\n```\n\n## Coverage\n\n\n\r\n```galaxy\nhistory_dataset_as_image(output=\"Mitogenome coverage: Image\")\n```\r\n\n\n## Contigs Stats\n\n\n```galaxy\nhistory_dataset_as_table(output=\"Mitogenome: Contigs Statistics\")\n```\n"
@@ -50,7 +50,7 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "980ea1e7-4758-4a8b-882e-aeb74ebaf2e5"
+                    "uuid": "c8b90efa-84ec-4c72-bda6-fc7e4731c48c"
                 }
             ]
         },
@@ -83,7 +83,7 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "b13c2151-7a40-4c82-b1b3-e60df89280ed"
+                    "uuid": "d5ca0944-9913-4a3b-af9e-6f17101fccc5"
                 }
             ]
         },
@@ -107,7 +107,7 @@
                 "top": 369.7578125
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"tag\": \"\", \"collection_type\": \"list\"}",
+            "tool_state": "{\"optional\": false, \"tag\": \"\", \"collection_type\": \"list\", \"fields\": null}",
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "861c3a49-1055-4030-9a91-e53cbf1ac436",
@@ -143,15 +143,48 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "b2d44167-0f1a-47ef-a05a-993bfc89cf33"
+                    "uuid": "6bbe8abb-f6d5-49b3-bf3a-c040baa26e01"
                 }
             ]
         },
         "4": {
+            "annotation": "Organism genetic code following NCBI table (for mitogenome annotation)",
+            "content_id": null,
+            "errors": null,
+            "id": 4,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Organism genetic code following NCBI table (for mitogenome annotation)",
+                    "name": "Genetic Code"
+                }
+            ],
+            "label": "Genetic Code",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 260,
+                "top": 650
+            },
+            "tool_id": null,
+            "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "b1b0ae79-6101-4161-877d-59f852e2937c",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "287bb080-5a98-43f9-91bf-a7d7db09f105"
+                }
+            ]
+        },
+        "5": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
             "errors": null,
-            "id": 4,
+            "id": 5,
             "input_connections": {
                 "components_0|param_type|component_value": {
                     "id": 0,
@@ -198,11 +231,11 @@
                 }
             ]
         },
-        "5": {
+        "6": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
             "errors": null,
-            "id": 5,
+            "id": 6,
             "input_connections": {
                 "components_0|param_type|component_value": {
                     "id": 1,
@@ -249,11 +282,11 @@
                 }
             ]
         },
-        "6": {
+        "7": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/mitohifi/mitohifi/3.2.3+galaxy0",
             "errors": null,
-            "id": 6,
+            "id": 7,
             "input_connections": {
                 "operation_mode|email": {
                     "id": 3,
@@ -296,22 +329,26 @@
             "when": null,
             "workflow_outputs": []
         },
-        "7": {
+        "8": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/mitohifi/mitohifi/3.2.3+galaxy0",
             "errors": null,
-            "id": 7,
+            "id": 8,
             "input_connections": {
+                "operation_mode|genetic_code": {
+                    "id": 4,
+                    "output_name": "output"
+                },
                 "operation_mode|input_option|input_reads": {
                     "id": 2,
                     "output_name": "output"
                 },
                 "operation_mode|reference_fasta": {
-                    "id": 6,
+                    "id": 7,
                     "output_name": "fasta_reference"
                 },
                 "operation_mode|reference_genbank": {
-                    "id": 6,
+                    "id": 7,
                     "output_name": "genbank_reference"
                 }
             },
@@ -441,17 +478,12 @@
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"operation_mode\": {\"command\": \"mitohifi\", \"__current_case__\": 1, \"input_option\": {\"input\": \"pacbio\", \"__current_case__\": 0, \"input_reads\": {\"__class__\": \"ConnectedValue\"}, \"bloom_filter\": \"0\"}, \"reference_fasta\": {\"__class__\": \"ConnectedValue\"}, \"reference_genbank\": {\"__class__\": \"ConnectedValue\"}, \"organism_selection\": \"animal\", \"genetic_code\": \"2\", \"advanced_options\": {\"query_blast\": \"70\", \"circular_size\": null, \"circular_offset\": null, \"outputs\": null}, \"output_zip\": false}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"operation_mode\": {\"command\": \"mitohifi\", \"__current_case__\": 1, \"input_option\": {\"input\": \"pacbio\", \"__current_case__\": 0, \"input_reads\": {\"__class__\": \"RuntimeValue\"}, \"bloom_filter\": \"0\"}, \"reference_fasta\": {\"__class__\": \"RuntimeValue\"}, \"reference_genbank\": {\"__class__\": \"RuntimeValue\"}, \"organism_selection\": \"animal\", \"genetic_code\": {\"__class__\": \"ConnectedValue\"}, \"advanced_options\": {\"query_blast\": \"70\", \"circular_size\": null, \"circular_offset\": null, \"outputs\": null}, \"output_zip\": false}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_version": "3.2.3+galaxy0",
             "type": "tool",
             "uuid": "ccd83410-608a-4b9d-a43a-11cecd6c2d42",
             "when": null,
             "workflow_outputs": [
-                {
-                    "label": "Mitogenome: Contigs Statistics",
-                    "output_name": "contigs_stats",
-                    "uuid": "d657a420-fa6c-422e-b46b-de8494a43a2f"
-                },
                 {
                     "label": "Mitogenome coverage: Image",
                     "output_name": "mitogenome_coverage",
@@ -466,17 +498,22 @@
                     "label": "Mitogenome annotation: GenBank",
                     "output_name": "mitogenome_genbank",
                     "uuid": "95a81d01-e0d4-4200-b0ca-d8906796bf15"
+                },
+                {
+                    "label": "Mitogenome: Contigs Statistics",
+                    "output_name": "contigs_stats",
+                    "uuid": "d657a420-fa6c-422e-b46b-de8494a43a2f"
                 }
             ]
         },
-        "8": {
+        "9": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compress_file/compress_file/0.1.0",
             "errors": null,
-            "id": 8,
+            "id": 9,
             "input_connections": {
                 "input": {
-                    "id": 7,
+                    "id": 8,
                     "output_name": "mitogenome_fasta"
                 }
             },
@@ -534,6 +571,6 @@
         "Reviewed",
         "VGP"
     ],
-    "uuid": "7e7034fd-c173-48fd-81cb-738863a2ebf4",
-    "version": 0
+    "uuid": "7de562f8-2ef4-4277-a88b-c0d12f22f0b6",
+    "version": 1
 }

--- a/workflows/VGP-assembly-v2/Mitogenome-assembly-VGP0/README.md
+++ b/workflows/VGP-assembly-v2/Mitogenome-assembly-VGP0/README.md
@@ -9,6 +9,7 @@ Generate mitochondrial assembly based on PacBio HiFi reads. Part of the VGP suit
 2. Name of the Assembly
 3. Hifi long reads [fastq]
 4. Email adress required for NCBI database query 
+5. Organism genetic code following NCBI table (for mitogenome annotation)
 
 ## Outputs
 


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
