### PR TITLE
VGP 4 - Urgent -  Fix bug caused by extract dataset 

### DIFF
--- a/workflows/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/Assembly-Hifi-HiC-phasing-VGP4.ga
+++ b/workflows/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/Assembly-Hifi-HiC-phasing-VGP4.ga
@@ -20,7 +20,7 @@
     ],
     "format-version": "0.1",
     "license": "CC-BY-4.0",
-    "release": "0.3.10",
+    "release": "0.3.11",
     "name": "Genome Assembly from Hifi reads with HiC phasing - VGP4",
     "report": {
         "markdown": "\nSpecies\n\n```galaxy\nhistory_dataset_embedded(output=\"Species Name for workflow report\")\n```\n\nAssembly\n\n```galaxy\nhistory_dataset_embedded(output=\"Assembly Name for workflow report\")\n```\n\n\n## Raw unitig graph\n\n```galaxy\nhistory_dataset_as_image(output=\"raw unitig graph image\")\n```\n\n## Merqury results\n\n### Merqury QV\n\n```galaxy\nhistory_dataset_as_table(output=\"merqury_qv\")\n```\n\n### Merqury completeness\n\n```galaxy\nhistory_dataset_as_table(output=\"merqury_stats\")\n```\n\n### Merqury plots\n\n\nspectra-cn:\n\n\n```galaxy\nhistory_dataset_as_image(output=\"output_merqury.spectra-cn.fl\")\n```\n\nspectra-asm:\n\n```galaxy\nhistory_dataset_as_image(output=\"output_merqury.spectra-asm.fl\")\n```\n\nhap1 spectra-cn:\n\n```galaxy\nhistory_dataset_as_image(output=\"output_merqury.assembly_01.spectra-cn.fl\")\n```\n\nhap2 spectra-cn:\n\n```galaxy\nhistory_dataset_as_image(output=\"output_merqury.assembly_02.spectra-cn.fl\")\n```\n\n## BUSCO results \n\nDatabase: \n```galaxy\nhistory_dataset_embedded(output=\"Lineage for workflow report\")\n```\n\n\nHap1\n\n```galaxy\nhistory_dataset_as_image(output=\"Busco Summary Image Hap1\")\n```\n\nHap2\n\n```galaxy\nhistory_dataset_as_image(output=\"Busco Summary Image Hap2\")\n```\n\n## Assembly statistics\n\n\n```galaxy\nhistory_dataset_as_table(output=\"clean_stats\")\n```\n\n\n## Nx and Size plots\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Nx Plot\")\n```\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Size Plot\")\n```\n\n\n\n## Current Workflow\n```galaxy\nworkflow_display()\n```\n"
@@ -1591,8 +1591,8 @@
                 }
             ],
             "position": {
-                "left": 1344.9593127646228,
-                "top": 1100.2737544514036
+                "left": 1345.6210876999032,
+                "top": 1092.364205415441
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1775,11 +1775,11 @@
             "id": 35,
             "input_connections": {
                 "style_cond|type_cond|pick_from_0|value": {
-                    "id": 29,
+                    "id": 31,
                     "output_name": "output"
                 },
                 "style_cond|type_cond|pick_from_1|value": {
-                    "id": 31,
+                    "id": 29,
                     "output_name": "output"
                 }
             },
@@ -1793,8 +1793,8 @@
                 }
             ],
             "position": {
-                "left": 1710.6715941860023,
-                "top": 817.7613309186661
+                "left": 1710.656264058676,
+                "top": 817.4469341952147
             },
             "post_job_actions": {
                 "RenameDatasetActiondata_param": {
@@ -1832,11 +1832,11 @@
             "id": 36,
             "input_connections": {
                 "style_cond|type_cond|pick_from_0|value": {
-                    "id": 30,
+                    "id": 32,
                     "output_name": "output"
                 },
                 "style_cond|type_cond|pick_from_1|value": {
-                    "id": 32,
+                    "id": 30,
                     "output_name": "output"
                 }
             },
@@ -4471,16 +4471,6 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Compleasm on Contigs hap2 Translated Proteins",
-                    "output_name": "translated_protein",
-                    "uuid": "484f8887-14a2-4eae-8b41-0bf52491cf5d"
-                },
-                {
-                    "label": "Compleasm hap2 Full Table Busco",
-                    "output_name": "full_table_busco",
-                    "uuid": "0eff5217-577f-483d-8d4a-ca3d04a98f8d"
-                },
-                {
                     "label": "Compleasm on Contigs hap2 Miniprot",
                     "output_name": "miniprot",
                     "uuid": "5bae72bd-9ba3-429a-9352-ffed843c85ab"
@@ -4489,6 +4479,16 @@
                     "label": "Compleasm on Contigs hap2 Full Table",
                     "output_name": "full_table",
                     "uuid": "1d6fbe87-d899-4a8a-91c0-75d0d758ac2b"
+                },
+                {
+                    "label": "Compleasm on Contigs hap2 Translated Proteins",
+                    "output_name": "translated_protein",
+                    "uuid": "484f8887-14a2-4eae-8b41-0bf52491cf5d"
+                },
+                {
+                    "label": "Compleasm hap2 Full Table Busco",
+                    "output_name": "full_table_busco",
+                    "uuid": "0eff5217-577f-483d-8d4a-ca3d04a98f8d"
                 }
             ]
         },
@@ -4862,11 +4862,6 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Compleasm on Contigs hap1 Full Table",
-                    "output_name": "full_table",
-                    "uuid": "65eb263e-d723-4992-8899-d032f07463b6"
-                },
-                {
                     "label": "Compleasm on Contigs hap1 Full Table Busco",
                     "output_name": "full_table_busco",
                     "uuid": "4503b22b-d2fe-4315-8086-732692a8ebe8"
@@ -4875,6 +4870,11 @@
                     "label": "Compleasm on Contigs hap1 Translated Proteins",
                     "output_name": "translated_protein",
                     "uuid": "f44cfaed-7a06-4a50-abb1-9ef469372b92"
+                },
+                {
+                    "label": "Compleasm on Contigs hap1 Full Table",
+                    "output_name": "full_table",
+                    "uuid": "65eb263e-d723-4992-8899-d032f07463b6"
                 },
                 {
                     "label": "Compleasm on Contigs hap1 Miniprot",
@@ -5314,6 +5314,6 @@
         "VGP",
         "Reviewed"
     ],
-    "uuid": "ff93d5d5-8078-4feb-8800-52f1c518ee03",
-    "version": 2
+    "uuid": "7b43721b-b4ab-4644-b85e-303194109e8c",
+    "version": 1
 }

--- a/workflows/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/CHANGELOG.md
+++ b/workflows/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
 
-## [0.3.10] - 2025-08-22
+## [0.3.11] - 2025-08-28
+
+### Changes
+- Fix bug appearing in version 0.3.10 where only the first hi-C pair of reads was used for phasing.
+
+
+## [0.3.10] - 2025-08-22 (Broken, do not use)
 
 ### Changes
 - Improve management of collections with single elements


### PR DESCRIPTION
Fix the issue caused by https://github.com/galaxyproject/galaxy/issues/20804 by just connecting the "extract dataset" outputs to the second position instead of the first when using "pick first values". Otherwise, in 0.3.10, the first dataset was extracted and used for scaffolding independently of the size of the Hi-C data collection.


FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
