### PR TITLE
VGP8 - Release 3.0 with duplicates removal 

### DIFF
--- a/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/CHANGELOG.md
+++ b/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+
+## [3.0] - 2025-09-24
+
+### Changes
+- Now remove duplicated Hi-C reads
+- Duplication statistics
+- Improved report
+
+
 ## [2.2] - 2025-09-01
 
 ### Automatic update

--- a/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml
+++ b/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml
@@ -1,186 +1,179 @@
-- doc: Test outline for Scaffolding-HiC-VGP8 with a single pair of hic data
+- doc: Test outline for Scaffolding-with-Hi-C-data-VGP8
   job:
-    Species Name: Random Name
-    Assembly Name: randName3 
     Assembly GFA:
       class: File
-      location: https://zenodo.org/records/10037496/files/input%20GFA.gfa1
+      location: https://zenodo.org/records/17190637/files/Assembly%20GFA.gfa1
       filetype: gfa1
+    Estimated genome size - Parameter File:
+      class: File
+      location: https://zenodo.org/records/17190637/files/Estimated%20genome%20size%20-%20Parameter%20File.expression.json
+      filetype: expression.json
     Hi-C reads:
       class: Collection
       collection_type: list:paired
-      identifier: Hi-C reads
       elements:
-        - class: Collection
-          type: paired
-          identifier: Pair1
-          elements:
-          - identifier: forward
-            class: File
-            location: https://zenodo.org/records/10037496/files/HiC%20Forward%20reads.fastqsanger.gz
-          - identifier: reverse
-            class: File
-            location: https://zenodo.org/records/10037496/files/HiC%20reverse%20reads.fastqsanger.gz
-    Estimated genome size - Parameter File:
-      class: File
-      location: https://zenodo.org/records/10037496/files/Estimated%20genome%20size%20-%20Parameter%20File.txt
-      filetype: txt
+      - class: Collection
+        type: paired
+        identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMMCCXY_L6_R1.fq.gz
+        elements:
+        - class: File
+          identifier: forward
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMMCCXY_L6_R1.fq.gz
+        - class: File
+          identifier: reverse
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMMCCXY_L6_R2.fq.gz
+      - class: Collection
+        type: paired
+        identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L8_R1.fq.gz
+        elements:
+        - class: File
+          identifier: forward
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L8_R1.fq.gz
+        - class: File
+          identifier: reverse
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L8_R2.fq.gz
+      - class: Collection
+        type: paired
+        identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L7_R1.fq.gz
+        elements:
+        - class: File
+          identifier: forward
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L7_R1.fq.gz
+        - class: File
+          identifier: reverse
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L7_R2.fq.gz
+      - class: Collection
+        type: paired
+        identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L6_R1.fq.gz
+        elements:
+        - class: File
+          identifier: forward
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L6_R1.fq.gz
+        - class: File
+          identifier: reverse
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L6_R2.fq.gz
+      - class: Collection
+        type: paired
+        identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L5_R1.fq.gz
+        elements:
+        - class: File
+          identifier: forward
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L5_R1.fq.gz
+        - class: File
+          identifier: reverse
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L5_R2.fq.gz
+      - class: Collection
+        type: paired
+        identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L4_R1.fq.gz
+        elements:
+        - class: File
+          identifier: forward
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L4_R1.fq.gz
+        - class: File
+          identifier: reverse
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L4_R2.fq.gz
+      - class: Collection
+        type: paired
+        identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L3_R1.fq.gz
+        elements:
+        - class: File
+          identifier: forward
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L3_R1.fq.gz
+        - class: File
+          identifier: reverse
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L3_R2.fq.gz
+      - class: Collection
+        type: paired
+        identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L2_R1.fq.gz
+        elements:
+        - class: File
+          identifier: forward
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L2_R1.fq.gz
+        - class: File
+          identifier: reverse
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L2_R2.fq.gz
+      - class: Collection
+        type: paired
+        identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L1_R1.fq.gz
+        elements:
+        - class: File
+          identifier: forward
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L1_R1.fq.gz
+        - class: File
+          identifier: reverse
+          location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L1_R2.fq.gz
+    Species Name: test
+    Assembly Name: test
+    Haplotype: Haplotype 1
+    Trim Hi-C Data?: false
+    Minimum Mapping Quality: 10
     Database for Busco Lineage: v5
     Lineage: vertebrata_odb10
     Restriction enzymes: arima2
-    Haplotype: Haplotype 1
-    Trim Hi-C Data?: false
-    Minimum Mapping Quality: 20
   outputs:
-    "Reconciliated Scaffolds: gfa":
+    Markdup Stats:
       asserts:
-        has_n_lines:
-          n: 173
-    "Reconciliated Scaffolds: fasta":
-      asserts:
-        has_n_lines:
-          n: 168
+        - has_text: 
+            text: "Unknown Library	4	9434	1574	0	0	1148	996	0.121662	231388"
     Suffixed AGP:
       asserts:
-        has_text:
-          text: "scaffold_49.H1"
-    Busco Summary:
+        - has_text: 
+            text: "scaffold_1.H1"
+    'Reconciliated Scaffolds: gfa':
       asserts:
-        has_text:
-          text: "C:1.1%[S:1.0%,D:0.0%],F:0.4%,M:98.5%,n:3354"
+        - has_n_lines:
+            n: 5
     Assembly Statistics for s2:
       asserts:
-        has_line:
-          line: "# scaffolds	84"
-    Nx Plot:
-      asserts:
-        has_size: 
-          value : 35000
-          delta: 5000
-    Pretext Map After HiC scaffolding:
-      asserts:
-        has_size: 
-          value : 1300000
-          delta: 200000
-    Compleasm Full table:
-      asserts:
-        has_n_lines:
-          n: 3356
-    Compleasm translated proteins:
-      asserts:
-        has_n_lines:
-          n: 39464
-    Hi-C Alignment Stats pre-scaffolding:
-      asserts:
-        - has_text_matching:
-            expression: 'reads mapped and paired:	17805.{3}'
-    Hi-C Alignment Stats scaffolds:
-      asserts:
-        - has_text_matching:
-            expression: 'reads mapped and paired:	17805.{3}'
-    Hi-C alignments stats:
-      asserts:
-        has_text:
-          text: "Hi-C Alignment Stats pre-scaffolding	0.9924"
-    Merged Alignment stats:
-      asserts:
-        - has_text_matching:
-            expression: 'bases mapped \(cigar\):	12933.{4}	129333.{3}'
-- doc: Test outline for Scaffolding-HiC-VGP8 with a muiltiple pairs of hic data
-  job:
-    Species Name: Random Name
-    Assembly Name: randName3 
-    Assembly GFA:
-      class: File
-      location: https://zenodo.org/records/10037496/files/input%20GFA.gfa1
-      filetype: gfa1
-    Hi-C reads:
-      class: Collection
-      collection_type: list:paired
-      identifier: Hi-C reads
-      elements:
-        - class: Collection
-          type: paired
-          identifier: Pair1
-          elements:
-          - identifier: forward
-            class: File
-            location: https://zenodo.org/records/10037496/files/HiC%20Forward%20reads.fastqsanger.gz
-          - identifier: reverse
-            class: File
-            location: https://zenodo.org/records/10037496/files/HiC%20reverse%20reads.fastqsanger.gz
-        - class: Collection
-          type: paired
-          identifier: Pair2
-          elements:
-          - identifier: forward
-            class: File
-            location: https://zenodo.org/records/10037496/files/HiC%20Forward%20reads.fastqsanger.gz
-          - identifier: reverse
-            class: File
-            location: https://zenodo.org/records/10037496/files/HiC%20reverse%20reads.fastqsanger.gz
-    Estimated genome size - Parameter File:
-      class: File
-      location: https://zenodo.org/records/10037496/files/Estimated%20genome%20size%20-%20Parameter%20File.txt
-      filetype: txt
-    Database for Busco Lineage: v5
-    Lineage: vertebrata_odb10
-    Restriction enzymes: arima2
-    Haplotype: Haplotype 1
-    Trim Hi-C Data?: false
-    Minimum Mapping Quality: 20
-  outputs:
-    "Reconciliated Scaffolds: gfa":
-      asserts:
-        has_n_lines:
-          n: 173
-    "Reconciliated Scaffolds: fasta":
-      asserts:
-        has_n_lines:
-          n: 168
-    Suffixed AGP:
-      asserts:
-        has_text:
-          text: "scaffold_49.H1"
+        - has_text: 
+            text: "Total scaffold length	5,788,676"
     Busco Summary:
       asserts:
-        has_text:
-          text: "C:1.1%[S:1.0%,D:0.0%],F:0.4%,M:98.5%,n:3354"
-    Assembly Statistics for s2:
+        - has_text: 
+            text: "C:0.0%[S:0.0%,D:0.0%],F:0.0%,M:100.0%,n:3354"
+    Scaffolding Plots:
       asserts:
-        has_line:
-          line: "# scaffolds	84"
-    Nx Plot:
+        - has_size: 
+            value : 93200
+            delta: 5000
+    Markdup Stats on Scaffolds:
       asserts:
-        has_size: 
-          value : 35000
-          delta: 5000
-    Pretext Map After HiC scaffolding:
-      asserts:
-        has_size: 
-          value : 1300000
-          delta: 200000
-    Compleasm Full table:
-      asserts:
-        has_n_lines:
-          n: 3356
-    Compleasm translated proteins:
-      asserts:
-        has_n_lines:
-          n: 39464
-    Hi-C Alignment Stats pre-scaffolding:
-      asserts:
-        - has_text_matching:
-            expression: 'reads mapped and paired:	35610.{3}'
+        - has_text: 
+            text: "Unknown Library	4	9434	1574	0	0	1148	996	0.121662	231388"
     Hi-C Alignment Stats scaffolds:
       asserts:
-        - has_text_matching:
-            expression: 'reads mapped and paired:	35610.{3}'
+        - has_text: 
+            text: "SN	reads mapped and paired:	16572"
     Hi-C alignments stats:
       asserts:
-        has_text:
-          text: "Hi-C Alignment Stats pre-scaffolding	0.9924"
+        - has_text: 
+            text: "Hi-C Alignment Stats pre-scaffolding	1.231733	0.0	0.016576"
+    Hi-C maps:
+      asserts:
+        - has_size: 
+            value : 835200
+            delta: 50000
+    Hi-C Alignment Stats pre-scaffolding:
+      asserts:
+        - has_text: 
+            text: "SN	reads mapped and paired:	16572"
+    Markduplicates Summary:
+      asserts:
+        - has_text: 
+            text: "Unknown Library	4	9434	1574	0	0	1148	996	0.121662	231388"
+    Compleasm Full Table Busco:
+      asserts:
+        - has_n_lines:
+            n: 3355
+    Markduplicates Summary on Scaffolds:
+      asserts:
+        - has_text: 
+            text: "Unknown Library	4	9434	1574	0	0	1148	996	0.121662	231388"
+    Summary Numbers Scaffolds:
+      asserts:
+        - has_text: 
+            text: "reads mapped and paired:	16572"
     Merged Alignment stats:
       asserts:
-        - has_text_matching:
-            expression: 'bases mapped \(cigar\):	25866.{4}	258667.{3}'
+        - has_text: 
+            text: "bases mapped:	2486400	2486400"

--- a/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.ga
+++ b/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8.ga
@@ -1,6 +1,6 @@
 {
     "a_galaxy_workflow": "true",
-    "annotation": "This workflow performs the scaffolding of a genome assembly using HiC data with YAHS. Can be used on any assembly with Hi-C data, and the assembly in the gfa format. You can generate a gfa from a fasta using the gfastat tool.  Part of the VGP set of workflows, it is meant to be run after the contigging (workflows 3,4, or 5), optional purging step (Workflow 6 or 6b), and an optionnal scaffolding with Bionano data (Workflow 7). This workflow includes QC with Assembly statistics, Busco, and Hi-C maps.",
+    "annotation": "This workflow performs the scaffolding of a genome assembly using HiC data with YAHS. Can be used on any assembly with Hi-C data, and the assembly in the gfa format.",
     "comments": [],
     "creator": [
         {
@@ -15,9 +15,11 @@
     ],
     "format-version": "0.1",
     "license": "CC-BY-4.0",
+    "release": "3.0",
     "name": "Scaffolding with Hi-C data VGP8",
+    "readme": "# Scaffolding with HiC data\n\nThis workflow performs genome assembly scaffolding using HiC data with YAHS. It is designed to be run as part of the VGP analysis trajectories, but can be used on any assembly in GFA format with Hi-C data. To generate a GFA from a fasta assembly, you can use the gfastats tool in Galaxy.  \n\nExample of VGP trajectory : \n- VGP1: Kmer profiling \n- VGP4: Genome assembly with HiC phasing\n- VGP6: Purge duplicated haplotigs\n- VGP8: Scaffolding with HiC\n\n## Inputs\n\n1. Genome assembly [gfa]\n2. Haplotype being scaffolded (Will be added to scaffold names: e.g. `>scaffold_01_H1`)\n3. HiC reads paired collection [fastq]\n5. Trim Hi-C data? If `yes`, trim five bases at the beginning of each read. Use with Arima Hi-C data if the Hi-C map looks \"noisy\" and the reads haven't been trimmed before. \n6. Minimum Mapping Quality [int] (Default:20). Minimum mapping quality for Hi-C alignments. Set to 0 if you want no filtering.  \n6. Database for busco lineage (recommended: latest)\n7. Busco lineage (recommended for VGP data: vertebrata)\n8. Restriction enzyme sequence (recommended for VGP data: Arima Hi-C 2.0)\n9. Estimated genome size [txt] (Output from the contigging workflows 3,4, or 5). A simple text file containing the estimated genome size as an integer. E.g. `2288021`\n\n\n### Outputs\n\n1. Scaffolds in [fasta] and [gfa] format with the haplotype in the scaffold names.\n2. If you selected `yes` for Hi-C trimming, the trimmed collections of Hi-C reads.\n3. QC: Assembly statistics.\n4. QC: Nx plot.\n5. QC: Size plot.\n6. QC: BUSCO report.\n7. QC: Compleasm report.\n8. QC: Pretext Maps before and after scaffolding.\n9. QC: Statistics on Hi-C alignements before and after scaffolding\n",
     "report": {
-        "markdown": "Species \n\n\n```galaxy\nhistory_dataset_embedded(output=\"Species Name for report\")\n```\n\nAssembly\n\n\n```galaxy\nhistory_dataset_embedded(output=\"Assembly for report\")\n```\n\n\nHaplotype\n\n\n```galaxy\nhistory_dataset_embedded(output=\"Haplotype for report\")\n```\n\n## Hi-C alignments Statistics\n\n\r\n```galaxy\nhistory_dataset_as_table(output=\"Hi-C alignments stats\")\n```\r\n\n\n## BUSCO results \n\nDatabase:\n\n\n```galaxy\nhistory_dataset_embedded(output=\"Lineage for report\")\n```\n\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Busco Summary image\")\n```\n\n\n## Assembly statistics\n\n\n```galaxy\nhistory_dataset_as_table(output=\"clean_stats\")\n```\n\n\n## Nx and Size plots\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Nx Plot\")\n```\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Size Plot\")\n```\n\n## PretextMap\n\n### Before Scaffolding\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Pretext Map Before HiC scaffolding\")\n```\n\n\n### After Scaffolding\n```galaxy\nhistory_dataset_as_image(output=\"Pretext Map After HiC scaffolding\")\n```\n\n\n\n## Current Workflow\n```galaxy\nworkflow_display()\n```\n"
+        "markdown": "# Scaffolding Report\n\n\n```galaxy\nhistory_dataset_as_table(output=\"Assembly Info\")\n```\n\n\n## Hi-C Statistics\n\nRaw Coverage\n\n\n```galaxy\nhistory_dataset_embedded(output=\"Raw Hi-C coverage\")\n```\n\n\n\n### Deduplication\n\nSummary\n\n\n```galaxy\nhistory_dataset_as_table(output=\"Markduplicates Summary\")\n```\n\n\n\n```galaxy\nhistory_dataset_embedded(output=\"Hi-C duplication stats: MultiQc\")\n```\n\n\n### Alignment stats\n\n```galaxy\nhistory_dataset_embedded(output=\"Hi-C alignments stats HTML Report\")\n```\n\n\n## BUSCO results \n\nDatabase:\n\n\n```galaxy\nhistory_dataset_embedded(output=\"Lineage for report\")\n```\n\n\r\n```galaxy\nhistory_dataset_as_image(output=\"Busco resized\")\n```\r\n\n\n\n## Assembly statistics\n\n\n\n```galaxy\nhistory_dataset_as_table(output=\"clean_stats\")\n```\n\n\n\n## Nx and Size plots\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Scaffolding Plots\")\n```\n\n\n## PretextMap\n\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Hi-C maps\")\n```\n\n\n\n## Current Workflow\n```galaxy\nworkflow_display()\n```\n"
     },
     "steps": {
         "0": {
@@ -37,7 +39,7 @@
             "outputs": [],
             "position": {
                 "left": 0,
-                "top": 372.33385588777514
+                "top": 625.4508228752503
             },
             "tool_id": null,
             "tool_state": "{\"multiple\": false, \"validators\": [], \"parameter_type\": \"text\", \"optional\": false}",
@@ -45,7 +47,13 @@
             "type": "parameter_input",
             "uuid": "de11b3d2-3fc1-4ae4-aec5-0c9e11d6cb75",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "b5a1f7fd-3a38-489b-aca3-6e708896334d"
+                }
+            ]
         },
         "1": {
             "annotation": "For Workflow report.",
@@ -64,7 +72,7 @@
             "outputs": [],
             "position": {
                 "left": 26.510262460620602,
-                "top": 469.82849789678244
+                "top": 722.9454648842577
             },
             "tool_id": null,
             "tool_state": "{\"multiple\": false, \"validators\": [], \"parameter_type\": \"text\", \"optional\": false}",
@@ -72,17 +80,23 @@
             "type": "parameter_input",
             "uuid": "0b156721-1b2d-45a5-96e5-55d4cd353604",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "0602e8ed-7ec8-4e27-bba5-b04148f34e1f"
+                }
+            ]
         },
         "2": {
-            "annotation": "The input GFA must conform to gfa1.2 standards, i.e. should have 'P' lines defined, and contain sequences. Output GFAs from assemblers can be run through a GFA-GFA conversion using gfastats to ensure this. \n",
+            "annotation": "The input GFA must conform to gfa1.2 standards, i.e. should have P lines defined, and contain sequences. Output GFAs from assemblers can be run through a GFA-GFA conversion using gfastats to ensure this. \n",
             "content_id": null,
             "errors": null,
             "id": 2,
             "input_connections": {},
             "inputs": [
                 {
-                    "description": "The input GFA must conform to gfa1.2 standards, i.e. should have 'P' lines defined, and contain sequences. Output GFAs from assemblers can be run through a GFA-GFA conversion using gfastats to ensure this. \n",
+                    "description": "The input GFA must conform to gfa1.2 standards, i.e. should have P lines defined, and contain sequences. Output GFAs from assemblers can be run through a GFA-GFA conversion using gfastats to ensure this. \n",
                     "name": "Assembly GFA"
                 }
             ],
@@ -91,7 +105,7 @@
             "outputs": [],
             "position": {
                 "left": 92.0360390209619,
-                "top": 574.2176820112883
+                "top": 827.3346489987637
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"format\": [\"gfa1\"], \"tag\": \"\"}",
@@ -118,7 +132,7 @@
             "outputs": [],
             "position": {
                 "left": 144.8594018543837,
-                "top": 657.6833781809568
+                "top": 910.8003451684322
             },
             "tool_id": null,
             "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictions\": [\"Haplotype 1\", \"Haplotype 2\", \"Maternal\", \"Paternal\", \"Primary\", \"Alternate\"], \"parameter_type\": \"text\", \"optional\": false}",
@@ -126,7 +140,13 @@
             "type": "parameter_input",
             "uuid": "3495a63c-bcd5-45fa-b327-ed7ec0234e78",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "d30f0e90-4d52-45c8-840f-568fa89bf3d0"
+                }
+            ]
         },
         "4": {
             "annotation": "",
@@ -145,7 +165,7 @@
             "outputs": [],
             "position": {
                 "left": 195.19745840401168,
-                "top": 738.2964273601127
+                "top": 991.4133943475881
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list:paired\", \"fields\": null}",
@@ -172,7 +192,7 @@
             "outputs": [],
             "position": {
                 "left": 225.75575357667353,
-                "top": 834.3099699882686
+                "top": 1087.4269369757437
             },
             "tool_id": null,
             "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
@@ -180,7 +200,13 @@
             "type": "parameter_input",
             "uuid": "68c2f24e-7f3f-40f9-b0dc-bbdd9ca46874",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "5f17443c-f293-49cf-8714-e1147cae69be"
+                }
+            ]
         },
         "6": {
             "annotation": "Filter low mapping quality for scaffolding. Set to 0 if no filtering is wanted. ",
@@ -198,16 +224,22 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 278.03133608546,
-                "top": 951.6681413166805
+                "left": 266.5347147004288,
+                "top": 1203.6235803749014
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 20, \"validators\": [{\"min\": 0, \"max\": 255, \"negate\": false, \"type\": \"in_range\"}], \"parameter_type\": \"integer\", \"optional\": false}",
+            "tool_state": "{\"default\": 10, \"validators\": [{\"min\": 0, \"max\": 255, \"negate\": false, \"type\": \"in_range\"}], \"parameter_type\": \"integer\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "dbac2181-7409-463f-872e-8bc39d659bec",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "0664de66-99e3-4d7e-b42f-c97f04c2b76c"
+                }
+            ]
         },
         "7": {
             "annotation": "Select the database to use for Busco lineage. ",
@@ -226,7 +258,7 @@
             "outputs": [],
             "position": {
                 "left": 297.31636429742264,
-                "top": 1069.463883019833
+                "top": 1322.580850007308
             },
             "tool_id": null,
             "tool_state": "{\"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
@@ -234,7 +266,13 @@
             "type": "parameter_input",
             "uuid": "1f4997fc-1880-4416-8857-2a63d3501a6c",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "d54d6f7b-0da4-4bfc-9a9f-24b926056cd3"
+                }
+            ]
         },
         "8": {
             "annotation": "Taxonomic lineage for the organism being assembled for Busco analysis.\n",
@@ -253,7 +291,7 @@
             "outputs": [],
             "position": {
                 "left": 321.7052916278543,
-                "top": 1180.7918864019948
+                "top": 1433.9088533894699
             },
             "tool_id": null,
             "tool_state": "{\"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
@@ -261,7 +299,13 @@
             "type": "parameter_input",
             "uuid": "b45e6bda-be0e-45e7-a9b1-17325a08dd76",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "abee13cc-1347-4bb1-9bbf-ed3ccbc61be9"
+                }
+            ]
         },
         "9": {
             "annotation": "Restriction enzymes used in preparation of Hi-C libraries.",
@@ -279,8 +323,8 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 370.05742687498156,
-                "top": 1257.9089776251567
+                "left": 380.11407669467053,
+                "top": 1530.640475919718
             },
             "tool_id": null,
             "tool_state": "{\"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
@@ -288,7 +332,13 @@
             "type": "parameter_input",
             "uuid": "b899a210-60c2-4e9e-8a34-e1bc82ef373d",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "7c3f0fda-522f-4ea2-bc99-a72fbb5cd979"
+                }
+            ]
         },
         "10": {
             "annotation": "Estimated genome size from contiging workflow.",
@@ -307,7 +357,7 @@
             "outputs": [],
             "position": {
                 "left": 434.6758797881475,
-                "top": 1396.4887775784086
+                "top": 1649.6057445658837
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"tag\": \"\"}",
@@ -319,118 +369,21 @@
         },
         "11": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
-            "errors": null,
-            "id": 11,
-            "input_connections": {
-                "components_0|param_type|component_value": {
-                    "id": 0,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": "Species Name: ",
-            "name": "Compose text parameter value",
-            "outputs": [
-                {
-                    "name": "out1",
-                    "type": "expression.json"
-                }
-            ],
-            "position": {
-                "left": 440.2300181074789,
-                "top": 82.82559902530076
-            },
-            "post_job_actions": {
-                "HideDatasetActionout1": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "out1"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
-            "tool_shed_repository": {
-                "changeset_revision": "e188c9826e0f",
-                "name": "compose_text_param",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.1.1",
-            "type": "tool",
-            "uuid": "95ad5427-9ab9-4db6-b775-30cea4011451",
-            "when": null,
-            "workflow_outputs": [
-                {
-                    "label": "Species Name for report",
-                    "output_name": "out1",
-                    "uuid": "a05d5327-f916-4701-90c7-5e3dbce0b239"
-                }
-            ]
-        },
-        "12": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
-            "errors": null,
-            "id": 12,
-            "input_connections": {
-                "components_0|param_type|component_value": {
-                    "id": 1,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": "Assembly Name:",
-            "name": "Compose text parameter value",
-            "outputs": [
-                {
-                    "name": "out1",
-                    "type": "expression.json"
-                }
-            ],
-            "position": {
-                "left": 440.8343918716563,
-                "top": 278.0864695537656
-            },
-            "post_job_actions": {
-                "HideDatasetActionout1": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "out1"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
-            "tool_shed_repository": {
-                "changeset_revision": "e188c9826e0f",
-                "name": "compose_text_param",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.1.1",
-            "type": "tool",
-            "uuid": "7022a630-b861-43b6-9cb1-1c07ba35ede1",
-            "when": null,
-            "workflow_outputs": [
-                {
-                    "label": "Assembly for report",
-                    "output_name": "out1",
-                    "uuid": "6d11c32b-82e0-4794-8d2d-5f81aa7b7c94"
-                }
-            ]
-        },
-        "13": {
-            "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/gfastats/gfastats/1.3.11+galaxy0",
             "errors": null,
-            "id": 13,
+            "id": 11,
             "input_connections": {
                 "input_file": {
                     "id": 2,
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool gfastats",
+                    "name": "mode_condition"
+                }
+            ],
             "label": null,
             "name": "gfastats",
             "outputs": [
@@ -441,7 +394,7 @@
             ],
             "position": {
                 "left": 885.8247518666775,
-                "top": 370.0881375826276
+                "top": 623.2051045701029
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/gfastats/gfastats/1.3.11+galaxy0",
@@ -458,18 +411,82 @@
             "when": null,
             "workflow_outputs": []
         },
-        "14": {
+        "12": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
+            "errors": null,
+            "id": 12,
+            "input_connections": {
+                "components_1|param_type|component_value": {
+                    "id": 0,
+                    "output_name": "output"
+                },
+                "components_3|param_type|component_value": {
+                    "id": 1,
+                    "output_name": "output"
+                },
+                "components_5|param_type|component_value": {
+                    "id": 3,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": "Assembly Info",
+            "name": "Compose text parameter value",
+            "outputs": [
+                {
+                    "name": "out1",
+                    "type": "expression.json"
+                }
+            ],
+            "position": {
+                "left": 473.8212119533163,
+                "top": 149.75998247380355
+            },
+            "post_job_actions": {
+                "HideDatasetActionout1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out1"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
+            "tool_shed_repository": {
+                "changeset_revision": "e188c9826e0f",
+                "name": "compose_text_param",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \"Species: \"}}, {\"__index__\": 1, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \", Assembly ID: \"}}, {\"__index__\": 3, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 4, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \", Haplotype: \"}}, {\"__index__\": 5, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.1.1",
+            "type": "tool",
+            "uuid": "95ad5427-9ab9-4db6-b775-30cea4011451",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Assembly Info",
+                    "output_name": "out1",
+                    "uuid": "7a0ebe5e-aa52-48b3-8a83-8cba57573da3"
+                }
+            ]
+        },
+        "13": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
             "errors": null,
-            "id": 14,
+            "id": 13,
             "input_connections": {
                 "input_param_type|input_param": {
                     "id": 3,
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Map parameter value",
+                    "name": "input_param_type"
+                }
+            ],
             "label": null,
             "name": "Map parameter value",
             "outputs": [
@@ -480,7 +497,7 @@
             ],
             "position": {
                 "left": 609.673737488522,
-                "top": 493.54397044636517
+                "top": 746.6609374338404
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_param_text": {
@@ -503,62 +520,11 @@
             "when": null,
             "workflow_outputs": []
         },
-        "15": {
+        "14": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
             "errors": null,
-            "id": 15,
-            "input_connections": {
-                "components_0|param_type|component_value": {
-                    "id": 3,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": "Haplotype:",
-            "name": "Compose text parameter value",
-            "outputs": [
-                {
-                    "name": "out1",
-                    "type": "expression.json"
-                }
-            ],
-            "position": {
-                "left": 664.3877977894061,
-                "top": 655.664239061971
-            },
-            "post_job_actions": {
-                "HideDatasetActionout1": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "out1"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
-            "tool_shed_repository": {
-                "changeset_revision": "e188c9826e0f",
-                "name": "compose_text_param",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.1.1",
-            "type": "tool",
-            "uuid": "4d730058-a36d-4fd5-a234-f1a4b4211130",
-            "when": null,
-            "workflow_outputs": [
-                {
-                    "label": "Haplotype for report",
-                    "output_name": "out1",
-                    "uuid": "6e70f7a3-e532-47b9-bf18-1d98402b3bcf"
-                }
-            ]
-        },
-        "16": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
-            "errors": null,
-            "id": 16,
+            "id": 14,
             "input_connections": {
                 "components_1|param_type|component_value": {
                     "id": 6,
@@ -576,7 +542,7 @@
             ],
             "position": {
                 "left": 744.7713672171391,
-                "top": 916.893835198506
+                "top": 1170.0108021859812
             },
             "post_job_actions": {
                 "HideDatasetActionout1": {
@@ -599,11 +565,11 @@
             "when": null,
             "workflow_outputs": []
         },
-        "17": {
+        "15": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
             "errors": null,
-            "id": 17,
+            "id": 15,
             "input_connections": {
                 "components_0|param_type|component_value": {
                     "id": 8,
@@ -620,8 +586,8 @@
                 }
             ],
             "position": {
-                "left": 851.710207004491,
-                "top": 1236.8424317656625
+                "left": 969.7949849502947,
+                "top": 1330.0144264741978
             },
             "post_job_actions": {
                 "HideDatasetActionout1": {
@@ -650,11 +616,518 @@
                 }
             ]
         },
-        "18": {
+        "16": {
+            "annotation": "",
+            "id": 16,
+            "input_connections": {
+                "Estimated Genome size": {
+                    "id": 10,
+                    "input_subworkflow_step_id": 1,
+                    "output_name": "output"
+                },
+                "Reads": {
+                    "id": 4,
+                    "input_subworkflow_step_id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Compute read coverage",
+            "outputs": [],
+            "position": {
+                "left": 1296.6690673828125,
+                "top": 1538.6093477081786
+            },
+            "subworkflow": {
+                "a_galaxy_workflow": "true",
+                "annotation": "",
+                "comments": [],
+                "format-version": "0.1",
+                "name": "Compute read coverage",
+                "report": {
+                    "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
+                },
+                "steps": {
+                    "0": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 0,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Reads"
+                            }
+                        ],
+                        "label": "Reads",
+                        "name": "Input dataset collection",
+                        "outputs": [],
+                        "position": {
+                            "left": 0,
+                            "top": 260.4454452800712
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"fastq\", \"fastqsanger.gz\", \"fastqsanger\", \"fastq.gz\"], \"tag\": null, \"collection_type\": \"list:paired\", \"fields\": null}",
+                        "tool_version": null,
+                        "type": "data_collection_input",
+                        "uuid": "e855ff8d-2fee-4560-8c2d-33ddbf5be228",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "1": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 1,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Estimated Genome size"
+                            }
+                        ],
+                        "label": "Estimated Genome size",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 187.578125,
+                            "top": 489.79400634765625
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"tag\": null}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "4d4bf631-3d8d-4590-a6ae-12d7f7796a14",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "2": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.74+galaxy1",
+                        "errors": null,
+                        "id": 2,
+                        "input_connections": {
+                            "input_file": {
+                                "id": 0,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [
+                            {
+                                "description": "runtime parameter for tool FastQC",
+                                "name": "adapters"
+                            },
+                            {
+                                "description": "runtime parameter for tool FastQC",
+                                "name": "contaminants"
+                            },
+                            {
+                                "description": "runtime parameter for tool FastQC",
+                                "name": "limits"
+                            }
+                        ],
+                        "label": null,
+                        "name": "FastQC",
+                        "outputs": [
+                            {
+                                "name": "html_file",
+                                "type": "html"
+                            },
+                            {
+                                "name": "text_file",
+                                "type": "txt"
+                            }
+                        ],
+                        "position": {
+                            "left": 416.2058685347717,
+                            "top": 0
+                        },
+                        "post_job_actions": {},
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.74+galaxy1",
+                        "tool_shed_repository": {
+                            "changeset_revision": "2c64fded1286",
+                            "name": "fastqc",
+                            "owner": "devteam",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"adapters\": {\"__class__\": \"RuntimeValue\"}, \"contaminants\": {\"__class__\": \"RuntimeValue\"}, \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"kmers\": \"7\", \"limits\": {\"__class__\": \"RuntimeValue\"}, \"min_length\": null, \"nogroup\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "0.74+galaxy1",
+                        "type": "tool",
+                        "uuid": "12756575-8977-4bf5-a3c2-a4c0492ea177",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "3": {
+                        "annotation": "",
+                        "content_id": "param_value_from_file",
+                        "errors": null,
+                        "id": 3,
+                        "input_connections": {
+                            "input1": {
+                                "id": 1,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Parse parameter value",
+                        "outputs": [
+                            {
+                                "name": "integer_param",
+                                "type": "expression.json"
+                            }
+                        ],
+                        "position": {
+                            "left": 1382.6199973031896,
+                            "top": 530.3531176413849
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActioninteger_param": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "integer_param"
+                            }
+                        },
+                        "tool_id": "param_value_from_file",
+                        "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"integer\", \"remove_newlines\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "0.1.0",
+                        "type": "tool",
+                        "uuid": "17e1eeeb-b627-4c39-99fe-ea3d9637b5a3",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "4": {
+                        "annotation": "",
+                        "content_id": "__FLATTEN__",
+                        "errors": null,
+                        "id": 4,
+                        "input_connections": {
+                            "input": {
+                                "id": 2,
+                                "output_name": "text_file"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Flatten collection",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 685.4890786413966,
+                            "top": 320.8777705818995
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionoutput": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output"
+                            }
+                        },
+                        "tool_id": "__FLATTEN__",
+                        "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"join_identifier\": \"_\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "1.0.0",
+                        "type": "tool",
+                        "uuid": "d86633e0-fe90-4441-ab5a-da92823ebb10",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "5": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.5+galaxy2",
+                        "errors": null,
+                        "id": 5,
+                        "input_connections": {
+                            "infile": {
+                                "id": 4,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "Total Sequences",
+                        "name": "Search in textfiles",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 940.7103509025985,
+                            "top": 69.8242192595482
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionoutput": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.5+galaxy2",
+                        "tool_shed_repository": {
+                            "changeset_revision": "c41d78ae5fee",
+                            "name": "text_processing",
+                            "owner": "bgruening",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"case_sensitive\": \"-i\", \"color\": \"NOCOLOR\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"invert\": \"\", \"lines_after\": \"0\", \"lines_before\": \"0\", \"regex_type\": \"-P\", \"url_paste\": \"Total Sequences\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "9.5+galaxy2",
+                        "type": "tool",
+                        "uuid": "8cc2544f-5d67-484a-8581-97c09cc40937",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "6": {
+                        "annotation": "",
+                        "content_id": "Cut1",
+                        "errors": null,
+                        "id": 6,
+                        "input_connections": {
+                            "input": {
+                                "id": 5,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Cut",
+                        "outputs": [
+                            {
+                                "name": "out_file1",
+                                "type": "tabular"
+                            }
+                        ],
+                        "position": {
+                            "left": 1221.9422341727904,
+                            "top": 322.22187118714794
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionout_file1": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "out_file1"
+                            }
+                        },
+                        "tool_id": "Cut1",
+                        "tool_state": "{\"columnList\": \"c2\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "1.0.2",
+                        "type": "tool",
+                        "uuid": "56891d5e-ab99-4cb7-acc2-4e5c7cb4e170",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "7": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+                        "errors": null,
+                        "id": 7,
+                        "input_connections": {
+                            "input_list": {
+                                "id": 6,
+                                "output_name": "out_file1"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Collapse Collection",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 1509.404567033452,
+                            "top": 38.15237719878539
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionoutput": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "90981f86000f",
+                            "name": "collapse_collections",
+                            "owner": "nml",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"filename\": {\"add_name\": false, \"__current_case__\": 1}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "5.1.0",
+                        "type": "tool",
+                        "uuid": "c34cd69a-879d-429d-990c-318616c94f72",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "8": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.9+galaxy0",
+                        "errors": null,
+                        "id": 8,
+                        "input_connections": {
+                            "in_file": {
+                                "id": 7,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Datamash",
+                        "outputs": [
+                            {
+                                "name": "out_file",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 1754.260475485942,
+                            "top": 342.4481650083536
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionout_file": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "out_file"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/datamash_ops/datamash_ops/1.9+galaxy0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "61e2aa6bb55d",
+                            "name": "datamash_ops",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"grouping\": null, \"header_in\": false, \"header_out\": false, \"ignore_case\": false, \"in_file\": {\"__class__\": \"ConnectedValue\"}, \"narm\": false, \"need_sort\": false, \"operations\": [{\"__index__\": 0, \"op_name\": \"sum\", \"op_column\": \"1\"}], \"print_full_line\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "1.9+galaxy0",
+                        "type": "tool",
+                        "uuid": "11776adf-de58-49ad-8e6d-faf15e2dddbb",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "9": {
+                        "annotation": "",
+                        "content_id": "param_value_from_file",
+                        "errors": null,
+                        "id": 9,
+                        "input_connections": {
+                            "input1": {
+                                "id": 8,
+                                "output_name": "out_file"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Parse parameter value",
+                        "outputs": [
+                            {
+                                "name": "integer_param",
+                                "type": "expression.json"
+                            }
+                        ],
+                        "position": {
+                            "left": 2088.328045392128,
+                            "top": 60.12269188656251
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActioninteger_param": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "integer_param"
+                            }
+                        },
+                        "tool_id": "param_value_from_file",
+                        "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"integer\", \"remove_newlines\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "0.1.0",
+                        "type": "tool",
+                        "uuid": "b5f1343d-eea3-4857-90c8-f60cda818bae",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "10": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/calculate_numeric_param/calculate_numeric_param/0.1.0",
+                        "errors": null,
+                        "id": 10,
+                        "input_connections": {
+                            "components_0|param_type|component_value": {
+                                "id": 9,
+                                "output_name": "integer_param"
+                            },
+                            "components_2|param_type|component_value": {
+                                "id": 3,
+                                "output_name": "integer_param"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "Coverage with sequences",
+                        "name": "Calculate numeric parameter value",
+                        "outputs": [
+                            {
+                                "name": "integer_param",
+                                "type": "expression.json"
+                            }
+                        ],
+                        "position": {
+                            "left": 2366.930906291078,
+                            "top": 327.90528211689497
+                        },
+                        "post_job_actions": {
+                            "RenameDatasetActioninteger_param": {
+                                "action_arguments": {
+                                    "newname": "Raw Hi-C coverage"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "integer_param"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/calculate_numeric_param/calculate_numeric_param/0.1.0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "0e586762f97b",
+                            "name": "calculate_numeric_param",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 0, \"component_value\": {\"__class__\": \"ConnectedValue\"}}, \"arith\": \"*\"}, {\"__index__\": 1, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 0, \"component_value\": \"150\"}, \"arith\": \"/\"}, {\"__index__\": 2, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 0, \"component_value\": {\"__class__\": \"ConnectedValue\"}}, \"arith\": \"\"}], \"output_type\": \"integer\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "0.1.0",
+                        "type": "tool",
+                        "uuid": "9a5fdc64-b6d1-452b-9af9-ea5436ef299d",
+                        "when": null,
+                        "workflow_outputs": [
+                            {
+                                "label": "Raw Hi-C coverage",
+                                "output_name": "integer_param",
+                                "uuid": "5acca623-5e24-44e1-becf-662fe593ae40"
+                            }
+                        ]
+                    }
+                },
+                "tags": [],
+                "uuid": "c002b00e-d0dd-43d0-8e1b-ac2935c6a1d5"
+            },
+            "tool_id": null,
+            "type": "subworkflow",
+            "uuid": "815c69c8-4388-48d3-b34b-a00cd0e75ef5",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Raw Hi-C coverage",
+                    "output_name": "Raw Hi-C coverage",
+                    "uuid": "259dda77-0252-48a4-a379-1ada5fe4f6fe"
+                }
+            ]
+        },
+        "17": {
             "annotation": "",
             "content_id": "param_value_from_file",
             "errors": null,
-            "id": 18,
+            "id": 17,
             "input_connections": {
                 "input1": {
                     "id": 10,
@@ -671,8 +1144,8 @@
                 }
             ],
             "position": {
-                "left": 2900,
-                "top": 1602.8255990253008
+                "left": 3211.901543678558,
+                "top": 1997.940667769313
             },
             "post_job_actions": {
                 "HideDatasetActioninteger_param": {
@@ -689,9 +1162,9 @@
             "when": null,
             "workflow_outputs": []
         },
-        "19": {
+        "18": {
             "annotation": "",
-            "id": 19,
+            "id": 18,
             "input_connections": {
                 "Do you want to trim the Hi-C data?": {
                     "id": 5,
@@ -704,7 +1177,7 @@
                     "output_name": "output"
                 },
                 "Reference": {
-                    "id": 13,
+                    "id": 11,
                     "input_subworkflow_step_id": 0,
                     "output_name": "output"
                 }
@@ -715,7 +1188,7 @@
             "outputs": [],
             "position": {
                 "left": 1160,
-                "top": 710
+                "top": 963.1169669874753
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -757,7 +1230,7 @@
                         "outputs": [],
                         "position": {
                             "left": 0,
-                            "top": 0
+                            "top": 27.330116020606376
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"tag\": null}",
@@ -784,7 +1257,7 @@
                         "outputs": [],
                         "position": {
                             "left": 124.6511831732837,
-                            "top": 159.35032776516732
+                            "top": 186.6804437857737
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list:paired\", \"fields\": null}",
@@ -811,7 +1284,7 @@
                         "outputs": [],
                         "position": {
                             "left": 234.54989137895723,
-                            "top": 295.2235674741496
+                            "top": 322.553683494756
                         },
                         "tool_id": null,
                         "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
@@ -823,15 +1296,60 @@
                             {
                                 "label": null,
                                 "output_name": "output",
-                                "uuid": "a707b86b-800e-47b3-aa98-8637a2880875"
+                                "uuid": "06a1fa07-2a39-4997-a627-8106fb3a2a92"
                             }
                         ]
                     },
                     "3": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/5.1+galaxy0",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bwa_mem2/bwa_mem2_idx/2.3+galaxy0",
                         "errors": null,
                         "id": 3,
+                        "input_connections": {
+                            "reference": {
+                                "id": 0,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "BWA-MEM2 indexer",
+                        "outputs": [
+                            {
+                                "name": "index",
+                                "type": "bwa_mem2_index"
+                            }
+                        ],
+                        "position": {
+                            "left": 1046.9177855113426,
+                            "top": 0.0
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionindex": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "index"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bwa_mem2/bwa_mem2_idx/2.3+galaxy0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "af91699b8d4c",
+                            "name": "bwa_mem2",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"reference\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_version": "2.3+galaxy0",
+                        "type": "tool",
+                        "uuid": "d307c5d4-0a18-4ef8-ac09-364bdff26b58",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "4": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/lparsons/cutadapt/cutadapt/5.1+galaxy0",
+                        "errors": null,
+                        "id": 4,
                         "input_connections": {
                             "library|input_1": {
                                 "id": 1,
@@ -842,7 +1360,12 @@
                                 "output_name": "output"
                             }
                         },
-                        "inputs": [],
+                        "inputs": [
+                            {
+                                "description": "runtime parameter for tool Cutadapt",
+                                "name": "library"
+                            }
+                        ],
                         "label": "Trim Hi-C reads 2",
                         "name": "Cutadapt",
                         "outputs": [
@@ -857,7 +1380,7 @@
                         ],
                         "position": {
                             "left": 782.453125,
-                            "top": 137.4375
+                            "top": 164.76761602060637
                         },
                         "post_job_actions": {
                             "HideDatasetActionout_pairs": {
@@ -894,14 +1417,14 @@
                         "when": "$(inputs.when)",
                         "workflow_outputs": []
                     },
-                    "4": {
+                    "5": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
                         "errors": null,
-                        "id": 4,
+                        "id": 5,
                         "input_connections": {
                             "style_cond|type_cond|pick_from_0|value": {
-                                "id": 3,
+                                "id": 4,
                                 "output_name": "out_pairs"
                             },
                             "style_cond|type_cond|pick_from_1|value": {
@@ -920,7 +1443,7 @@
                         ],
                         "position": {
                             "left": 1065.48046875,
-                            "top": 389.734375
+                            "top": 417.0644910206064
                         },
                         "post_job_actions": {
                             "RenameDatasetActiondata_param": {
@@ -958,22 +1481,31 @@
                             }
                         ]
                     },
-                    "5": {
+                    "6": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bwa_mem2/bwa_mem2/2.3+galaxy0",
                         "errors": null,
-                        "id": 5,
+                        "id": 6,
                         "input_connections": {
                             "fastq_input|fastq_input1": {
-                                "id": 4,
+                                "id": 5,
                                 "output_name": "data_param"
                             },
                             "reference_source|ref_file": {
-                                "id": 0,
-                                "output_name": "output"
+                                "id": 3,
+                                "output_name": "index"
                             }
                         },
-                        "inputs": [],
+                        "inputs": [
+                            {
+                                "description": "runtime parameter for tool BWA-MEM2",
+                                "name": "fastq_input"
+                            },
+                            {
+                                "description": "runtime parameter for tool BWA-MEM2",
+                                "name": "reference_source"
+                            }
+                        ],
                         "label": null,
                         "name": "BWA-MEM2",
                         "outputs": [
@@ -984,7 +1516,7 @@
                         ],
                         "position": {
                             "left": 1350.390625,
-                            "top": 57.07421875
+                            "top": 84.40433477060637
                         },
                         "post_job_actions": {
                             "HideDatasetActionbam_output": {
@@ -1022,7 +1554,7 @@
                     }
                 },
                 "tags": [],
-                "uuid": "a7abef93-a0de-4413-a764-e0f712334d7e"
+                "uuid": "97261879-f967-4ca3-baf2-6b3f82525f63"
             },
             "tool_id": null,
             "type": "subworkflow",
@@ -1030,16 +1562,71 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "s1 Trimmed Hi-C data",
-                    "output_name": "Trimmed Hi-C data",
-                    "uuid": "bfee12c8-1715-48ad-a35b-d938e9038c87"
+                    "label": null,
+                    "output_name": "2:output",
+                    "uuid": "de16499f-85e4-445d-a536-ef2a9c5f4d93"
                 },
                 {
                     "label": "s1 Hi-C Alignments",
                     "output_name": "Hi-C Alignments",
                     "uuid": "936f703d-5288-4bc6-85a1-81bd91ce77ef"
+                },
+                {
+                    "label": "s1 Trimmed Hi-C data",
+                    "output_name": "Trimmed Hi-C data",
+                    "uuid": "bfee12c8-1715-48ad-a35b-d938e9038c87"
                 }
             ]
+        },
+        "19": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_compute_length/fasta_compute_length/1.0.4",
+            "errors": null,
+            "id": 19,
+            "input_connections": {
+                "ref|input": {
+                    "id": 11,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Compute sequence length",
+                    "name": "ref"
+                }
+            ],
+            "label": null,
+            "name": "Compute sequence length",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 1756.3316383210945,
+                "top": 1878.7337217841712
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_compute_length/fasta_compute_length/1.0.4",
+            "tool_shed_repository": {
+                "changeset_revision": "5cbde03c1103",
+                "name": "fasta_compute_length",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"ref\": {\"ref_source\": \"history\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}, \"keep_first\": \"0\", \"keep_first_word\": false}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.4",
+            "type": "tool",
+            "uuid": "84620d8b-c746-4254-9ef5-a5217ad8951a",
+            "when": null,
+            "workflow_outputs": []
         },
         "20": {
             "annotation": "",
@@ -1048,7 +1635,7 @@
             "id": 20,
             "input_connections": {
                 "components_1|param_type|component_value": {
-                    "id": 14,
+                    "id": 13,
                     "output_name": "output_param_text"
                 }
             },
@@ -1063,7 +1650,7 @@
             ],
             "position": {
                 "left": 909.273938951095,
-                "top": 576.2390857203078
+                "top": 829.3560527077832
             },
             "post_job_actions": {
                 "HideDatasetActionout1": {
@@ -1088,80 +1675,12 @@
         },
         "21": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy3",
-            "errors": null,
             "id": 21,
             "input_connections": {
-                "conditions_0|filters_0|bam_property|bam_property_value": {
-                    "id": 16,
-                    "output_name": "out1"
-                },
-                "input_bam": {
-                    "id": 19,
-                    "output_name": "Hi-C Alignments"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Filter BAM",
-            "outputs": [
-                {
-                    "name": "out_file2",
-                    "type": "txt"
-                },
-                {
-                    "name": "out_file1",
-                    "type": "bam"
-                }
-            ],
-            "position": {
-                "left": 1410,
-                "top": 930
-            },
-            "post_job_actions": {
-                "RenameDatasetActionout_file1": {
-                    "action_arguments": {
-                        "newname": "Filtered H-C Alignments on contigs"
-                    },
-                    "action_type": "RenameDatasetAction",
-                    "output_name": "out_file1"
-                },
-                "TagDatasetActionout_file1": {
-                    "action_arguments": {
-                        "tags": "filtered_alignments_s1"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "out_file1"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy3",
-            "tool_shed_repository": {
-                "changeset_revision": "62e4d6cdbaa7",
-                "name": "bamtools_filter",
-                "owner": "devteam",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"conditions\": [{\"__index__\": 0, \"filters\": [{\"__index__\": 0, \"bam_property\": {\"bam_property_selector\": \"mapQuality\", \"__current_case__\": 14, \"bam_property_value\": {\"__class__\": \"ConnectedValue\"}}}]}], \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"rule_configuration\": {\"rules_selector\": \"false\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.5.2+galaxy3",
-            "type": "tool",
-            "uuid": "f0408f17-344c-457d-960b-9f1b41608a9d",
-            "when": null,
-            "workflow_outputs": [
-                {
-                    "label": "Filtered H-C Alignments on contigs",
-                    "output_name": "out_file1",
-                    "uuid": "ca98e7ae-8802-442f-b519-e683fd13bf0f"
-                }
-            ]
-        },
-        "22": {
-            "annotation": "",
-            "id": 22,
-            "input_connections": {
                 "0:Input dataset collection": {
-                    "id": 21,
+                    "id": 18,
                     "input_subworkflow_step_id": 0,
-                    "output_name": "out_file1"
+                    "output_name": "Hi-C Alignments"
                 }
             },
             "inputs": [],
@@ -1169,8 +1688,8 @@
             "name": "Test if collection has only one item or is empty",
             "outputs": [],
             "position": {
-                "left": 1560,
-                "top": 410
+                "left": 1403.169300526819,
+                "top": 621.0110444137098
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -1377,7 +1896,12 @@
                                 "output_name": "text_param"
                             }
                         },
-                        "inputs": [],
+                        "inputs": [
+                            {
+                                "description": "runtime parameter for tool Map parameter value",
+                                "name": "input_param_type"
+                            }
+                        ],
                         "label": null,
                         "name": "Map parameter value",
                         "outputs": [
@@ -1428,7 +1952,12 @@
                                 "output_name": "text_param"
                             }
                         },
-                        "inputs": [],
+                        "inputs": [
+                            {
+                                "description": "runtime parameter for tool Map parameter value",
+                                "name": "input_param_type"
+                            }
+                        ],
                         "label": null,
                         "name": "Map parameter value",
                         "outputs": [
@@ -1479,7 +2008,12 @@
                                 "output_name": "text_param"
                             }
                         },
-                        "inputs": [],
+                        "inputs": [
+                            {
+                                "description": "runtime parameter for tool Map parameter value",
+                                "name": "input_param_type"
+                            }
+                        ],
                         "label": null,
                         "name": "Map parameter value",
                         "outputs": [
@@ -1521,11 +2055,50 @@
                     }
                 },
                 "tags": [],
-                "uuid": "f2dea72e-5b3d-4ccb-a41e-faa5d65a2e3f"
+                "uuid": "58ab41da-d6f5-41c7-93b1-b3dade5c43b0"
             },
             "tool_id": null,
             "type": "subworkflow",
             "uuid": "96aea9d9-40ab-4eb5-9665-e832e10ba939",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "22": {
+            "annotation": "",
+            "content_id": "Cut1",
+            "errors": null,
+            "id": 22,
+            "input_connections": {
+                "input": {
+                    "id": 19,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Cut",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 2169.014568496489,
+                "top": 2031.9275641332713
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "Cut1",
+            "tool_state": "{\"columnList\": \"c1\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.2",
+            "type": "tool",
+            "uuid": "28dea751-5a8f-407c-aba8-2bb9a7434082",
             "when": null,
             "workflow_outputs": []
         },
@@ -1536,15 +2109,24 @@
             "id": 23,
             "input_connections": {
                 "bamfiles": {
-                    "id": 21,
-                    "output_name": "out_file1"
+                    "id": 18,
+                    "output_name": "Hi-C Alignments"
                 },
                 "when": {
-                    "id": 22,
+                    "id": 21,
                     "output_name": "Has multiple samples"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Samtools merge",
+                    "name": "bed_file"
+                },
+                {
+                    "description": "runtime parameter for tool Samtools merge",
+                    "name": "headerbam"
+                }
+            ],
             "label": null,
             "name": "Samtools merge",
             "outputs": [
@@ -1554,8 +2136,8 @@
                 }
             ],
             "position": {
-                "left": 1890,
-                "top": 660
+                "left": 1666.573638208404,
+                "top": 985.1643374392736
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1592,11 +2174,11 @@
             "id": 24,
             "input_connections": {
                 "input": {
-                    "id": 21,
-                    "output_name": "out_file1"
+                    "id": 18,
+                    "output_name": "Hi-C Alignments"
                 },
                 "when": {
-                    "id": 22,
+                    "id": 21,
                     "output_name": "Has a single sample"
                 }
             },
@@ -1610,8 +2192,8 @@
                 }
             ],
             "position": {
-                "left": 1890,
-                "top": 1010
+                "left": 1646.636412376603,
+                "top": 1347.4841154574945
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -1653,8 +2235,8 @@
                 }
             ],
             "position": {
-                "left": 2220,
-                "top": 780
+                "left": 1929.4088756931892,
+                "top": 1243.5550995451576
             },
             "post_job_actions": {
                 "RenameDatasetActiondata_param": {
@@ -1694,24 +2276,453 @@
         },
         "26": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/yahs/yahs/1.2a.2+galaxy2",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy3",
             "errors": null,
             "id": 26,
             "input_connections": {
-                "function|bfile": {
+                "conditions_0|filters_0|bam_property|bam_property_value": {
+                    "id": 14,
+                    "output_name": "out1"
+                },
+                "input_bam": {
                     "id": 25,
                     "output_name": "data_param"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Filter BAM",
+            "outputs": [
+                {
+                    "name": "out_file2",
+                    "type": "txt"
+                },
+                {
+                    "name": "out_file1",
+                    "type": "bam"
+                }
+            ],
+            "position": {
+                "left": 2224.87920716103,
+                "top": 1339.6100858953473
+            },
+            "post_job_actions": {
+                "RenameDatasetActionout_file1": {
+                    "action_arguments": {
+                        "newname": "Filtered H-C Alignments on contigs"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out_file1"
+                },
+                "TagDatasetActionout_file1": {
+                    "action_arguments": {
+                        "tags": "filtered_alignments_s1"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy3",
+            "tool_shed_repository": {
+                "changeset_revision": "62e4d6cdbaa7",
+                "name": "bamtools_filter",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"conditions\": [{\"__index__\": 0, \"filters\": [{\"__index__\": 0, \"bam_property\": {\"bam_property_selector\": \"mapQuality\", \"__current_case__\": 14, \"bam_property_value\": {\"__class__\": \"ConnectedValue\"}}}]}], \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"rule_configuration\": {\"rules_selector\": \"false\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.5.2+galaxy3",
+            "type": "tool",
+            "uuid": "d0695b3c-002e-45f7-8bb7-98d3d51b2690",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Filtered H-C Alignments on contigs",
+                    "output_name": "out_file1",
+                    "uuid": "ca98e7ae-8802-442f-b519-e683fd13bf0f"
+                }
+            ]
+        },
+        "27": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_sort/samtools_sort/2.0.7",
+            "errors": null,
+            "id": 27,
+            "input_connections": {
+                "input1": {
+                    "id": 25,
+                    "output_name": "data_param"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Samtools sort",
+            "outputs": [
+                {
+                    "name": "output1",
+                    "type": "bam"
+                }
+            ],
+            "position": {
+                "left": 2219.3376244545107,
+                "top": 1767.0350150378667
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionoutput1": {
+                    "action_arguments": {
+                        "newtype": "qname_sorted.bam"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "output1"
+                },
+                "HideDatasetActionoutput1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output1"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_sort/samtools_sort/2.0.7",
+            "tool_shed_repository": {
+                "changeset_revision": "f2f2650aeade",
+                "name": "samtools_sort",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"minhash\": false, \"prim_key_cond\": {\"prim_key_select\": \"-n\", \"__current_case__\": 1}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.0.7",
+            "type": "tool",
+            "uuid": "0fba553a-4e04-4f00-98e8-d168a03dba68",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "28": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_map/pretext_map/0.1.9+galaxy1",
+            "errors": null,
+            "id": 28,
+            "input_connections": {
+                "input": {
+                    "id": 25,
+                    "output_name": "data_param"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "PretextMap",
+            "outputs": [
+                {
+                    "name": "pretext_map_out",
+                    "type": "pretext"
+                }
+            ],
+            "position": {
+                "left": 3018.2926476132297,
+                "top": 1653.0680717857417
+            },
+            "post_job_actions": {
+                "TagDatasetActionpretext_map_out": {
+                    "action_arguments": {
+                        "tags": "pretextmap_s1, #s1"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "pretext_map_out"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_map/pretext_map/0.1.9+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "0346286a3b0a",
+                "name": "pretext_map",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"filter\": {\"filter_type\": \"\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"map_qual\": \"20\", \"sorting\": {\"sortby\": \"nosort\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.1.9+galaxy1",
+            "type": "tool",
+            "uuid": "357b7d30-1c06-40c5-813d-ea009d3c33e7",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "29": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/3.1.1.0",
+            "errors": null,
+            "id": 29,
+            "input_connections": {
+                "inputFile": {
+                    "id": 26,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "MarkDuplicates",
+            "outputs": [
+                {
+                    "name": "metrics_file",
+                    "type": "txt"
+                },
+                {
+                    "name": "outFile",
+                    "type": "bam"
+                }
+            ],
+            "position": {
+                "left": 2461.0480354243323,
+                "top": 782.8178161717558
+            },
+            "post_job_actions": {
+                "RenameDatasetActionmetrics_file": {
+                    "action_arguments": {
+                        "newname": "Markdup Stats"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "metrics_file"
+                },
+                "RenameDatasetActionoutFile": {
+                    "action_arguments": {
+                        "newname": "Deduplicated Hi-C Alignments"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "outFile"
+                },
+                "TagDatasetActionmetrics_file": {
+                    "action_arguments": {
+                        "tags": "markdup_stats"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "metrics_file"
+                },
+                "TagDatasetActionoutFile": {
+                    "action_arguments": {
+                        "tags": "deduplicated_hic"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "outFile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/3.1.1.0",
+            "tool_shed_repository": {
+                "changeset_revision": "3f254c5ced1d",
+                "name": "picard",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"assume_sorted\": false, \"barcode_tag\": null, \"comments\": [], \"duplicate_scoring_strategy\": \"SUM_OF_BASE_QUALITIES\", \"inputFile\": {\"__class__\": \"ConnectedValue\"}, \"optical_duplicate_pixel_distance\": \"2500\", \"read_name_regex\": \"\", \"remove_duplicates\": true, \"validation_stringency\": \"LENIENT\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "3.1.1.0",
+            "type": "tool",
+            "uuid": "68c17fe9-1f3c-4168-929e-57d563313dad",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Markdup Stats",
+                    "output_name": "metrics_file",
+                    "uuid": "331abd05-d39d-4ddc-b862-e1e8382686e8"
+                },
+                {
+                    "label": "Deduplicated Hi-C Alignments",
+                    "output_name": "outFile",
+                    "uuid": "09cc15ff-558c-4ffc-bcd7-fc4f9a82c223"
+                }
+            ]
+        },
+        "30": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pairtools_parse/pairtools_parse/1.1.3+galaxy5",
+            "errors": null,
+            "id": 30,
+            "input_connections": {
+                "assembly_name": {
+                    "id": 1,
+                    "output_name": "output"
+                },
+                "chroms_path": {
+                    "id": 22,
+                    "output_name": "out_file1"
+                },
+                "sam_path": {
+                    "id": 27,
+                    "output_name": "output1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Pairtools parse",
+            "outputs": [
+                {
+                    "name": "output_parsed_pairs",
+                    "type": "4dn_pairsam"
+                },
+                {
+                    "name": "parsed_pairs_stats",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 2552.2139437895576,
+                "top": 1993.0849804014304
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput_parsed_pairs": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_parsed_pairs"
+                },
+                "HideDatasetActionparsed_pairs_stats": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "parsed_pairs_stats"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pairtools_parse/pairtools_parse/1.1.3+galaxy5",
+            "tool_shed_repository": {
+                "changeset_revision": "987ed7d8e152",
+                "name": "pairtools_parse",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"assembly_name\": {\"__class__\": \"ConnectedValue\"}, \"chroms_path\": {\"__class__\": \"ConnectedValue\"}, \"compress_output\": true, \"drop_readid\": false, \"drop_sam\": true, \"drop_seq\": false, \"max_inter_algn_gap\": \"20\", \"max_molecule_size\": \"2000\", \"min_mapq\": \"1\", \"output_stats\": true, \"sam_path\": {\"__class__\": \"ConnectedValue\"}, \"select_add_columns\": {\"add_columns_selection\": \"no\", \"__current_case__\": 1}, \"sort_output\": true, \"walks_policy\": \"mask\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.3+galaxy5",
+            "type": "tool",
+            "uuid": "5a3d50ea-1492-40b4-bbcb-fe15434b6816",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "31": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_snapshot/pretext_snapshot/0.0.5+galaxy0",
+            "errors": null,
+            "id": 31,
+            "input_connections": {
+                "input": {
+                    "id": 28,
+                    "output_name": "pretext_map_out"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Pretext Snapshot",
+            "outputs": [
+                {
+                    "name": "pretext_snap_out",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3326.3450888623306,
+                "top": 1734.6093796344633
+            },
+            "post_job_actions": {
+                "HideDatasetActionpretext_snap_out": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "pretext_snap_out"
+                },
+                "TagDatasetActionpretext_snap_out": {
+                    "action_arguments": {
+                        "tags": "pretext_s1"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "pretext_snap_out"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_snapshot/pretext_snapshot/0.0.5+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "9ec9c22767c8",
+                "name": "pretext_snapshot",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"colormap\": \"8\", \"formats\": {\"outformat\": \"png\", \"__current_case__\": 0}, \"grid\": {\"showGrid\": \"yes\", \"__current_case__\": 0, \"gridsize\": \"1\", \"gridcolor\": \"black\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"mintexels\": \"64\", \"resolution\": \"1000\", \"sequencenames\": false, \"sequences\": \"=full\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.0.5+galaxy0",
+            "type": "tool",
+            "uuid": "0d79214f-0f8b-4d4f-b836-9935dd334da8",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "32": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.5+galaxy2",
+            "errors": null,
+            "id": 32,
+            "input_connections": {
+                "infile": {
+                    "id": 29,
+                    "output_name": "metrics_file"
+                }
+            },
+            "inputs": [],
+            "label": "Deduplication Summary",
+            "name": "Search in textfiles",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2839.002731850677,
+                "top": 0
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                },
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "Markduplicates Summary"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.5+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "c41d78ae5fee",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"case_sensitive\": \"-i\", \"color\": \"NOCOLOR\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"invert\": \"\", \"lines_after\": \"2\", \"lines_before\": \"0\", \"regex_type\": \"-G\", \"url_paste\": \"## METRICS CLASS\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "9.5+galaxy2",
+            "type": "tool",
+            "uuid": "4f792590-575c-4b69-993a-e5aefd4371cf",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "33": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/yahs/yahs/1.2a.2+galaxy2",
+            "errors": null,
+            "id": 33,
+            "input_connections": {
+                "function|bfile": {
+                    "id": 29,
+                    "output_name": "outFile"
                 },
                 "function|enzyme_conditional|preconfigured_enzymes": {
                     "id": 9,
                     "output_name": "output"
                 },
                 "function|fasta": {
-                    "id": 13,
+                    "id": 11,
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool YAHS",
+                    "name": "function"
+                },
+                {
+                    "description": "runtime parameter for tool YAHS",
+                    "name": "function"
+                },
+                {
+                    "description": "runtime parameter for tool YAHS",
+                    "name": "function"
+                }
+            ],
             "label": null,
             "name": "YAHS",
             "outputs": [
@@ -1741,8 +2752,8 @@
                 }
             ],
             "position": {
-                "left": 2580,
-                "top": 132.82559902530076
+                "left": 2832.2727259236954,
+                "top": 470.32668644346495
             },
             "post_job_actions": {
                 "HideDatasetActionfinal_fasta_out": {
@@ -1792,22 +2803,27 @@
                 }
             ]
         },
-        "27": {
+        "34": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.7",
             "errors": null,
-            "id": 27,
+            "id": 34,
             "input_connections": {
                 "addref_cond|ref": {
-                    "id": 13,
+                    "id": 11,
                     "output_name": "output"
                 },
                 "input": {
-                    "id": 25,
-                    "output_name": "data_param"
+                    "id": 29,
+                    "output_name": "outFile"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Samtools stats",
+                    "name": "addref_cond"
+                }
+            ],
             "label": "Hi-C Alignment Stats pre-scaffolding",
             "name": "Samtools stats",
             "outputs": [
@@ -1817,8 +2833,8 @@
                 }
             ],
             "position": {
-                "left": 2800,
-                "top": 1012.8255990253008
+                "left": 2853.3182732880587,
+                "top": 1367.884773997814
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -1856,69 +2872,27 @@
                 }
             ]
         },
-        "28": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_map/pretext_map/0.1.9+galaxy1",
-            "errors": null,
-            "id": 28,
-            "input_connections": {
-                "input": {
-                    "id": 25,
-                    "output_name": "data_param"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "PretextMap",
-            "outputs": [
-                {
-                    "name": "pretext_map_out",
-                    "type": "pretext"
-                }
-            ],
-            "position": {
-                "left": 2820,
-                "top": 1362.8255990253008
-            },
-            "post_job_actions": {
-                "TagDatasetActionpretext_map_out": {
-                    "action_arguments": {
-                        "tags": "pretextmap_s1, #s1"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "pretext_map_out"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_map/pretext_map/0.1.9+galaxy1",
-            "tool_shed_repository": {
-                "changeset_revision": "0346286a3b0a",
-                "name": "pretext_map",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"filter\": {\"filter_type\": \"\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"map_qual\": \"20\", \"sorting\": {\"sortby\": \"nosort\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.1.9+galaxy1",
-            "type": "tool",
-            "uuid": "357b7d30-1c06-40c5-813d-ea009d3c33e7",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "29": {
+        "35": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.7",
             "errors": null,
-            "id": 29,
+            "id": 35,
             "input_connections": {
                 "addref_cond|ref": {
-                    "id": 13,
+                    "id": 11,
                     "output_name": "output"
                 },
                 "input": {
-                    "id": 25,
-                    "output_name": "data_param"
+                    "id": 29,
+                    "output_name": "outFile"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Samtools stats",
+                    "name": "addref_cond"
+                }
+            ],
             "label": "Hi-C Alignment Stats contigs summary",
             "name": "Samtools stats",
             "outputs": [
@@ -1929,7 +2903,7 @@
             ],
             "position": {
                 "left": 4848.7423480246025,
-                "top": 2736.4460142140706
+                "top": 2989.562981201546
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_collection": {
@@ -1966,18 +2940,202 @@
             "when": null,
             "workflow_outputs": []
         },
-        "30": {
+        "36": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pairtools_dedup/pairtools_dedup/1.1.3+galaxy5",
+            "errors": null,
+            "id": 36,
+            "input_connections": {
+                "pairs_path": {
+                    "id": 30,
+                    "output_name": "output_parsed_pairs"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Pairtools dedup",
+            "outputs": [
+                {
+                    "name": "output_dedup_pairs",
+                    "type": "input"
+                },
+                {
+                    "name": "dedup_pairs_stats",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 2929.499461996689,
+                "top": 2249.9611695039976
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput_dedup_pairs": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_dedup_pairs"
+                },
+                "RenameDatasetActiondedup_pairs_stats": {
+                    "action_arguments": {
+                        "newname": "Hi-C duplication stats: Raw"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "dedup_pairs_stats"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pairtools_dedup/pairtools_dedup/1.1.3+galaxy5",
+            "tool_shed_repository": {
+                "changeset_revision": "52c601d961b6",
+                "name": "pairtools_dedup",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"compress_output\": true, \"mark_dups\": true, \"max_mismatch\": \"0\", \"output_bytile_stats\": false, \"output_dups\": false, \"output_stats\": true, \"pairs_path\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.1.3+galaxy5",
+            "type": "tool",
+            "uuid": "cedcd244-d3d8-4274-9108-62ae37687a73",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Hi-C duplication stats: Raw",
+                    "output_name": "dedup_pairs_stats",
+                    "uuid": "eea17d44-d831-46c5-a927-633a57c5ef2c"
+                }
+            ]
+        },
+        "37": {
+            "annotation": "",
+            "content_id": "__EXTRACT_DATASET__",
+            "errors": null,
+            "id": 37,
+            "input_connections": {
+                "input": {
+                    "id": 31,
+                    "output_name": "pretext_snap_out"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Extract dataset",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "data"
+                }
+            ],
+            "position": {
+                "left": 3632.1624179889664,
+                "top": 1668.7014646588236
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionoutput": {
+                    "action_arguments": {
+                        "newtype": "png"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "output"
+                },
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "PretextMap Before scaffolding"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                },
+                "TagDatasetActionoutput": {
+                    "action_arguments": {
+                        "tags": "pretext_s1"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__EXTRACT_DATASET__",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"which\": {\"which_dataset\": \"first\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.2",
+            "type": "tool",
+            "uuid": "d99db0c7-f705-4861-92a8-2f49b3e597e4",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Pretext Map Before HiC scaffolding",
+                    "output_name": "output",
+                    "uuid": "40c397f4-282b-46b3-8e73-56475a411cf5"
+                }
+            ]
+        },
+        "38": {
+            "annotation": "",
+            "content_id": "Show tail1",
+            "errors": null,
+            "id": 38,
+            "input_connections": {
+                "input": {
+                    "id": 32,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Select last",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3095.9999309826662,
+                "top": 173.1390984933681
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionout_file1": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "out_file1"
+                },
+                "RenameDatasetActionout_file1": {
+                    "action_arguments": {
+                        "newname": "Markduplicates Summary"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out_file1"
+                },
+                "TagDatasetActionout_file1": {
+                    "action_arguments": {
+                        "tags": "markdup_summ"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "Show tail1",
+            "tool_state": "{\"header\": false, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineNum\": \"2\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.1",
+            "type": "tool",
+            "uuid": "cff7b42c-9997-4812-88d9-d4a190a41f10",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Markduplicates Summary",
+                    "output_name": "out_file1",
+                    "uuid": "87bae5b3-e95d-4454-886d-146b697b5250"
+                }
+            ]
+        },
+        "39": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy2",
             "errors": null,
-            "id": 30,
+            "id": 39,
             "input_connections": {
                 "find_and_replace_0|replace_pattern": {
                     "id": 20,
                     "output_name": "out1"
                 },
                 "infile": {
-                    "id": 26,
+                    "id": 33,
                     "output_name": "final_agp_out"
                 }
             },
@@ -1991,8 +3149,8 @@
                 }
             ],
             "position": {
-                "left": 2830,
-                "top": 602.8255990253008
+                "left": 3097.6020957967994,
+                "top": 796.8812741438992
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -2021,66 +3179,14 @@
                 }
             ]
         },
-        "31": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_snapshot/pretext_snapshot/0.0.5+galaxy0",
-            "errors": null,
-            "id": 31,
-            "input_connections": {
-                "input": {
-                    "id": 28,
-                    "output_name": "pretext_map_out"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Pretext Snapshot",
-            "outputs": [
-                {
-                    "name": "pretext_snap_out",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 3070,
-                "top": 1112.8255990253008
-            },
-            "post_job_actions": {
-                "HideDatasetActionpretext_snap_out": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "pretext_snap_out"
-                },
-                "TagDatasetActionpretext_snap_out": {
-                    "action_arguments": {
-                        "tags": "pretext_s1"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "pretext_snap_out"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_snapshot/pretext_snapshot/0.0.5+galaxy0",
-            "tool_shed_repository": {
-                "changeset_revision": "9ec9c22767c8",
-                "name": "pretext_snapshot",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"colormap\": \"8\", \"formats\": {\"outformat\": \"png\", \"__current_case__\": 0}, \"grid\": {\"showGrid\": \"yes\", \"__current_case__\": 0, \"gridsize\": \"1\", \"gridcolor\": \"black\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"mintexels\": \"64\", \"resolution\": \"1000\", \"sequencenames\": false, \"sequences\": \"=full\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.0.5+galaxy0",
-            "type": "tool",
-            "uuid": "0d79214f-0f8b-4d4f-b836-9935dd334da8",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "32": {
+        "40": {
             "annotation": "",
             "content_id": "__EXTRACT_DATASET__",
             "errors": null,
-            "id": 32,
+            "id": 40,
             "input_connections": {
                 "input": {
-                    "id": 29,
+                    "id": 35,
                     "output_name": "output_collection"
                 }
             },
@@ -2094,8 +3200,8 @@
                 }
             ],
             "position": {
-                "left": 5296.718632938909,
-                "top": 2790.637362164681
+                "left": 6096.790414176621,
+                "top": 3417.345746404967
             },
             "post_job_actions": {
                 "ChangeDatatypeActionoutput": {
@@ -2132,22 +3238,94 @@
                 }
             ]
         },
-        "33": {
+        "41": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy3",
+            "errors": null,
+            "id": 41,
+            "input_connections": {
+                "results_0|software_cond|input": {
+                    "id": 36,
+                    "output_name": "dedup_pairs_stats"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool MultiQC",
+                    "name": "image_content_input"
+                }
+            ],
+            "label": null,
+            "name": "MultiQC",
+            "outputs": [
+                {
+                    "name": "html_report",
+                    "type": "html"
+                },
+                {
+                    "name": "stats",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 3251.6967900366653,
+                "top": 2329.757922439029
+            },
+            "post_job_actions": {
+                "HideDatasetActionstats": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "stats"
+                },
+                "RenameDatasetActionhtml_report": {
+                    "action_arguments": {
+                        "newname": "Hi-C duplication stats: MultiQc"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "html_report"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy3",
+            "tool_shed_repository": {
+                "changeset_revision": "31c42a2c02d3",
+                "name": "multiqc",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"image_content_input\": {\"__class__\": \"RuntimeValue\"}, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"pairtools\", \"__current_case__\": 37, \"input\": {\"__class__\": \"ConnectedValue\"}}}], \"title\": \"Hi-C alignements to Scaffold stats\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.27+galaxy3",
+            "type": "tool",
+            "uuid": "6a652dc4-1ed5-4317-9927-d450b8f185bf",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Hi-C duplication stats: MultiQc",
+                    "output_name": "html_report",
+                    "uuid": "2d7cbb04-9cf2-4e62-a614-76891e9226d8"
+                }
+            ]
+        },
+        "42": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/gfastats/gfastats/1.3.11+galaxy0",
             "errors": null,
-            "id": 33,
+            "id": 42,
             "input_connections": {
                 "input_file": {
                     "id": 2,
                     "output_name": "output"
                 },
                 "mode_condition|agp_to_path": {
-                    "id": 30,
+                    "id": 39,
                     "output_name": "outfile"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool gfastats",
+                    "name": "mode_condition"
+                }
+            ],
             "label": null,
             "name": "gfastats",
             "outputs": [
@@ -2157,8 +3335,8 @@
                 }
             ],
             "position": {
-                "left": 3094.7258486125843,
-                "top": 169.60721977132718
+                "left": 3404.9715576171875,
+                "top": 433.0980562042723
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -2196,22 +3374,27 @@
                 }
             ]
         },
-        "34": {
+        "43": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/gfastats/gfastats/1.3.11+galaxy0",
             "errors": null,
-            "id": 34,
+            "id": 43,
             "input_connections": {
                 "input_file": {
                     "id": 2,
                     "output_name": "output"
                 },
                 "mode_condition|agp_to_path": {
-                    "id": 30,
+                    "id": 39,
                     "output_name": "outfile"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool gfastats",
+                    "name": "mode_condition"
+                }
+            ],
             "label": null,
             "name": "gfastats",
             "outputs": [
@@ -2221,8 +3404,8 @@
                 }
             ],
             "position": {
-                "left": 3106.3623492483616,
-                "top": 526.4068145056176
+                "left": 3372.961365042402,
+                "top": 983.6975256145447
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -2260,61 +3443,14 @@
                 }
             ]
         },
-        "35": {
-            "annotation": "",
-            "content_id": "__EXTRACT_DATASET__",
-            "errors": null,
-            "id": 35,
-            "input_connections": {
-                "input": {
-                    "id": 31,
-                    "output_name": "pretext_snap_out"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Extract dataset",
-            "outputs": [
-                {
-                    "name": "output",
-                    "type": "data"
-                }
-            ],
-            "position": {
-                "left": 3410,
-                "top": 1372.8255990253008
-            },
-            "post_job_actions": {
-                "TagDatasetActionoutput": {
-                    "action_arguments": {
-                        "tags": "pretext_s1"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "output"
-                }
-            },
-            "tool_id": "__EXTRACT_DATASET__",
-            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"which\": {\"which_dataset\": \"first\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.2",
-            "type": "tool",
-            "uuid": "d99db0c7-f705-4861-92a8-2f49b3e597e4",
-            "when": null,
-            "workflow_outputs": [
-                {
-                    "label": "Pretext Map Before HiC scaffolding",
-                    "output_name": "output",
-                    "uuid": "40c397f4-282b-46b3-8e73-56475a411cf5"
-                }
-            ]
-        },
-        "36": {
+        "44": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_tail_tool/9.5+galaxy2",
             "errors": null,
-            "id": 36,
+            "id": 44,
             "input_connections": {
                 "infile": {
-                    "id": 32,
+                    "id": 40,
                     "output_name": "output"
                 }
             },
@@ -2328,8 +3464,8 @@
                 }
             ],
             "position": {
-                "left": 5484.269940863294,
-                "top": 3031.725172004136
+                "left": 6284.341722101007,
+                "top": 3658.433556244422
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -2352,18 +3488,76 @@
             "when": null,
             "workflow_outputs": []
         },
-        "37": {
+        "45": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/gfastats/gfastats/1.3.11+galaxy0",
             "errors": null,
-            "id": 37,
+            "id": 45,
             "input_connections": {
                 "input_file": {
-                    "id": 34,
+                    "id": 42,
                     "output_name": "output"
                 }
             },
             "inputs": [],
+            "label": null,
+            "name": "gfastats",
+            "outputs": [
+                {
+                    "name": "stats",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 4141.2926025390625,
+                "top": 229.36227739567855
+            },
+            "post_job_actions": {
+                "TagDatasetActionstats": {
+                    "action_arguments": {
+                        "tags": "gfastats_scaffolds_s2, #s2"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "stats"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/gfastats/gfastats/1.3.11+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "59150c883ed5",
+                "name": "gfastats",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"mode_condition\": {\"selector\": \"statistics\", \"__current_case__\": 1, \"statistics_condition\": {\"selector\": \"size\", \"__current_case__\": 0, \"out_size\": \"s\"}, \"locale\": false, \"tabular\": true, \"discover_paths\": false}, \"target_condition\": {\"target_option\": \"false\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.3.11+galaxy0",
+            "type": "tool",
+            "uuid": "b6926854-bb2c-485c-afb8-65bf43d62536",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Scaffold sizes for s2",
+                    "output_name": "stats",
+                    "uuid": "b651f4bd-5dc8-4a29-a984-b6a2c10ff0b4"
+                }
+            ]
+        },
+        "46": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/gfastats/gfastats/1.3.11+galaxy0",
+            "errors": null,
+            "id": 46,
+            "input_connections": {
+                "input_file": {
+                    "id": 43,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool gfastats",
+                    "name": "mode_condition"
+                }
+            ],
             "label": null,
             "name": "gfastats",
             "outputs": [
@@ -2373,8 +3567,8 @@
                 }
             ],
             "position": {
-                "left": 3434.509557789402,
-                "top": 738.1298855626042
+                "left": 3694.6583646048007,
+                "top": 902.4384942494803
             },
             "post_job_actions": {
                 "TagDatasetActionoutput": {
@@ -2405,71 +3599,18 @@
                 }
             ]
         },
-        "38": {
+        "47": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/gfastats/gfastats/1.3.11+galaxy0",
             "errors": null,
-            "id": 38,
+            "id": 47,
             "input_connections": {
                 "input_file": {
-                    "id": 34,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "gfastats",
-            "outputs": [
-                {
-                    "name": "stats",
-                    "type": "tabular"
-                }
-            ],
-            "position": {
-                "left": 3948.231436790109,
-                "top": 478.6222575397917
-            },
-            "post_job_actions": {
-                "TagDatasetActionstats": {
-                    "action_arguments": {
-                        "tags": "gfastats_scaffolds_s2, #s2"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "stats"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/gfastats/gfastats/1.3.11+galaxy0",
-            "tool_shed_repository": {
-                "changeset_revision": "59150c883ed5",
-                "name": "gfastats",
-                "owner": "bgruening",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"mode_condition\": {\"selector\": \"statistics\", \"__current_case__\": 1, \"statistics_condition\": {\"selector\": \"size\", \"__current_case__\": 0, \"out_size\": \"s\"}, \"locale\": false, \"tabular\": true, \"discover_paths\": false}, \"target_condition\": {\"target_option\": \"false\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.3.11+galaxy0",
-            "type": "tool",
-            "uuid": "6b973613-a8f7-497a-a7e1-203affa3690b",
-            "when": null,
-            "workflow_outputs": [
-                {
-                    "label": "Scaffold sizes for s2",
-                    "output_name": "stats",
-                    "uuid": "b651f4bd-5dc8-4a29-a984-b6a2c10ff0b4"
-                }
-            ]
-        },
-        "39": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/gfastats/gfastats/1.3.11+galaxy0",
-            "errors": null,
-            "id": 39,
-            "input_connections": {
-                "input_file": {
-                    "id": 34,
+                    "id": 43,
                     "output_name": "output"
                 },
                 "mode_condition|statistics_condition|expected_genomesize": {
-                    "id": 18,
+                    "id": 17,
                     "output_name": "integer_param"
                 }
             },
@@ -2484,7 +3625,7 @@
             ],
             "position": {
                 "left": 3900,
-                "top": 1720
+                "top": 1973.116966987475
             },
             "post_job_actions": {
                 "TagDatasetActionstats": {
@@ -2515,14 +3656,14 @@
                 }
             ]
         },
-        "40": {
+        "48": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy2",
             "errors": null,
-            "id": 40,
+            "id": 48,
             "input_connections": {
                 "infile": {
-                    "id": 36,
+                    "id": 44,
                     "output_name": "outfile"
                 }
             },
@@ -2536,8 +3677,8 @@
                 }
             ],
             "position": {
-                "left": 5700.060306105712,
-                "top": 2903.8964794328735
+                "left": 6500.132087343424,
+                "top": 3530.60486367316
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy2",
@@ -2554,293 +3695,12 @@
             "when": null,
             "workflow_outputs": []
         },
-        "41": {
+        "49": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bwa_mem2/bwa_mem2/2.3+galaxy0",
-            "errors": null,
-            "id": 41,
-            "input_connections": {
-                "fastq_input|fastq_input1": {
-                    "id": 19,
-                    "output_name": "Trimmed Hi-C data"
-                },
-                "reference_source|ref_file": {
-                    "id": 37,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "BWA-MEM2",
-            "outputs": [
-                {
-                    "name": "bam_output",
-                    "type": "bam"
-                }
-            ],
-            "position": {
-                "left": 3689.946743243398,
-                "top": 992.0598942125396
-            },
-            "post_job_actions": {
-                "HideDatasetActionbam_output": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "bam_output"
-                },
-                "RenameDatasetActionbam_output": {
-                    "action_arguments": {
-                        "newname": "Merged Hi-C Alignments"
-                    },
-                    "action_type": "RenameDatasetAction",
-                    "output_name": "bam_output"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bwa_mem2/bwa_mem2/2.3+galaxy0",
-            "tool_shed_repository": {
-                "changeset_revision": "af91699b8d4c",
-                "name": "bwa_mem2",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"analysis_type\": {\"analysis_type_selector\": \"full\", \"__current_case__\": 4, \"algorithmic_options\": {\"algorithmic_options_selector\": \"set\", \"__current_case__\": 0, \"k\": \"19\", \"w\": \"100\", \"d\": \"100\", \"r\": \"1.5\", \"y\": \"20\", \"c\": \"500\", \"D\": \"0.5\", \"W\": \"0\", \"m\": \"50\", \"S\": true, \"P\": true, \"e\": false}, \"scoring_options\": {\"scoring_options_selector\": \"do_not_set\", \"__current_case__\": 1}, \"io_options\": {\"io_options_selector\": \"set\", \"__current_case__\": 0, \"five\": true, \"q\": false, \"T\": \"30\", \"h\": \"5\", \"a\": false, \"C\": false, \"V\": false, \"Y\": false, \"M\": false, \"K\": null}}, \"fastq_input\": {\"fastq_input_selector\": \"paired_collection\", \"__current_case__\": 2, \"fastq_input1\": {\"__class__\": \"ConnectedValue\"}, \"iset_stats\": null}, \"output_sort\": \"coordinate\", \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"ConnectedValue\"}}, \"rg\": {\"rg_selector\": \"do_not_set\", \"__current_case__\": 3}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.3+galaxy0",
-            "type": "tool",
-            "uuid": "6b35b1f3-b654-4ef2-82cc-ea9d5c55f0ac",
-            "when": null,
-            "workflow_outputs": [
-                {
-                    "label": "Hi-C Alignments",
-                    "output_name": "bam_output",
-                    "uuid": "16019374-1e25-4b5b-a89e-a9a4fe7dcb95"
-                }
-            ]
-        },
-        "42": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/5.8.0+galaxy1",
-            "errors": null,
-            "id": 42,
-            "input_connections": {
-                "cached_db": {
-                    "id": 7,
-                    "output_name": "output"
-                },
-                "input": {
-                    "id": 37,
-                    "output_name": "output"
-                },
-                "lineage|lineage_dataset": {
-                    "id": 8,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Busco",
-            "outputs": [
-                {
-                    "name": "busco_sum",
-                    "type": "txt"
-                },
-                {
-                    "name": "busco_table",
-                    "type": "tabular"
-                },
-                {
-                    "name": "busco_missing",
-                    "type": "tabular"
-                },
-                {
-                    "name": "summary_image",
-                    "type": "png"
-                },
-                {
-                    "name": "busco_gff",
-                    "type": "gff3"
-                }
-            ],
-            "position": {
-                "left": 4383.630380662751,
-                "top": 502.80723157808995
-            },
-            "post_job_actions": {
-                "TagDatasetActionbusco_gff": {
-                    "action_arguments": {
-                        "tags": "busco_s2_gff"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "busco_gff"
-                },
-                "TagDatasetActionbusco_missing": {
-                    "action_arguments": {
-                        "tags": "busco_s2_missing"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "busco_missing"
-                },
-                "TagDatasetActionbusco_sum": {
-                    "action_arguments": {
-                        "tags": "busco_s2_summ"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "busco_sum"
-                },
-                "TagDatasetActionbusco_table": {
-                    "action_arguments": {
-                        "tags": " busco_s2_full"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "busco_table"
-                },
-                "TagDatasetActionsummary_image": {
-                    "action_arguments": {
-                        "tags": "busco_s2_img"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "summary_image"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/5.8.0+galaxy1",
-            "tool_shed_repository": {
-                "changeset_revision": "4e70d88adf2f",
-                "name": "busco",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"adv\": {\"evalue\": \"0.001\", \"limit\": \"3\", \"contig_break\": \"10\"}, \"busco_mode\": {\"mode\": \"geno\", \"__current_case__\": 0, \"use_augustus\": {\"use_augustus_selector\": \"metaeuk\", \"__current_case__\": 0}}, \"cached_db\": {\"__class__\": \"ConnectedValue\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineage\": {\"lineage_mode\": \"select_lineage\", \"__current_case__\": 1, \"lineage_dataset\": {\"__class__\": \"ConnectedValue\"}}, \"outputs\": [\"short_summary\", \"missing\", \"image\", \"gff\"], \"test\": null, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "5.8.0+galaxy1",
-            "type": "tool",
-            "uuid": "c30b907f-05c9-4709-a939-b66f52daf6e4",
-            "when": null,
-            "workflow_outputs": [
-                {
-                    "label": "Busco Summary image",
-                    "output_name": "summary_image",
-                    "uuid": "cf7a5b93-9021-4029-8107-015787fa2ca5"
-                },
-                {
-                    "label": "Busco Summary",
-                    "output_name": "busco_sum",
-                    "uuid": "49589149-e16f-4a88-9d84-c1b06288021f"
-                }
-            ]
-        },
-        "43": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compleasm/compleasm/0.2.6+galaxy2",
-            "errors": null,
-            "id": 43,
-            "input_connections": {
-                "busco_database": {
-                    "id": 7,
-                    "output_name": "output"
-                },
-                "input": {
-                    "id": 37,
-                    "output_name": "output"
-                },
-                "lineage_dataset": {
-                    "id": 8,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "compleasm",
-            "outputs": [
-                {
-                    "name": "full_table_busco",
-                    "type": "tsv"
-                },
-                {
-                    "name": "full_table",
-                    "type": "tsv"
-                },
-                {
-                    "name": "miniprot",
-                    "type": "gff3"
-                },
-                {
-                    "name": "translated_protein",
-                    "type": "fasta"
-                }
-            ],
-            "position": {
-                "left": 4840,
-                "top": 420
-            },
-            "post_job_actions": {
-                "TagDatasetActionfull_table": {
-                    "action_arguments": {
-                        "tags": "compleasm_s2_full"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "full_table"
-                },
-                "TagDatasetActionfull_table_busco": {
-                    "action_arguments": {
-                        "tags": "compleasm_s2_busco"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "full_table_busco"
-                },
-                "TagDatasetActionminiprot": {
-                    "action_arguments": {
-                        "tags": "compleasm_s2_miniprot"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "miniprot"
-                },
-                "TagDatasetActiontranslated_protein": {
-                    "action_arguments": {
-                        "tags": "compleasm_s2_protein"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "translated_protein"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/compleasm/compleasm/0.2.6+galaxy2",
-            "tool_shed_repository": {
-                "changeset_revision": "7109a27a11db",
-                "name": "compleasm",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"busco_database\": {\"__class__\": \"ConnectedValue\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineage_dataset\": {\"__class__\": \"ConnectedValue\"}, \"mode\": \"busco\", \"outputs\": [\"full_table_busco\", \"full_table\", \"miniprot\", \"translated_protein\"], \"specified_contigs\": null, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "0.2.6+galaxy2",
-            "type": "tool",
-            "uuid": "debf83e8-6ff7-4e47-9fa5-ab13fa3b79e1",
-            "when": null,
-            "workflow_outputs": [
-                {
-                    "label": "Compleasm translated proteins",
-                    "output_name": "translated_protein",
-                    "uuid": "96498b92-f563-4674-bf8b-1cc4eb47c368"
-                },
-                {
-                    "label": "Compleasm miniprot",
-                    "output_name": "miniprot",
-                    "uuid": "eb7d5b78-b308-46d8-8718-597604c53a4f"
-                },
-                {
-                    "label": "Compleasm Full table",
-                    "output_name": "full_table",
-                    "uuid": "d639dd00-b1f7-497e-9a5d-01cd00dc5bc4"
-                },
-                {
-                    "label": "Compleasm Full Table Busco",
-                    "output_name": "full_table_busco",
-                    "uuid": "3686f2e3-a4c0-4fd5-b8f5-25da225539eb"
-                }
-            ]
-        },
-        "44": {
-            "annotation": "",
-            "id": 44,
+            "id": 49,
             "input_connections": {
                 "gfa_stats": {
-                    "id": 38,
+                    "id": 45,
                     "input_subworkflow_step_id": 0,
                     "output_name": "stats"
                 }
@@ -2850,8 +3710,8 @@
             "name": "gfastats_data_prep",
             "outputs": [],
             "position": {
-                "left": 4592.948668348775,
-                "top": 246.43472522442866
+                "left": 4447.230791326534,
+                "top": 263.54146566637803
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -3208,18 +4068,302 @@
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "d0ccdae0-c2ae-49f7-a517-87a51f835252",
+            "uuid": "fd7d6375-1234-41af-b44b-3bf8d3d97774",
             "when": null,
             "workflow_outputs": []
         },
-        "45": {
+        "50": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bwa_mem2/bwa_mem2_idx/2.3+galaxy0",
+            "errors": null,
+            "id": 50,
+            "input_connections": {
+                "reference": {
+                    "id": 46,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "BWA-MEM2 indexer",
+            "outputs": [
+                {
+                    "name": "index",
+                    "type": "bwa_mem2_index"
+                }
+            ],
+            "position": {
+                "left": 3908.933015683574,
+                "top": 1278.461848815444
+            },
+            "post_job_actions": {
+                "RenameDatasetActionindex": {
+                    "action_arguments": {
+                        "newname": "Scaffold bwa-mem2 index"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "index"
+                },
+                "TagDatasetActionindex": {
+                    "action_arguments": {
+                        "tags": "scaffold_index"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "index"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bwa_mem2/bwa_mem2_idx/2.3+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "af91699b8d4c",
+                "name": "bwa_mem2",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"reference\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.3+galaxy0",
+            "type": "tool",
+            "uuid": "cd7c6069-f459-437a-b01f-0dc2a4eee826",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Scaffold bwa-mem2 index",
+                    "output_name": "index",
+                    "uuid": "2dd51249-13ba-4d92-9fd7-1bd1b732f7cd"
+                }
+            ]
+        },
+        "51": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/5.8.0+galaxy1",
+            "errors": null,
+            "id": 51,
+            "input_connections": {
+                "cached_db": {
+                    "id": 7,
+                    "output_name": "output"
+                },
+                "input": {
+                    "id": 46,
+                    "output_name": "output"
+                },
+                "lineage|lineage_dataset": {
+                    "id": 8,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Busco",
+                    "name": "lineage"
+                }
+            ],
+            "label": null,
+            "name": "Busco",
+            "outputs": [
+                {
+                    "name": "busco_sum",
+                    "type": "txt"
+                },
+                {
+                    "name": "busco_table",
+                    "type": "tabular"
+                },
+                {
+                    "name": "busco_missing",
+                    "type": "tabular"
+                },
+                {
+                    "name": "summary_image",
+                    "type": "png"
+                },
+                {
+                    "name": "busco_gff",
+                    "type": "gff3"
+                }
+            ],
+            "position": {
+                "left": 4383.630380662751,
+                "top": 755.9241985655653
+            },
+            "post_job_actions": {
+                "TagDatasetActionbusco_gff": {
+                    "action_arguments": {
+                        "tags": "busco_s2_gff"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "busco_gff"
+                },
+                "TagDatasetActionbusco_missing": {
+                    "action_arguments": {
+                        "tags": "busco_s2_missing"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "busco_missing"
+                },
+                "TagDatasetActionbusco_sum": {
+                    "action_arguments": {
+                        "tags": "busco_s2_summ"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "busco_sum"
+                },
+                "TagDatasetActionbusco_table": {
+                    "action_arguments": {
+                        "tags": " busco_s2_full"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "busco_table"
+                },
+                "TagDatasetActionsummary_image": {
+                    "action_arguments": {
+                        "tags": "busco_s2_img"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "summary_image"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/busco/busco/5.8.0+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "4e70d88adf2f",
+                "name": "busco",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"adv\": {\"evalue\": \"0.001\", \"limit\": \"3\", \"contig_break\": \"10\"}, \"busco_mode\": {\"mode\": \"geno\", \"__current_case__\": 0, \"use_augustus\": {\"use_augustus_selector\": \"metaeuk\", \"__current_case__\": 0}}, \"cached_db\": {\"__class__\": \"ConnectedValue\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineage\": {\"lineage_mode\": \"select_lineage\", \"__current_case__\": 1, \"lineage_dataset\": {\"__class__\": \"ConnectedValue\"}}, \"outputs\": [\"short_summary\", \"missing\", \"image\", \"gff\"], \"test\": null, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "5.8.0+galaxy1",
+            "type": "tool",
+            "uuid": "c30b907f-05c9-4709-a939-b66f52daf6e4",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Busco Summary",
+                    "output_name": "busco_sum",
+                    "uuid": "49589149-e16f-4a88-9d84-c1b06288021f"
+                },
+                {
+                    "label": "Busco Summary image",
+                    "output_name": "summary_image",
+                    "uuid": "cf7a5b93-9021-4029-8107-015787fa2ca5"
+                }
+            ]
+        },
+        "52": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compleasm/compleasm/0.2.6+galaxy2",
+            "errors": null,
+            "id": 52,
+            "input_connections": {
+                "busco_database": {
+                    "id": 7,
+                    "output_name": "output"
+                },
+                "input": {
+                    "id": 46,
+                    "output_name": "output"
+                },
+                "lineage_dataset": {
+                    "id": 8,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "compleasm",
+            "outputs": [
+                {
+                    "name": "full_table_busco",
+                    "type": "tsv"
+                },
+                {
+                    "name": "full_table",
+                    "type": "tsv"
+                },
+                {
+                    "name": "miniprot",
+                    "type": "gff3"
+                },
+                {
+                    "name": "translated_protein",
+                    "type": "fasta"
+                }
+            ],
+            "position": {
+                "left": 4840,
+                "top": 673.1169669874753
+            },
+            "post_job_actions": {
+                "TagDatasetActionfull_table": {
+                    "action_arguments": {
+                        "tags": "compleasm_s2_full"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "full_table"
+                },
+                "TagDatasetActionfull_table_busco": {
+                    "action_arguments": {
+                        "tags": "compleasm_s2_busco"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "full_table_busco"
+                },
+                "TagDatasetActionminiprot": {
+                    "action_arguments": {
+                        "tags": "compleasm_s2_miniprot"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "miniprot"
+                },
+                "TagDatasetActiontranslated_protein": {
+                    "action_arguments": {
+                        "tags": "compleasm_s2_protein"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "translated_protein"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/compleasm/compleasm/0.2.6+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "7109a27a11db",
+                "name": "compleasm",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"busco_database\": {\"__class__\": \"ConnectedValue\"}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineage_dataset\": {\"__class__\": \"ConnectedValue\"}, \"mode\": \"busco\", \"outputs\": [\"full_table_busco\", \"full_table\", \"miniprot\", \"translated_protein\"], \"specified_contigs\": null, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.2.6+galaxy2",
+            "type": "tool",
+            "uuid": "debf83e8-6ff7-4e47-9fa5-ab13fa3b79e1",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Compleasm miniprot",
+                    "output_name": "miniprot",
+                    "uuid": "eb7d5b78-b308-46d8-8718-597604c53a4f"
+                },
+                {
+                    "label": "Compleasm Full Table Busco",
+                    "output_name": "full_table_busco",
+                    "uuid": "3686f2e3-a4c0-4fd5-b8f5-25da225539eb"
+                },
+                {
+                    "label": "Compleasm Full table",
+                    "output_name": "full_table",
+                    "uuid": "d639dd00-b1f7-497e-9a5d-01cd00dc5bc4"
+                },
+                {
+                    "label": "Compleasm translated proteins",
+                    "output_name": "translated_protein",
+                    "uuid": "96498b92-f563-4674-bf8b-1cc4eb47c368"
+                }
+            ]
+        },
+        "53": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy2",
             "errors": null,
-            "id": 45,
+            "id": 53,
             "input_connections": {
                 "infile": {
-                    "id": 39,
+                    "id": 47,
                     "output_name": "stats"
                 }
             },
@@ -3234,7 +4378,7 @@
             ],
             "position": {
                 "left": 4190,
-                "top": 1890
+                "top": 2143.1169669874753
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -3263,82 +4407,14 @@
                 }
             ]
         },
-        "46": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy3",
-            "errors": null,
-            "id": 46,
-            "input_connections": {
-                "conditions_0|filters_0|bam_property|bam_property_value": {
-                    "id": 16,
-                    "output_name": "out1"
-                },
-                "input_bam": {
-                    "id": 41,
-                    "output_name": "bam_output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Filter BAM",
-            "outputs": [
-                {
-                    "name": "out_file2",
-                    "type": "txt"
-                },
-                {
-                    "name": "out_file1",
-                    "type": "bam"
-                }
-            ],
-            "position": {
-                "left": 3955.0698349040376,
-                "top": 1128.100760143182
-            },
-            "post_job_actions": {
-                "RenameDatasetActionout_file1": {
-                    "action_arguments": {
-                        "newname": "Filtered H-C Alignments on scaffolds"
-                    },
-                    "action_type": "RenameDatasetAction",
-                    "output_name": "out_file1"
-                },
-                "TagDatasetActionout_file1": {
-                    "action_arguments": {
-                        "tags": "filtered_alignments_s2"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "out_file1"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy3",
-            "tool_shed_repository": {
-                "changeset_revision": "62e4d6cdbaa7",
-                "name": "bamtools_filter",
-                "owner": "devteam",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"conditions\": [{\"__index__\": 0, \"filters\": [{\"__index__\": 0, \"bam_property\": {\"bam_property_selector\": \"mapQuality\", \"__current_case__\": 14, \"bam_property_value\": {\"__class__\": \"ConnectedValue\"}}}]}], \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"rule_configuration\": {\"rules_selector\": \"false\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.5.2+galaxy3",
-            "type": "tool",
-            "uuid": "2d146ae2-f29a-4883-ac39-4bdf5f8dff18",
-            "when": null,
-            "workflow_outputs": [
-                {
-                    "label": "Filtered H-C Alignments on scaffolds",
-                    "output_name": "out_file1",
-                    "uuid": "79fad504-8aaf-4fad-93d6-dc85d9102612"
-                }
-            ]
-        },
-        "47": {
+        "54": {
             "annotation": "",
             "content_id": "Cut1",
             "errors": null,
-            "id": 47,
+            "id": 54,
             "input_connections": {
                 "input": {
-                    "id": 44,
+                    "id": 49,
                     "output_name": "gfastats data for plotting"
                 }
             },
@@ -3352,8 +4428,41 @@
                 }
             ],
             "position": {
-                "left": 5023.4375,
-                "top": 236.2881539569414
+                "left": 4885.672895993854,
+                "top": 170.95463971075228
+            },
+            "post_job_actions": {},
+            "tool_id": "Cut1",
+            "tool_state": "{\"columnList\": \"c5,c6\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.2",
+            "type": "tool",
+            "uuid": "90d82f51-741b-4ec7-97d2-62fa92e9efad",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "55": {
+            "annotation": "",
+            "content_id": "Cut1",
+            "errors": null,
+            "id": 55,
+            "input_connections": {
+                "input": {
+                    "id": 49,
+                    "output_name": "gfastats data for plotting"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Cut",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 4876.969658547916,
+                "top": 407.2427936676937
             },
             "post_job_actions": {
                 "HideDatasetActionout_file1": {
@@ -3366,203 +4475,134 @@
             "tool_state": "{\"columnList\": \"c4,c7\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.2",
             "type": "tool",
-            "uuid": "f722cb99-55a1-4de3-8631-1093acad3a38",
+            "uuid": "c55ded6b-078a-48cd-82d2-8a34902e21e3",
             "when": null,
             "workflow_outputs": []
         },
-        "48": {
+        "56": {
             "annotation": "",
-            "content_id": "Cut1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bwa_mem2/bwa_mem2/2.3+galaxy0",
             "errors": null,
-            "id": 48,
+            "id": 56,
             "input_connections": {
-                "input": {
-                    "id": 44,
-                    "output_name": "gfastats data for plotting"
+                "fastq_input|fastq_input1": {
+                    "id": 18,
+                    "output_name": "Trimmed Hi-C data"
+                },
+                "reference_source|ref_file": {
+                    "id": 50,
+                    "output_name": "index"
                 }
             },
-            "inputs": [],
-            "label": null,
-            "name": "Cut",
-            "outputs": [
+            "inputs": [
                 {
-                    "name": "out_file1",
-                    "type": "tabular"
+                    "description": "runtime parameter for tool BWA-MEM2",
+                    "name": "fastq_input"
+                },
+                {
+                    "description": "runtime parameter for tool BWA-MEM2",
+                    "name": "reference_source"
                 }
             ],
-            "position": {
-                "left": 5032.140737445938,
-                "top": 0
-            },
-            "post_job_actions": {},
-            "tool_id": "Cut1",
-            "tool_state": "{\"columnList\": \"c5,c6\", \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.2",
-            "type": "tool",
-            "uuid": "a2a87cfa-4202-4755-bb85-0c7eef887084",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "49": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_merge/samtools_merge/1.21+galaxy0",
-            "errors": null,
-            "id": 49,
-            "input_connections": {
-                "bamfiles": {
-                    "id": 46,
-                    "output_name": "out_file1"
-                },
-                "when": {
-                    "id": 22,
-                    "output_name": "Has multiple samples"
-                }
-            },
-            "inputs": [],
             "label": null,
-            "name": "Samtools merge",
+            "name": "BWA-MEM2",
             "outputs": [
                 {
-                    "name": "output",
+                    "name": "bam_output",
                     "type": "bam"
                 }
             ],
             "position": {
-                "left": 4330,
-                "top": 1100
+                "left": 4128.336874249134,
+                "top": 1458.5390026961738
             },
             "post_job_actions": {
-                "HideDatasetActionoutput": {
+                "HideDatasetActionbam_output": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
-                    "output_name": "output"
+                    "output_name": "bam_output"
+                },
+                "RenameDatasetActionbam_output": {
+                    "action_arguments": {
+                        "newname": "Merged Hi-C Alignments"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "bam_output"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_merge/samtools_merge/1.21+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bwa_mem2/bwa_mem2/2.3+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "a7617eb92baf",
-                "name": "samtools_merge",
+                "changeset_revision": "af91699b8d4c",
+                "name": "bwa_mem2",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"bamfiles\": {\"__class__\": \"ConnectedValue\"}, \"bed_file\": {\"__class__\": \"RuntimeValue\"}, \"headerbam\": {\"__class__\": \"RuntimeValue\"}, \"idpg\": false, \"idrg\": false, \"region\": null, \"seed\": \"1\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.21+galaxy0",
+            "tool_state": "{\"analysis_type\": {\"analysis_type_selector\": \"full\", \"__current_case__\": 4, \"algorithmic_options\": {\"algorithmic_options_selector\": \"set\", \"__current_case__\": 0, \"k\": \"19\", \"w\": \"100\", \"d\": \"100\", \"r\": \"1.5\", \"y\": \"20\", \"c\": \"500\", \"D\": \"0.5\", \"W\": \"0\", \"m\": \"50\", \"S\": true, \"P\": true, \"e\": false}, \"scoring_options\": {\"scoring_options_selector\": \"do_not_set\", \"__current_case__\": 1}, \"io_options\": {\"io_options_selector\": \"set\", \"__current_case__\": 0, \"five\": true, \"q\": false, \"T\": \"30\", \"h\": \"5\", \"a\": false, \"C\": false, \"V\": false, \"Y\": false, \"M\": false, \"K\": null}}, \"fastq_input\": {\"fastq_input_selector\": \"paired_collection\", \"__current_case__\": 2, \"fastq_input1\": {\"__class__\": \"ConnectedValue\"}, \"iset_stats\": null}, \"output_sort\": \"coordinate\", \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"ConnectedValue\"}}, \"rg\": {\"rg_selector\": \"do_not_set\", \"__current_case__\": 3}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.3+galaxy0",
             "type": "tool",
-            "uuid": "6eff5303-a997-4727-a545-7857971b3fac",
-            "when": "$(inputs.when)",
-            "workflow_outputs": []
+            "uuid": "d45a4e62-29c0-4cc9-b9ba-b13f60548899",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Hi-C Alignments",
+                    "output_name": "bam_output",
+                    "uuid": "16019374-1e25-4b5b-a89e-a9a4fe7dcb95"
+                }
+            ]
         },
-        "50": {
+        "57": {
             "annotation": "",
-            "content_id": "__EXTRACT_DATASET__",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/imagemagick_image_montage/imagemagick_image_montage/7.1.2-2+galaxy0",
             "errors": null,
-            "id": 50,
+            "id": 57,
             "input_connections": {
-                "input": {
-                    "id": 46,
-                    "output_name": "out_file1"
-                },
-                "when": {
-                    "id": 22,
-                    "output_name": "Has a single sample"
+                "images_0|input": {
+                    "id": 51,
+                    "output_name": "summary_image"
                 }
             },
             "inputs": [],
             "label": null,
-            "name": "Extract dataset",
+            "name": "Image Montage",
             "outputs": [
                 {
                     "name": "output",
-                    "type": "data"
-                }
-            ],
-            "position": {
-                "left": 4340,
-                "top": 1510
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output"
-                }
-            },
-            "tool_id": "__EXTRACT_DATASET__",
-            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"which\": {\"which_dataset\": \"first\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.2",
-            "type": "tool",
-            "uuid": "e2d1de95-b41b-4861-b715-05457d45c88a",
-            "when": "$(inputs.when)",
-            "workflow_outputs": []
-        },
-        "51": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_point/ggplot2_point/3.5.1+galaxy2",
-            "errors": null,
-            "id": 51,
-            "input_connections": {
-                "input1": {
-                    "id": 47,
-                    "output_name": "out_file1"
-                }
-            },
-            "inputs": [],
-            "label": "Size Plot",
-            "name": "Scatterplot with ggplot2",
-            "outputs": [
-                {
-                    "name": "output1",
                     "type": "png"
                 }
             ],
             "position": {
-                "left": 5409.99365234375,
-                "top": 259.19431240420704
+                "left": 5375.805895845155,
+                "top": 1222.520344950555
             },
-            "post_job_actions": {
-                "RenameDatasetActionoutput1": {
-                    "action_arguments": {
-                        "newname": "Size Plot"
-                    },
-                    "action_type": "RenameDatasetAction",
-                    "output_name": "output1"
-                },
-                "TagDatasetActionoutput1": {
-                    "action_arguments": {
-                        "tags": "#size_plot"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "output1"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_point/ggplot2_point/3.5.1+galaxy2",
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/imagemagick_image_montage/imagemagick_image_montage/7.1.2-2+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "f87634b12749",
-                "name": "ggplot2_point",
-                "owner": "iuc",
+                "changeset_revision": "506a90ab5581",
+                "name": "imagemagick_image_montage",
+                "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"adv\": {\"type_conditional\": {\"type_options\": \"lines\", \"__current_case__\": 2}, \"factor\": {\"factoring\": \"Default\", \"__current_case__\": 0}, \"axis_title_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"axis_text_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"plot_title_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"gridlinecust\": \"default\", \"transform\": \"none\", \"scaling\": {\"plot_scaling\": \"Automatic\", \"__current_case__\": 0}, \"theme\": \"bw\", \"legend\": \"yes\"}, \"cols\": {\"header\": \"yes\", \"__current_case__\": 0, \"xplot\": \"1\", \"yplot\": \"2\"}, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"out\": {\"unit_output_dim\": \"in\", \"width_output_dim\": \"6.0\", \"height_output_dim\": \"4.0\", \"dpi_output_dim\": \"300.0\", \"additional_output_format\": \"none\"}, \"title\": \"Size Plot\", \"xlab\": \"Scaffold number\", \"ylab\": \"Cumulative Size (Mb)\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "3.5.1+galaxy2",
+            "tool_state": "{\"images\": [{\"__index__\": 0, \"input\": {\"__class__\": \"RuntimeValue\"}}], \"label_options\": {\"label\": \"false\", \"__current_case__\": 1}, \"pointsize\": \"14\", \"resize\": \"50\", \"title\": \"\", \"width\": \"2\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "7.1.2-2+galaxy0",
             "type": "tool",
-            "uuid": "e02afb1a-3e33-46a7-be51-1bb30c86b089",
+            "uuid": "77ac6a57-f0e5-4e50-ad75-e3677c4af03a",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Size Plot",
-                    "output_name": "output1",
-                    "uuid": "6756b2b5-d6f6-4dac-8c08-7d1c00f1f276"
+                    "label": "Busco resized",
+                    "output_name": "output",
+                    "uuid": "45f3e7e6-43f0-425c-a448-b48f463c03b1"
                 }
             ]
         },
-        "52": {
+        "58": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_point/ggplot2_point/3.5.1+galaxy2",
             "errors": null,
-            "id": 52,
+            "id": 58,
             "input_connections": {
                 "input1": {
-                    "id": 48,
+                    "id": 54,
                     "output_name": "out_file1"
                 }
             },
@@ -3576,8 +4616,8 @@
                 }
             ],
             "position": {
-                "left": 5384.297023157385,
-                "top": 1.6453506289526558
+                "left": 5237.829181705301,
+                "top": 172.59999033970493
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput1": {
@@ -3605,7 +4645,7 @@
             "tool_state": "{\"adv\": {\"type_conditional\": {\"type_options\": \"lines\", \"__current_case__\": 2}, \"factor\": {\"factoring\": \"Default\", \"__current_case__\": 0}, \"axis_title_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"axis_text_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"plot_title_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"gridlinecust\": \"default\", \"transform\": \"none\", \"scaling\": {\"plot_scaling\": \"Automatic\", \"__current_case__\": 0}, \"theme\": \"bw\", \"legend\": \"yes\"}, \"cols\": {\"header\": \"yes\", \"__current_case__\": 0, \"xplot\": \"1\", \"yplot\": \"2\"}, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"out\": {\"unit_output_dim\": \"in\", \"width_output_dim\": \"6.0\", \"height_output_dim\": \"4.0\", \"dpi_output_dim\": \"300.0\", \"additional_output_format\": \"none\"}, \"title\": \"Nx Plot\", \"xlab\": \"x\", \"ylab\": \"Nx (Mb)\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_version": "3.5.1+galaxy2",
             "type": "tool",
-            "uuid": "d2c8aaf8-7924-4536-b2a4-027113575635",
+            "uuid": "1f18287d-bd79-4592-90b9-3fdfe3175281",
             "when": null,
             "workflow_outputs": [
                 {
@@ -3615,18 +4655,311 @@
                 }
             ]
         },
-        "53": {
+        "59": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_point/ggplot2_point/3.5.1+galaxy2",
+            "errors": null,
+            "id": 59,
+            "input_connections": {
+                "input1": {
+                    "id": 55,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": "Size Plot",
+            "name": "Scatterplot with ggplot2",
+            "outputs": [
+                {
+                    "name": "output1",
+                    "type": "png"
+                }
+            ],
+            "position": {
+                "left": 5237.646457956964,
+                "top": 398.02355790306285
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutput1": {
+                    "action_arguments": {
+                        "newname": "Size Plot"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output1"
+                },
+                "TagDatasetActionoutput1": {
+                    "action_arguments": {
+                        "tags": "#size_plot"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "output1"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/ggplot2_point/ggplot2_point/3.5.1+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "f87634b12749",
+                "name": "ggplot2_point",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"adv\": {\"type_conditional\": {\"type_options\": \"lines\", \"__current_case__\": 2}, \"factor\": {\"factoring\": \"Default\", \"__current_case__\": 0}, \"axis_title_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"axis_text_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"plot_title_customization\": {\"axis_customization\": \"default\", \"__current_case__\": 0}, \"gridlinecust\": \"default\", \"transform\": \"none\", \"scaling\": {\"plot_scaling\": \"Automatic\", \"__current_case__\": 0}, \"theme\": \"bw\", \"legend\": \"yes\"}, \"cols\": {\"header\": \"yes\", \"__current_case__\": 0, \"xplot\": \"1\", \"yplot\": \"2\"}, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"out\": {\"unit_output_dim\": \"in\", \"width_output_dim\": \"6.0\", \"height_output_dim\": \"4.0\", \"dpi_output_dim\": \"300.0\", \"additional_output_format\": \"none\"}, \"title\": \"Size Plot\", \"xlab\": \"Scaffold number\", \"ylab\": \"Cumulative Size (Mb)\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "3.5.1+galaxy2",
+            "type": "tool",
+            "uuid": "7f661dee-45d8-4b2f-a837-39cc776afce8",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Size Plot",
+                    "output_name": "output1",
+                    "uuid": "6756b2b5-d6f6-4dac-8c08-7d1c00f1f276"
+                }
+            ]
+        },
+        "60": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy3",
+            "errors": null,
+            "id": 60,
+            "input_connections": {
+                "conditions_0|filters_0|bam_property|bam_property_value": {
+                    "id": 14,
+                    "output_name": "out1"
+                },
+                "input_bam": {
+                    "id": 56,
+                    "output_name": "bam_output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Filter BAM",
+            "outputs": [
+                {
+                    "name": "out_file2",
+                    "type": "txt"
+                },
+                {
+                    "name": "out_file1",
+                    "type": "bam"
+                }
+            ],
+            "position": {
+                "left": 4438.00377248393,
+                "top": 1434.058702905889
+            },
+            "post_job_actions": {
+                "RenameDatasetActionout_file1": {
+                    "action_arguments": {
+                        "newname": "Filtered H-C Alignments on scaffolds"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out_file1"
+                },
+                "TagDatasetActionout_file1": {
+                    "action_arguments": {
+                        "tags": "filtered_alignments_s2"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bamtools_filter/bamFilter/2.5.2+galaxy3",
+            "tool_shed_repository": {
+                "changeset_revision": "62e4d6cdbaa7",
+                "name": "bamtools_filter",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"conditions\": [{\"__index__\": 0, \"filters\": [{\"__index__\": 0, \"bam_property\": {\"bam_property_selector\": \"mapQuality\", \"__current_case__\": 14, \"bam_property_value\": {\"__class__\": \"ConnectedValue\"}}}]}], \"input_bam\": {\"__class__\": \"ConnectedValue\"}, \"rule_configuration\": {\"rules_selector\": \"false\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.5.2+galaxy3",
+            "type": "tool",
+            "uuid": "c536de2a-564e-4295-9098-51443404771e",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Filtered H-C Alignments on scaffolds",
+                    "output_name": "out_file1",
+                    "uuid": "79fad504-8aaf-4fad-93d6-dc85d9102612"
+                }
+            ]
+        },
+        "61": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/imagemagick_image_montage/imagemagick_image_montage/7.1.2-2+galaxy0",
+            "errors": null,
+            "id": 61,
+            "input_connections": {
+                "images_0|input": {
+                    "id": 58,
+                    "output_name": "output1"
+                },
+                "images_1|input": {
+                    "id": 59,
+                    "output_name": "output1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Image Montage",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "png"
+                }
+            ],
+            "position": {
+                "left": 5630.8563805443055,
+                "top": 267.267600323983
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "Scaffolding Plots"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/imagemagick_image_montage/imagemagick_image_montage/7.1.2-2+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "506a90ab5581",
+                "name": "imagemagick_image_montage",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"images\": [{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}}], \"label_options\": {\"label\": \"true\", \"__current_case__\": 0, \"label_indexes\": false}, \"pointsize\": \"14\", \"resize\": \"70\", \"title\": \"Scaffolding Plots\", \"width\": \"2\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "7.1.2-2+galaxy0",
+            "type": "tool",
+            "uuid": "fefdac0f-28b6-4717-8484-a0a3052ea50c",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Scaffolding Plots",
+                    "output_name": "output",
+                    "uuid": "92d59b97-f325-467a-8ac1-1f9cca2ebc16"
+                }
+            ]
+        },
+        "62": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_merge/samtools_merge/1.21+galaxy0",
+            "errors": null,
+            "id": 62,
+            "input_connections": {
+                "bamfiles": {
+                    "id": 60,
+                    "output_name": "out_file1"
+                },
+                "when": {
+                    "id": 21,
+                    "output_name": "Has multiple samples"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Samtools merge",
+                    "name": "bed_file"
+                },
+                {
+                    "description": "runtime parameter for tool Samtools merge",
+                    "name": "headerbam"
+                }
+            ],
+            "label": null,
+            "name": "Samtools merge",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "bam"
+                }
+            ],
+            "position": {
+                "left": 4751.7739799874125,
+                "top": 1613.920606294505
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                },
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "Merged Hi-C Alignments"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/samtools_merge/samtools_merge/1.21+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "a7617eb92baf",
+                "name": "samtools_merge",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"bamfiles\": {\"__class__\": \"ConnectedValue\"}, \"bed_file\": {\"__class__\": \"RuntimeValue\"}, \"headerbam\": {\"__class__\": \"RuntimeValue\"}, \"idpg\": false, \"idrg\": false, \"region\": null, \"seed\": \"1\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.21+galaxy0",
+            "type": "tool",
+            "uuid": "f5a01046-a23b-4cd0-83b9-6443a21433f2",
+            "when": "$(inputs.when)",
+            "workflow_outputs": []
+        },
+        "63": {
+            "annotation": "",
+            "content_id": "__EXTRACT_DATASET__",
+            "errors": null,
+            "id": 63,
+            "input_connections": {
+                "input": {
+                    "id": 60,
+                    "output_name": "out_file1"
+                },
+                "when": {
+                    "id": 21,
+                    "output_name": "Has a single sample"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Extract dataset",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "data"
+                }
+            ],
+            "position": {
+                "left": 4730.799032286633,
+                "top": 1946.7806211033487
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "__EXTRACT_DATASET__",
+            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"which\": {\"which_dataset\": \"first\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.2",
+            "type": "tool",
+            "uuid": "dd9b5102-3978-4fcc-9af6-f003018e54d8",
+            "when": "$(inputs.when)",
+            "workflow_outputs": []
+        },
+        "64": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
             "errors": null,
-            "id": 53,
+            "id": 64,
             "input_connections": {
                 "style_cond|type_cond|pick_from_0|value": {
-                    "id": 49,
+                    "id": 62,
                     "output_name": "output"
                 },
                 "style_cond|type_cond|pick_from_1|value": {
-                    "id": 50,
+                    "id": 63,
                     "output_name": "output"
                 }
             },
@@ -3640,20 +4973,20 @@
                 }
             ],
             "position": {
-                "left": 4620,
-                "top": 1420
+                "left": 5060.106815509576,
+                "top": 1789.886856012782
             },
             "post_job_actions": {
                 "RenameDatasetActiondata_param": {
                     "action_arguments": {
-                        "newname": "s2 Merged Hi-C Alignments"
+                        "newname": "Merged Hi-C Alignments on scaffolds"
                     },
                     "action_type": "RenameDatasetAction",
                     "output_name": "data_param"
                 },
                 "TagDatasetActiondata_param": {
                     "action_arguments": {
-                        "tags": "merged_hic_mapping_s2"
+                        "tags": "merged_alignments_s1"
                     },
                     "action_type": "TagDatasetAction",
                     "output_name": "data_param"
@@ -3669,25 +5002,108 @@
             "tool_state": "{\"style_cond\": {\"pick_style\": \"first\", \"__current_case__\": 0, \"type_cond\": {\"param_type\": \"data\", \"__current_case__\": 4, \"pick_from\": [{\"__index__\": 0, \"value\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"value\": {\"__class__\": \"ConnectedValue\"}}]}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "c9d16915-4ffe-4df0-88a3-0af6016e0742",
+            "uuid": "0df13b31-5803-4a69-b7d0-66a78d9ed09b",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "s2 Merged Hi-C Alignments",
+                    "label": "Merged Hi-C Alignments on scaffolds",
                     "output_name": "data_param",
-                    "uuid": "c7ba151f-64d4-49ba-ba93-eed1aaa88900"
+                    "uuid": "423d4a89-418f-4a9a-b72c-88db0923d6d4"
                 }
             ]
         },
-        "54": {
+        "65": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/3.1.1.0",
+            "errors": null,
+            "id": 65,
+            "input_connections": {
+                "inputFile": {
+                    "id": 64,
+                    "output_name": "data_param"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "MarkDuplicates",
+            "outputs": [
+                {
+                    "name": "metrics_file",
+                    "type": "txt"
+                },
+                {
+                    "name": "outFile",
+                    "type": "bam"
+                }
+            ],
+            "position": {
+                "left": 5422.186321130172,
+                "top": 1970.7901977527285
+            },
+            "post_job_actions": {
+                "RenameDatasetActionmetrics_file": {
+                    "action_arguments": {
+                        "newname": "Markdup Stats on Scaffolds"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "metrics_file"
+                },
+                "RenameDatasetActionoutFile": {
+                    "action_arguments": {
+                        "newname": "Deduplicated Hi-C Alignments on Scaffolds"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "outFile"
+                },
+                "TagDatasetActionmetrics_file": {
+                    "action_arguments": {
+                        "tags": "markdup_stats_scaffolds"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "metrics_file"
+                },
+                "TagDatasetActionoutFile": {
+                    "action_arguments": {
+                        "tags": "deduplicated_hic_scaffolds"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "outFile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/picard/picard_MarkDuplicates/3.1.1.0",
+            "tool_shed_repository": {
+                "changeset_revision": "3f254c5ced1d",
+                "name": "picard",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"assume_sorted\": false, \"barcode_tag\": null, \"comments\": [], \"duplicate_scoring_strategy\": \"SUM_OF_BASE_QUALITIES\", \"inputFile\": {\"__class__\": \"ConnectedValue\"}, \"optical_duplicate_pixel_distance\": \"2500\", \"read_name_regex\": \"\", \"remove_duplicates\": true, \"validation_stringency\": \"LENIENT\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "3.1.1.0",
+            "type": "tool",
+            "uuid": "b0e22aa8-c5a3-4195-a90a-8982ae85db05",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Deduplicated Hi-C Alignments on Scaffolds",
+                    "output_name": "outFile",
+                    "uuid": "c47a8ebd-eb10-40b9-ac51-bb584485e622"
+                },
+                {
+                    "label": "Markdup Stats on Scaffolds",
+                    "output_name": "metrics_file",
+                    "uuid": "a924c207-09d7-48ce-944e-b2c97b47a488"
+                }
+            ]
+        },
+        "66": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_map/pretext_map/0.1.9+galaxy1",
             "errors": null,
-            "id": 54,
+            "id": 66,
             "input_connections": {
                 "input": {
-                    "id": 53,
-                    "output_name": "data_param"
+                    "id": 65,
+                    "output_name": "outFile"
                 }
             },
             "inputs": [],
@@ -3700,8 +5116,8 @@
                 }
             ],
             "position": {
-                "left": 5030,
-                "top": 1810
+                "left": 5830.0717812377125,
+                "top": 2436.7083842402863
             },
             "post_job_actions": {
                 "TagDatasetActionpretext_map_out": {
@@ -3726,22 +5142,27 @@
             "when": null,
             "workflow_outputs": []
         },
-        "55": {
+        "67": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.7",
             "errors": null,
-            "id": 55,
+            "id": 67,
             "input_connections": {
                 "addref_cond|ref": {
-                    "id": 37,
+                    "id": 46,
                     "output_name": "output"
                 },
                 "input": {
-                    "id": 53,
-                    "output_name": "data_param"
+                    "id": 65,
+                    "output_name": "outFile"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Samtools stats",
+                    "name": "addref_cond"
+                }
+            ],
             "label": "Hi-C Alignment Stats scaffolds",
             "name": "Samtools stats",
             "outputs": [
@@ -3751,8 +5172,8 @@
                 }
             ],
             "position": {
-                "left": 5040.987774843362,
-                "top": 2026.2226856134582
+                "left": 5857.992240936195,
+                "top": 2649.3823654622593
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -3790,22 +5211,87 @@
                 }
             ]
         },
-        "56": {
+        "68": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.7",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.5+galaxy2",
             "errors": null,
-            "id": 56,
+            "id": 68,
             "input_connections": {
-                "addref_cond|ref": {
-                    "id": 37,
-                    "output_name": "output"
-                },
-                "input": {
-                    "id": 53,
-                    "output_name": "data_param"
+                "infile": {
+                    "id": 65,
+                    "output_name": "metrics_file"
                 }
             },
             "inputs": [],
+            "label": "Deduplication Summary 2",
+            "name": "Search in textfiles",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 6192.920110033738,
+                "top": 1936.006755619339
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "Markduplicates Summary on Scaffolds"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                },
+                "TagDatasetActionoutput": {
+                    "action_arguments": {
+                        "tags": "markdup_summ"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.5+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "c41d78ae5fee",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"case_sensitive\": \"-i\", \"color\": \"NOCOLOR\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"invert\": \"\", \"lines_after\": \"2\", \"lines_before\": \"0\", \"regex_type\": \"-G\", \"url_paste\": \"## METRICS CLASS\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "9.5+galaxy2",
+            "type": "tool",
+            "uuid": "bea12ebc-83ed-4dcf-831c-ce89d01667ac",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Markduplicates Summary on Scaffolds",
+                    "output_name": "output",
+                    "uuid": "4a6610ac-0115-4ea1-b48f-1c264a001f42"
+                }
+            ]
+        },
+        "69": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/samtools_stats/samtools_stats/2.0.7",
+            "errors": null,
+            "id": 69,
+            "input_connections": {
+                "addref_cond|ref": {
+                    "id": 46,
+                    "output_name": "output"
+                },
+                "input": {
+                    "id": 65,
+                    "output_name": "outFile"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Samtools stats",
+                    "name": "addref_cond"
+                }
+            ],
             "label": "Hi-C Alignment Stats scaffolds summary",
             "name": "Samtools stats",
             "outputs": [
@@ -3815,8 +5301,8 @@
                 }
             ],
             "position": {
-                "left": 5043.433997144277,
-                "top": 2280.0697001940825
+                "left": 5843.505778381989,
+                "top": 2906.778084434369
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_collection": {
@@ -3853,14 +5339,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "57": {
+        "70": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pretext_snapshot/pretext_snapshot/0.0.5+galaxy0",
             "errors": null,
-            "id": 57,
+            "id": 70,
             "input_connections": {
                 "input": {
-                    "id": 54,
+                    "id": 66,
                     "output_name": "pretext_map_out"
                 }
             },
@@ -3874,8 +5360,8 @@
                 }
             ],
             "position": {
-                "left": 5312.128843037729,
-                "top": 1910.080173931541
+                "left": 6112.200624275441,
+                "top": 2536.7885581718274
             },
             "post_job_actions": {
                 "HideDatasetActionpretext_snap_out": {
@@ -3905,22 +5391,27 @@
             "when": null,
             "workflow_outputs": []
         },
-        "58": {
+        "71": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy3",
             "errors": null,
-            "id": 58,
+            "id": 71,
             "input_connections": {
                 "results_0|software_cond|output_0|type|input": {
-                    "id": 27,
+                    "id": 34,
                     "output_name": "output"
                 },
                 "results_0|software_cond|output_1|type|input": {
-                    "id": 55,
+                    "id": 67,
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool MultiQC",
+                    "name": "image_content_input"
+                }
+            ],
             "label": null,
             "name": "MultiQC",
             "outputs": [
@@ -3934,8 +5425,8 @@
                 }
             ],
             "position": {
-                "left": 5481.949328015899,
-                "top": 2141.098973871991
+                "left": 6282.021109253611,
+                "top": 2767.807358112277
             },
             "post_job_actions": {
                 "RenameDatasetActionhtml_report": {
@@ -3967,25 +5458,25 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Hi-C alignments stats",
-                    "output_name": "stats",
-                    "uuid": "e4da8f8f-be1f-4b27-8ec0-3ab95e725b77"
-                },
-                {
                     "label": "Hi-C alignments stats HTML Report",
                     "output_name": "html_report",
                     "uuid": "fbbed2f6-db59-4156-8423-021160dd449d"
+                },
+                {
+                    "label": "Hi-C alignments stats",
+                    "output_name": "stats",
+                    "uuid": "e4da8f8f-be1f-4b27-8ec0-3ab95e725b77"
                 }
             ]
         },
-        "59": {
+        "72": {
             "annotation": "",
             "content_id": "__EXTRACT_DATASET__",
             "errors": null,
-            "id": 59,
+            "id": 72,
             "input_connections": {
                 "input": {
-                    "id": 56,
+                    "id": 69,
                     "output_name": "output_collection"
                 }
             },
@@ -3999,8 +5490,8 @@
                 }
             ],
             "position": {
-                "left": 5284.83481035722,
-                "top": 2538.5916893871367
+                "left": 6084.906591594932,
+                "top": 3165.300073627423
             },
             "post_job_actions": {
                 "ChangeDatatypeActionoutput": {
@@ -4037,14 +5528,14 @@
                 }
             ]
         },
-        "60": {
+        "73": {
             "annotation": "",
             "content_id": "__EXTRACT_DATASET__",
             "errors": null,
-            "id": 60,
+            "id": 73,
             "input_connections": {
                 "input": {
-                    "id": 57,
+                    "id": 70,
                     "output_name": "pretext_snap_out"
                 }
             },
@@ -4058,10 +5549,24 @@
                 }
             ],
             "position": {
-                "left": 5558.128846481945,
-                "top": 1735.2337626386554
+                "left": 6517.923394864781,
+                "top": 2454.150290948025
             },
             "post_job_actions": {
+                "ChangeDatatypeActionoutput": {
+                    "action_arguments": {
+                        "newtype": "png"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "output"
+                },
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "PretextMap After scaffolding"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                },
                 "TagDatasetActionoutput": {
                     "action_arguments": {
                         "tags": "pretext_s2"
@@ -4084,14 +5589,14 @@
                 }
             ]
         },
-        "61": {
+        "74": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_tail_tool/9.5+galaxy2",
             "errors": null,
-            "id": 61,
+            "id": 74,
             "input_connections": {
                 "infile": {
-                    "id": 59,
+                    "id": 72,
                     "output_name": "output"
                 }
             },
@@ -4105,8 +5610,8 @@
                 }
             ],
             "position": {
-                "left": 5526.1281314527705,
-                "top": 2655.474556753144
+                "left": 6326.199912690483,
+                "top": 3282.1829409934303
             },
             "post_job_actions": {
                 "HideDatasetActionoutfile": {
@@ -4129,14 +5634,71 @@
             "when": null,
             "workflow_outputs": []
         },
-        "62": {
+        "75": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/imagemagick_image_montage/imagemagick_image_montage/7.1.2-2+galaxy0",
+            "errors": null,
+            "id": 75,
+            "input_connections": {
+                "images_0|input": {
+                    "id": 37,
+                    "output_name": "output"
+                },
+                "images_1|input": {
+                    "id": 73,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Image Montage",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "png"
+                }
+            ],
+            "position": {
+                "left": 6959.544625831438,
+                "top": 2629.075125327976
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "Hi-C maps"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/imagemagick_image_montage/imagemagick_image_montage/7.1.2-2+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "506a90ab5581",
+                "name": "imagemagick_image_montage",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"images\": [{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}}], \"label_options\": {\"label\": \"true\", \"__current_case__\": 0, \"label_indexes\": false}, \"pointsize\": \"14\", \"resize\": \"60\", \"title\": \"\", \"width\": \"2\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "7.1.2-2+galaxy0",
+            "type": "tool",
+            "uuid": "531fe495-365e-419e-bcca-f7696636b716",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Hi-C maps",
+                    "output_name": "output",
+                    "uuid": "ce216f71-d0b6-48f2-ae97-9ab29848990f"
+                }
+            ]
+        },
+        "76": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy2",
             "errors": null,
-            "id": 62,
+            "id": 76,
             "input_connections": {
                 "infile": {
-                    "id": 61,
+                    "id": 74,
                     "output_name": "outfile"
                 }
             },
@@ -4150,8 +5712,8 @@
                 }
             ],
             "position": {
-                "left": 5744.378827127462,
-                "top": 2537.166969938635
+                "left": 6544.450608365174,
+                "top": 3163.875354178921
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_awk_tool/9.5+galaxy2",
@@ -4168,18 +5730,18 @@
             "when": null,
             "workflow_outputs": []
         },
-        "63": {
+        "77": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.5+galaxy2",
             "errors": null,
-            "id": 63,
+            "id": 77,
             "input_connections": {
                 "infile1": {
-                    "id": 62,
+                    "id": 76,
                     "output_name": "outfile"
                 },
                 "infile2": {
-                    "id": 40,
+                    "id": 48,
                     "output_name": "outfile"
                 }
             },
@@ -4193,8 +5755,8 @@
                 }
             ],
             "position": {
-                "left": 5988.3360980246025,
-                "top": 2699.3210142140706
+                "left": 6788.407879262315,
+                "top": 3326.029398454357
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.5+galaxy2",
@@ -4211,14 +5773,14 @@
             "when": null,
             "workflow_outputs": []
         },
-        "64": {
+        "78": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cut_tool/9.5+galaxy2",
             "errors": null,
-            "id": 64,
+            "id": 78,
             "input_connections": {
                 "input": {
-                    "id": 63,
+                    "id": 77,
                     "output_name": "output"
                 }
             },
@@ -4232,8 +5794,8 @@
                 }
             ],
             "position": {
-                "left": 6337.375543016976,
-                "top": 2689.567882528065
+                "left": 7084.573393826667,
+                "top": 3267.2415411095494
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -4270,12 +5832,62 @@
                     "uuid": "d43a8ed6-a869-417f-a9e9-d92c84902fe2"
                 }
             ]
+        },
+        "79": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy2",
+            "errors": null,
+            "id": 79,
+            "input_connections": {
+                "infile": {
+                    "id": 78,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Replace",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 7456.389181327085,
+                "top": 3290.9420761446413
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutfile": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy2",
+            "tool_shed_repository": {
+                "changeset_revision": "c41d78ae5fee",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"#\", \"replace_pattern\": \"Number of\", \"is_regex\": false, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "9.5+galaxy2",
+            "type": "tool",
+            "uuid": "f439be57-645d-4e70-aa63-013d9879561d",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "clean_alignement_stats",
+                    "output_name": "outfile",
+                    "uuid": "1ef39bc7-ef49-4fe6-ab22-2507c7ef90aa"
+                }
+            ]
         }
     },
     "tags": [
         "VGP_curated"
     ],
-    "uuid": "cc074d20-afb7-4cb6-8d4f-271b3fc70921",
-    "version": 1,
-    "release": "2.2"
+    "uuid": "21d12b40-2e47-487d-b296-33ac57a32361",
+    "version": 28
 }


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
