### PR TITLE
Typo in Scanpy workflow readme

### DIFF
--- a/workflows/scRNAseq/scanpy-clustering/README.md
+++ b/workflows/scRNAseq/scanpy-clustering/README.md
@@ -12,7 +12,7 @@ This workflow follows Scanpy legacy workflow [clustering 3k PBMCs](https://scanp
         - Cell Ranger v2 or earlier version call this file as `genes.tsv` and contains two columns:
             - Gene ID (Ensembl gene ID or other identifiers)
             - Gene Name (common gene name or symbol)
-        - Cell Ranger v2 or earlier version call this file as `features.tsv` and contains three columns:
+        - Cell Ranger v3 or later version call this file as `features.tsv` and contains three columns:
             - Feature ID (Ensembl gene ID or other identifiers)
             - Feature Name (common gene name or symbol)
             - Feature Type (e.g., Gene Expression, Antibody Capture, CRISPR Guide Capture, etc.)


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [x] License permits unrestricted use (educational + commercial)
* [x] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
