### PR TITLE
fix url encoding for test files with spaces in their names

### DIFF
--- a/scripts/workflow_manifest.py
+++ b/scripts/workflow_manifest.py
@@ -4,7 +4,7 @@ import yaml
 import requests
 import re
 import shutil
-from urllib.parse import quote_plus
+from urllib.parse import quote_plus, quote
 from create_mermaid import walk_directory
 from planemo.galaxy.workflows import job_template
 
@@ -230,7 +230,10 @@ def path_to_location(input_item, root):
                 else:
                     # Create location URL from path for downloading files
                     relative_path = os.path.join(root.replace("./", ""), input_item["path"].lstrip("/"))
-                    input_item["location"] = f"https://raw.githubusercontent.com/galaxyproject/iwc/main/{relative_path}"
+                    # URL-encode the path to handle spaces and special characters
+                    # Use safe='/' to keep forward slashes unencoded as path separators
+                    encoded_path = quote(relative_path, safe='/')
+                    input_item["location"] = f"https://raw.githubusercontent.com/galaxyproject/iwc/main/{encoded_path}"
                     del input_item["path"]
             if "filetype" not in input_item:
                 # Add filetype if not present


### PR DESCRIPTION
Closes https://github.com/galaxyproject/iwc/issues/1004


FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
