### PR TITLE
Add hashes to most workflow tests

### DIFF
--- a/workflows/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/Assembly-Hifi-HiC-phasing-VGP4-tests.yml
+++ b/workflows/VGP-assembly-v2/Assembly-Hifi-HiC-phasing-VGP4/Assembly-Hifi-HiC-phasing-VGP4-tests.yml
@@ -6,30 +6,45 @@
       class: Collection
       collection_type: list:paired
       elements:
-        - class: Collection
-          type: paired
-          identifier: Hi-C reads
-          elements:
-          - identifier: forward
-            class: File
-            location:  https://zenodo.org/records/10068595/files/HiC%20forward%20reads.fastqsanger.gz?download=1
-            filetype: fastqsanger.gz
-          - identifier: reverse
-            class: File
-            location: https://zenodo.org/records/10068595/files/HiC%20reverse%20reads.fastqsanger.gz?download=1
-            filetype: fastqsanger.gz
+      - class: Collection
+        type: paired
+        identifier: Hi-C reads
+        elements:
+        - identifier: forward
+          class: File
+          location: https://zenodo.org/records/10068595/files/HiC%20forward%20reads.fastqsanger.gz?download=1
+          filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: eb2e87b12418c0665f5de6d97101a4fc088f8bdf
+        - identifier: reverse
+          class: File
+          location: https://zenodo.org/records/10068595/files/HiC%20reverse%20reads.fastqsanger.gz?download=1
+          filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 538110c9b14a5b11088a6999244ee04983389d80
     Genomescope Model Parameters:
       class: File
       path: test-data/Genomescope Model Parameters.tabular
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 6daf4567ff37e9d5ceebf76ddeb15e0d5773f694
     Genomescope Summary:
       class: File
       location: https://zenodo.org/records/10068595/files/Genomescope%20Summary.txt?download=1
       filetype: txt
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 42c6e189d26791e637dbaee533ad13cab39a7c1b
     Meryl Database:
       class: File
       location: https://zenodo.org/records/10068595/files/Meryl%20Database.meryldb?download=1
       filetype: meryldb
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 95615073e670e81ca03e6582b7da437c915cfccd
     Pacbio Reads:
       class: Collection
       collection_type: list
@@ -37,16 +52,19 @@
       - class: File
         identifier: yeast_reads_sub1.fastq.gz
         location: https://zenodo.org/records/10068595/files/Pacbio%20Reads%20Collection_yeast_reads_sub1.fastq.gz.fastq.gz?download=1
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 6757ca53673956e3f536d8f3fe08c6b3c6287d37
     Lineage: vertebrata_odb10
     Bits for bloom filter: 32
     Name for Haplotype 1: Hap1
     Name for Haplotype 2: Hap2
-    Homozygous Read Coverage: null
+    Homozygous Read Coverage:
     Database for Busco Lineage: v5
     Trim Hi-C reads?: false
   outputs:
     Hifiasm Hi-C hap1:
-      asserts: 
+      asserts:
         has_n_lines:
           n: 114
     Estimated Genome size: 2288021
@@ -56,31 +74,31 @@
           value: 65000
           delta: 10000
     usable hap1 gfa:
-      asserts: 
+      asserts:
         has_n_lines:
           n: 119
     No Sequences hap2 gfa:
       asserts:
         has_text:
-          text: "S	h2tg000001l	*	LN:i:43860	LN:i:43860	rd:i:45"
+          text: "S\th2tg000001l\t*\tLN:i:43860\tLN:i:43860\trd:i:45"
     Assembly statistics for Hap1 and Hap2:
       asserts:
-        has_text: 
-          text: "# scaffolds	57	51"
+        has_text:
+          text: "# scaffolds\t57\t51"
     Compleasm on Contigs hap1 Full Table:
-      asserts: 
+      asserts:
         has_n_lines:
           n: 3356
     Compleasm on Contigs hap1 Translated Proteins:
-      asserts: 
+      asserts:
         has_n_lines:
           n: 31142
     Compleasm on Contigs hap2 Full Table:
-      asserts: 
+      asserts:
         has_n_lines:
           n: 3356
     Compleasm on Contigs hap2 Translated Proteins:
-      asserts: 
+      asserts:
         has_n_lines:
           n: 23694
     Compleasm on Contigs hap1 Summary:
@@ -99,42 +117,63 @@
       class: Collection
       collection_type: list:paired
       elements:
-        - class: Collection
-          type: paired
-          identifier: Hi-C reads 1
-          elements:
-          - identifier: forward
-            class: File
-            location:  https://zenodo.org/records/10068595/files/HiC%20forward%20reads.fastqsanger.gz?download=1
-            filetype: fastqsanger.gz
-          - identifier: reverse
-            class: File
-            location: https://zenodo.org/records/10068595/files/HiC%20reverse%20reads.fastqsanger.gz?download=1
-            filetype: fastqsanger.gz
-        - class: Collection
-          type: paired
-          identifier: Hi-C reads 2
-          elements:
-          - identifier: forward
-            class: File
-            location:  https://zenodo.org/records/10068595/files/HiC%20forward%20reads.fastqsanger.gz?download=1
-            filetype: fastqsanger.gz
-          - identifier: reverse
-            class: File
-            location: https://zenodo.org/records/10068595/files/HiC%20reverse%20reads.fastqsanger.gz?download=1
-            filetype: fastqsanger.gz
+      - class: Collection
+        type: paired
+        identifier: Hi-C reads 1
+        elements:
+        - identifier: forward
+          class: File
+          location: https://zenodo.org/records/10068595/files/HiC%20forward%20reads.fastqsanger.gz?download=1
+          filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: eb2e87b12418c0665f5de6d97101a4fc088f8bdf
+        - identifier: reverse
+          class: File
+          location: https://zenodo.org/records/10068595/files/HiC%20reverse%20reads.fastqsanger.gz?download=1
+          filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 538110c9b14a5b11088a6999244ee04983389d80
+      - class: Collection
+        type: paired
+        identifier: Hi-C reads 2
+        elements:
+        - identifier: forward
+          class: File
+          location: https://zenodo.org/records/10068595/files/HiC%20forward%20reads.fastqsanger.gz?download=1
+          filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: eb2e87b12418c0665f5de6d97101a4fc088f8bdf
+        - identifier: reverse
+          class: File
+          location: https://zenodo.org/records/10068595/files/HiC%20reverse%20reads.fastqsanger.gz?download=1
+          filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 538110c9b14a5b11088a6999244ee04983389d80
     Genomescope Model Parameters:
       class: File
       path: test-data/Genomescope Model Parameters.tabular
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 6daf4567ff37e9d5ceebf76ddeb15e0d5773f694
     Genomescope Summary:
       class: File
       location: https://zenodo.org/records/10068595/files/Genomescope%20Summary.txt?download=1
       filetype: txt
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 42c6e189d26791e637dbaee533ad13cab39a7c1b
     Meryl Database:
       class: File
       location: https://zenodo.org/records/10068595/files/Meryl%20Database.meryldb?download=1
       filetype: meryldb
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 95615073e670e81ca03e6582b7da437c915cfccd
     Pacbio Reads:
       class: Collection
       collection_type: list
@@ -142,16 +181,19 @@
       - class: File
         identifier: yeast_reads_sub1.fastq.gz
         location: https://zenodo.org/records/10068595/files/Pacbio%20Reads%20Collection_yeast_reads_sub1.fastq.gz.fastq.gz?download=1
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 6757ca53673956e3f536d8f3fe08c6b3c6287d37
     Lineage: vertebrata_odb10
     Bits for bloom filter: 32
     Name for Haplotype 1: Hap1
     Name for Haplotype 2: Hap2
-    Homozygous Read Coverage: null
+    Homozygous Read Coverage:
     Database for Busco Lineage: v5
     Trim Hi-C reads?: false
   outputs:
     Hifiasm Hi-C hap1:
-      asserts: 
+      asserts:
         has_n_lines:
           n: 114
     Estimated Genome size: 2288021
@@ -161,31 +203,31 @@
           value: 65000
           delta: 10000
     usable hap1 gfa:
-      asserts: 
+      asserts:
         has_n_lines:
           n: 119
     No Sequences hap2 gfa:
       asserts:
         has_text:
-          text: "S	h2tg000001l	*	LN:i:43860	LN:i:43860	rd:i:45"
+          text: "S\th2tg000001l\t*\tLN:i:43860\tLN:i:43860\trd:i:45"
     Assembly statistics for Hap1 and Hap2:
       asserts:
-        has_text: 
-          text: "# scaffolds	57	51"
+        has_text:
+          text: "# scaffolds\t57\t51"
     Compleasm on Contigs hap1 Full Table:
-      asserts: 
+      asserts:
         has_n_lines:
           n: 3356
     Compleasm on Contigs hap1 Translated Proteins:
-      asserts: 
+      asserts:
         has_n_lines:
           n: 31142
     Compleasm on Contigs hap2 Full Table:
-      asserts: 
+      asserts:
         has_n_lines:
           n: 3356
     Compleasm on Contigs hap2 Translated Proteins:
-      asserts: 
+      asserts:
         has_n_lines:
           n: 23694
     Compleasm on Contigs hap1 Summary:

--- a/workflows/VGP-assembly-v2/Assembly-Hifi-Trio-phasing-VGP5/Assembly-Hifi-Trio-phasing-VGP5-tests.yml
+++ b/workflows/VGP-assembly-v2/Assembly-Hifi-Trio-phasing-VGP5/Assembly-Hifi-Trio-phasing-VGP5-tests.yml
@@ -6,22 +6,37 @@
       class: File
       location: https://zenodo.org/records/10056319/files/Meryl%20Database%20-%20Child.meryldb?download=1
       filetype: meryldb
+      hashes:
+      - hash_function: SHA-1
+        hash_value: d947eb6b317fcd30bc18e59f1ddd0afa52f72587
     'Hapmer Database: Paternal':
       class: File
       location: https://zenodo.org/records/10056319/files/Hapmer%20Database%20-%20Paternal.meryldb?download=1
       filetype: meryldb
+      hashes:
+      - hash_function: SHA-1
+        hash_value: cb3b00cbd6415c46ce2e4dc2d8a9f2430818a3ab
     'Hapmer Database: Maternal':
       class: File
       location: https://zenodo.org/records/10056319/files/Hapmer%20Database%20-%20Maternal.meryldb?download=1
       filetype: meryldb
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 2fca1ca9b87ad48c7f1291bac29abd98eb5f43d8
     Genomescope Summary:
       class: File
       location: https://zenodo.org/records/10056319/files/Genomescope%20Summary.txt?download=1
       filetype: txt
+      hashes:
+      - hash_function: SHA-1
+        hash_value: c3614564b2c84ef811c5d8bc56c394624d283fe4
     Genomescope Model Parameters:
       class: File
       path: test-data/GenomeScope_Model_parameters.tabular
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 6daf4567ff37e9d5ceebf76ddeb15e0d5773f694
     'Pacbio Reads Collection: child':
       class: Collection
       collection_type: list
@@ -29,6 +44,9 @@
       - class: File
         identifier: yeast_reads_sub1.fastq.gz
         location: https://zenodo.org/records/10056319/files/Pacbio%20Reads%20Collection.fastq.gz?download=1
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 6757ca53673956e3f536d8f3fe08c6b3c6287d37
     Paternal Illumina reads (hap1):
       class: Collection
       collection_type: list
@@ -36,9 +54,15 @@
       - class: File
         identifier: hap1_2.fq
         location: https://zenodo.org/records/10056319/files/Sub_hap1_2.fastqsanger?download=1
+        hashes:
+        - hash_function: SHA-1
+          hash_value: dccc29434921e0ac1b22819a2bc39c1a293f4f4a
       - class: File
         identifier: hap1_1.fq
         location: https://zenodo.org/records/10056319/files/Sub_hap1_1.fastqsanger?download=1
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 18776ce58066ec81ec47cf5a9987a5f3ba911348
     Maternal Illumina reads (hap2):
       class: Collection
       collection_type: list
@@ -46,21 +70,27 @@
       - class: File
         identifier: hap2_2.fq
         location: https://zenodo.org/records/10056319/files/Sub_hap2_2.fastqsanger?download=1
+        hashes:
+        - hash_function: SHA-1
+          hash_value: dc93abf6733d6069c7fc5c1d250527844638a91c
       - class: File
         identifier: hap2_1.fq
         location: https://zenodo.org/records/10056319/files/Sub_hap2_1.fastqsanger?download=1
-    Homozygous Read Coverage: null
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 450db0747f0d09b18e6b9c16b4d1aef8243bfa24
+    Homozygous Read Coverage:
     Bits for bloom filter: 32
     Name for Haplotype 1: Hap1
     Name for Haplotype 2: Hap2
     Database for Busco Lineage: v5
-    Lineage: vertebrata_odb10 
+    Lineage: vertebrata_odb10
   outputs:
-    Estimated Genome size: 2288021 
+    Estimated Genome size: 2288021
     Assembly statistics for Hap1 and Hap2:
       asserts:
         has_line:
-          line: "# contigs	81	27"
+          line: "# contigs\t81\t27"
     usable hap1 gfa:
       asserts:
         has_n_lines:
@@ -75,7 +105,7 @@
           text: "C:1.2%[S:1.1%,D:0.0%],F:0.4%,M:98.4%"
     Nx Plot:
       asserts:
-        has_size: 
+        has_size:
           value: 65000
           delta: 5000
     No Sequence hap1 gfa:

--- a/workflows/VGP-assembly-v2/Assembly-Hifi-only-VGP3/Assembly-Hifi-only-VGP3-tests.yml
+++ b/workflows/VGP-assembly-v2/Assembly-Hifi-only-VGP3/Assembly-Hifi-only-VGP3-tests.yml
@@ -6,14 +6,23 @@
       class: File
       location: https://zenodo.org/record/8371053/files/Meryl-db.meryldb?download=1
       filetype: meryldb
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 95615073e670e81ca03e6582b7da437c915cfccd
     Genomescope Summary:
       class: File
       location: https://zenodo.org/record/8371053/files/GenomeScope_Summary.txt?download=1
       filetype: txt
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 42c6e189d26791e637dbaee533ad13cab39a7c1b
     Genomescope Model Parameters:
       class: File
       path: test-data/GenomeScope_Model_parameters.tabular
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 6daf4567ff37e9d5ceebf76ddeb15e0d5773f694
     Pacbio Reads Collection:
       class: Collection
       collection_type: list
@@ -22,8 +31,11 @@
         identifier: yeast_reads_sub1.fastq.gz
         location: https://zenodo.org/record/8371053/files/yeast_reads_sub1.fastq.gz?download=1
         filetype: fastqsanger.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 6757ca53673956e3f536d8f3fe08c6b3c6287d37
     Bits for Hifiasm bloom filter: 32
-    Homozygous Read Coverage: null
+    Homozygous Read Coverage:
     Database for Busco Lineage: v5
     Lineage: vertebrata_odb10
     Name of primary assembly: Primary
@@ -40,23 +52,23 @@
     Assembly Stats on Alternate Assembly:
       asserts:
         has_line:
-          line: "# scaffolds	3"
+          line: "# scaffolds\t3"
     Estimated Genome size: 2288021
     Assembly Stats on Primary assembly:
       asserts:
         has_line:
-          line: "# scaffolds	84"
+          line: "# scaffolds\t84"
     Assembly statistics:
       asserts:
         has_line:
-          line: "# scaffolds	84	3"
+          line: "# scaffolds\t84\t3"
     Busco Summary:
       asserts:
         has_text:
           text: "C:1.2%[S:1.2%,D:0.0%],F:0.4%,M:98.4%,n:3354"
     Nx Plot:
       asserts:
-        has_size: 
+        has_size:
           value: 60000
           delta: 10000
     "Compleasm on Primary Assembly contigs: Translated Proteins":

--- a/workflows/VGP-assembly-v2/Assembly-decontamination-VGP9/Assembly-decontamination-VGP9-tests.yml
+++ b/workflows/VGP-assembly-v2/Assembly-decontamination-VGP9/Assembly-decontamination-VGP9-tests.yml
@@ -4,85 +4,91 @@
       class: File
       location: https://zenodo.org/records/16999526/files/Genome_assembly.fasta.gz
       filetype: fasta.gz
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 7ae7b2e76aad9ac560657a87faee53438dcfe708
     Taxonomic Identifier: '9606'
     Species Binomial Name: Homo Sapiens
     Assembly Name: Hg19
     Haplotype: Haplotype 1
     Maximum length of sequence to consider for mitochondrial scaffolds: 0
-    Database for NCBI FCS GX : test-only
+    Database for NCBI FCS GX: test-only
   outputs:
     Masking Action Report:
       asserts:
-        - has_text:
-            text: "seq_00010	745809	FIX	100001..100058"
+      - has_text:
+          text: "seq_00010\t745809\tFIX\t100001..100058"
     Taxonomy Report:
       asserts:
-        - has_text:
-            text: "seq_00017	85779	0,13059,0,0,0,0,0	3864	|	Bacteroides massiliensis"
+      - has_text:
+          text: "seq_00017\t85779\t0,13059,0,0,0,0,0\t3864\t|\tBacteroides massiliensis"
     Contaminants sequences:
       asserts:
-        - has_text:
-            text: ">seq_00238"
-        - has_n_lines:
-            n: 14
+      - has_text:
+          text: ">seq_00238"
+      - has_n_lines:
+          n: 14
     Mitochondrial Scaffolds:
       asserts:
-        - has_text:
-            text: "seq_00500"
+      - has_text:
+          text: "seq_00500"
     Adaptor Report:
       asserts:
-        - has_text:
-            text: "seq_00010	745809	ACTION_TRIM	100001..100058"
+      - has_text:
+          text: "seq_00010\t745809\tACTION_TRIM\t100001..100058"
     Final Decontaminated Assembly:
       decompress: true
       asserts:
-        - not_has_text: 
-            text: "seq_00500"
-        - not_has_text:
-            text: "seq_00238"
-        - has_text:
-            text: "seq_00024"
+      - not_has_text:
+          text: "seq_00500"
+      - not_has_text:
+          text: "seq_00238"
+      - has_text:
+          text: "seq_00024"
 - doc: Test outline for Assembly-decontamination-VGP9 without mid-sequence adaptors
   job:
     Scaffolded assembly (fasta):
       class: File
       location: https://zenodo.org/records/17296714/files/Genome_assembly_2.fasta
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: e51edc961b61efb217eaf823727507265e77d637
     Taxonomic Identifier: '9606'
     Species Binomial Name: Homo Sapiens
     Assembly Name: Hg19
     Haplotype: Haplotype 1
     Maximum length of sequence to consider for mitochondrial scaffolds: 0
-    Database for NCBI FCS GX : test-only
+    Database for NCBI FCS GX: test-only
   outputs:
     Masking Action Report:
       asserts:
-        - has_text:
-            text: "seq_00001	230276	ACTION_TRIM"
+      - has_text:
+          text: "seq_00001\t230276\tACTION_TRIM"
     Taxonomy Report:
       asserts:
-        - has_text:
-            text: "seq_00017	85779	0,13059,0,0,0,0,0	3864	|	Bacteroides massiliensis"
+      - has_text:
+          text: "seq_00017\t85779\t0,13059,0,0,0,0,0\t3864\t|\tBacteroides massiliensis"
     Contaminants sequences:
       asserts:
-        - has_text:
-            text: ">seq_00238"
-        - has_n_lines:
-            n: 14
+      - has_text:
+          text: ">seq_00238"
+      - has_n_lines:
+          n: 14
     Mitochondrial Scaffolds:
       asserts:
-        - has_text:
-            text: "seq_00500"
+      - has_text:
+          text: "seq_00500"
     Adaptor Report:
       asserts:
-        - has_text:
-            text: "seq_00001	230276	ACTION_TRIM"
+      - has_text:
+          text: "seq_00001\t230276\tACTION_TRIM"
     Final Decontaminated Assembly:
       decompress: true
       asserts:
-        - not_has_text: 
-            text: "seq_00500"
-        - not_has_text:
-            text: "seq_00238"
-        - has_text:
-            text: "seq_00024"          
+      - not_has_text:
+          text: "seq_00500"
+      - not_has_text:
+          text: "seq_00238"
+      - has_text:
+          text: "seq_00024"

--- a/workflows/VGP-assembly-v2/Mitogenome-assembly-VGP0/Mitogenome-Assembly-VGP0-tests.yml
+++ b/workflows/VGP-assembly-v2/Mitogenome-assembly-VGP0/Mitogenome-Assembly-VGP0-tests.yml
@@ -7,15 +7,18 @@
       - class: File
         identifier: pacbio_01.fasta.gz
         location: https://zenodo.org/records/10454765/files/pacbio_01.fasta.gz?download=1
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 2a202c392647de30904c8886bf42c0f948b28797
     Species name (latin name): Theretra latreillii lucasii
     Assembly Name: MW539688
     Email adress: iwc@galaxyproject.org
-    Genetic Code: '2' 
+    Genetic Code: '2'
   outputs:
     "Mitogenome: Contigs Statistics":
       asserts:
         has_text:
-          text: "15316	36	True"
+          text: "15316\t36\tTrue"
     "Mitogenome coverage: Image":
       asserts:
         has_size:

--- a/workflows/VGP-assembly-v2/Plot-Nx-Size/Generate-Nx-and-Size-plots-for-multiple-assemblies-tests.yml
+++ b/workflows/VGP-assembly-v2/Plot-Nx-Size/Generate-Nx-and-Size-plots-for-multiple-assemblies-tests.yml
@@ -7,9 +7,15 @@
       - class: File
         identifier: Primary
         location: https://zenodo.org/records/10047837/files/Hifiasm%20Primary%20assembly.fasta?download=1
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 0c2c964e5b5d8ca1025b6e9d8f24c8e2224e88c0
       - class: File
         identifier: Alternate
         location: https://zenodo.org/records/10047837/files/Hifiasm%20Alternate%20assembly.fasta?download=1
+        hashes:
+        - hash_function: SHA-1
+          hash_value: bbf0d8abfb61a93c1641aa901ad2f347024cfadc
   outputs:
     Size Plot:
       asserts:

--- a/workflows/VGP-assembly-v2/Purge-duplicate-contigs-VGP6/Purge-duplicate-contigs-VGP6-tests.yml
+++ b/workflows/VGP-assembly-v2/Purge-duplicate-contigs-VGP6/Purge-duplicate-contigs-VGP6-tests.yml
@@ -6,22 +6,37 @@
       class: File
       location: https://zenodo.org/records/10047837/files/Hifiasm%20Primary%20assembly.fasta?download=1
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 0c2c964e5b5d8ca1025b6e9d8f24c8e2224e88c0
     Hifiasm Alternate assembly:
       class: File
       location: https://zenodo.org/records/10047837/files/Hifiasm%20Alternate%20assembly.fasta?download=1
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: bbf0d8abfb61a93c1641aa901ad2f347024cfadc
     Meryl Database:
       class: File
       location: https://zenodo.org/records/10047837/files/Meryl%20Database.meryldb?download=1
       filetype: meryldb
+      hashes:
+      - hash_function: SHA-1
+        hash_value: d947eb6b317fcd30bc18e59f1ddd0afa52f72587
     Genomescope model parameters:
       class: File
       location: https://zenodo.org/records/10047837/files/Genomescope%20model%20parameters.tabular?download=1
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 6daf4567ff37e9d5ceebf76ddeb15e0d5773f694
     Estimated genome size - Parameter File:
       class: File
       location: https://zenodo.org/records/10047837/files/Estimated%20genome%20size%20-%20Parameter%20File.expression.json?download=1
       filetype: expression.json
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 378f4f5733c91e6d6ea5be5b2b979ca865e78aae
     Pacbio Reads Collection - Trimmed:
       class: Collection
       collection_type: list
@@ -29,6 +44,9 @@
       - class: File
         identifier: yeast_reads_sub1.fastq.gz
         location: https://zenodo.org/records/10047837/files/Pacbio%20Reads%20Collection%20-%20Trimmed_yeast_reads_sub1.fastq.gz.fastq.gz?download=1
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 22655cfeb863227dc07af755f6a892a4558c16cf
     Database for Busco Lineage: v5
     Lineage: vertebrata_odb10
     Name of primary assembly: Primary
@@ -37,7 +55,7 @@
     Cutoffs for primary assembly:
       asserts:
         has_text:
-          text: "1	15	15	16	16	48"
+          text: "1\t15\t15\t16\t16\t48"
     Purged Primary Assembly:
       asserts:
         has_n_lines:
@@ -53,7 +71,7 @@
     Cutoffs for alternate assembly:
       asserts:
         has_text:
-          text: "1	15	15	16	16	48"
+          text: "1\t15\t15\t16\t16\t48"
     Purged Alternate assembly:
       asserts:
         has_n_lines:
@@ -65,18 +83,18 @@
     Assembly statistics for purged assemblies:
       asserts:
         has_text:
-          text: "# contigs	78	72"
+          text: "# contigs\t78\t72"
     Nx Plot:
       asserts:
-        has_size: 
+        has_size:
           value: 61000
           delta: 5000
     'Merqury on Phased assemblies: stats':
       element_tests:
         output_merqury.completeness:
-         asserts:
-          has_text:
-            text: "both	all	1212740	1300032	93.2854"
+          asserts:
+            has_text:
+              text: "both\tall\t1212740\t1300032\t93.2854"
     "Compleasm on purged primary/hap1 assembly: Translated Proteins":
       asserts:
         has_n_lines:

--- a/workflows/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b-tests.yml
+++ b/workflows/VGP-assembly-v2/Purge-duplicates-one-haplotype-VGP6b/Purging-duplicates-one-haplotype-VGP6b-tests.yml
@@ -7,22 +7,37 @@
       class: File
       location: https://zenodo.org/records/10632760/files/Genomescope%20model%20parameters.tabular?download=1
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 6daf4567ff37e9d5ceebf76ddeb15e0d5773f694
     Assembly to purge:
       class: File
       location: https://zenodo.org/records/10632760/files/hap1.fasta?download=1
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 0c2c964e5b5d8ca1025b6e9d8f24c8e2224e88c0
     Meryl Database:
       class: File
       location: https://zenodo.org/records/10632760/files/Meryl%20Database.meryldb?download=1
       filetype: meryldb
+      hashes:
+      - hash_function: SHA-1
+        hash_value: d947eb6b317fcd30bc18e59f1ddd0afa52f72587
     Estimated genome size - Parameter File:
       class: File
       location: https://zenodo.org/records/10632760/files/Estimated%20genome%20size%20-%20Parameter%20File.expression.json?download=1
       filetype: expression.json
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 378f4f5733c91e6d6ea5be5b2b979ca865e78aae
     Assembly to leave alone (For Merqury comparison):
       class: File
       location: https://zenodo.org/records/10632760/files/hap2.fasta?download=1
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: bbf0d8abfb61a93c1641aa901ad2f347024cfadc
     Pacbio Reads Collection - Trimmed:
       class: Collection
       collection_type: list
@@ -30,6 +45,9 @@
       - class: File
         identifier: yeast_reads_sub1.fastq.gz
         location: https://zenodo.org/records/10632760/files/Trimmed_yeast_reads_sub1.fastq.gz?download=1
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 6757ca53673956e3f536d8f3fe08c6b3c6287d37
     Name of un-altered assembly: Hap2
     Name of purged assembly: Hap1
     Database for Busco Lineage: v5
@@ -44,13 +62,13 @@
         has_n_lines:
           n: 158
     Purged assembly (GFA):
-     asserts:
+      asserts:
         has_n_lines:
           n: 160
     Assembly statistics for both assemblies:
       asserts:
         has_text:
-          text: "# scaffolds	79	79"
+          text: "# scaffolds\t79\t79"
     Cutoffs:
       asserts:
         has_text:
@@ -62,7 +80,7 @@
     Purged assembly statistics:
       asserts:
         has_text:
-          text: "# scaffolds	79"
+          text: "# scaffolds\t79"
     Nx Plot:
       asserts:
         has_size:

--- a/workflows/VGP-assembly-v2/Scaffolding-Bionano-VGP7/Scaffolding-BioNano-VGP7-tests.yml
+++ b/workflows/VGP-assembly-v2/Scaffolding-Bionano-VGP7/Scaffolding-BioNano-VGP7-tests.yml
@@ -4,14 +4,23 @@
       class: File
       location: https://zenodo.org/records/10063794/files/Bionano%20Data.cmap?download=1
       filetype: cmap
+      hashes:
+      - hash_function: SHA-1
+        hash_value: adfb6481579e41f7e22a0862be2a9ac6f23e1615
     Estimated genome size - Parameter File:
       class: File
       location: https://zenodo.org/records/10063794/files/Estimated%20genome%20size%20-%20Parameter%20File.expression.json?download=1
       filetype: expression.json
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 387649fbac6ede96037bd8cf4a3d184645ce2d7b
     Input GFA:
       class: File
       location: https://zenodo.org/records/10063794/files/Input%20GFA.gfa1?download=1
       filetype: gfa1
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 9a7ae707193197354124d5d8fd71d3ab0ba4606d
   outputs:
     'Bionano scaffolds reconciliated: gfa':
       asserts:
@@ -20,7 +29,7 @@
     Assembly Statistics for s1:
       asserts:
         has_line:
-          line: "# scaffolds	24"
+          line: "# scaffolds\t24"
     'Scaffolds: agp':
       asserts:
         has_n_lines:
@@ -31,6 +40,6 @@
           n: 390825
     Nx Plot:
       asserts:
-        has_size: 
-          value : 76000
+        has_size:
+          value: 76000
           delta: 5000

--- a/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml
+++ b/workflows/VGP-assembly-v2/Scaffolding-HiC-VGP8/Scaffolding-HiC-VGP8-tests.yml
@@ -4,10 +4,16 @@
       class: File
       location: https://zenodo.org/records/17190637/files/Assembly%20GFA.gfa1
       filetype: gfa1
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 674d80de5c15f407a7f8c194d0fa098bef9ae53b
     Estimated genome size - Parameter File:
       class: File
       location: https://zenodo.org/records/17190637/files/Estimated%20genome%20size%20-%20Parameter%20File.expression.json
       filetype: expression.json
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 71cb196fbcdbf99c80d431de60704386d3a92d5f
     Hi-C reads:
       class: Collection
       collection_type: list:paired
@@ -19,9 +25,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMMCCXY_L6_R1.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: e28a3c03d447f75f9f4b1ebba638d7519718653f
         - class: File
           identifier: reverse
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMMCCXY_L6_R2.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: a79ef11410b7d1f28f93dcbbd0c9ca12537c9df2
       - class: Collection
         type: paired
         identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L8_R1.fq.gz
@@ -29,9 +41,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L8_R1.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: f327e867f7e9b986b60196152c020b7c1a177e1b
         - class: File
           identifier: reverse
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L8_R2.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: cc4bf7af7686447bf9409aeb50f3825faca87e1b
       - class: Collection
         type: paired
         identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L7_R1.fq.gz
@@ -39,9 +57,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L7_R1.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 9b67b4d69cc9b0bc8248a68550d2b2c19b3ac2ac
         - class: File
           identifier: reverse
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L7_R2.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 10085c31a5d99205c52dca89b3df569165c226cc
       - class: Collection
         type: paired
         identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L6_R1.fq.gz
@@ -49,9 +73,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L6_R1.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 688442b3d97416f02eadb6fc4e3b3021d6b2c8bf
         - class: File
           identifier: reverse
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L6_R2.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 9f3fdec98d03356b6dd73710e5ab723867b6b4a4
       - class: Collection
         type: paired
         identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L5_R1.fq.gz
@@ -59,9 +89,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L5_R1.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: cf4fea47b72d4f81f099a7a98729a53237b91441
         - class: File
           identifier: reverse
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L5_R2.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 1b806853794f65b6292f3e7a16294543d09ccba8
       - class: Collection
         type: paired
         identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L4_R1.fq.gz
@@ -69,9 +105,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L4_R1.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 17e493fc2b897bb8233ad3fe6d08010804f76e9d
         - class: File
           identifier: reverse
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L4_R2.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 97dd20426ecaa0a85c098506354c2dcbc8abf534
       - class: Collection
         type: paired
         identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L3_R1.fq.gz
@@ -79,9 +121,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L3_R1.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 7f7d69998da49d5d34a2801dff8485bddaa74750
         - class: File
           identifier: reverse
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L3_R2.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 372ff52ecf58d379fa227a0392af88a2501eca54
       - class: Collection
         type: paired
         identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L2_R1.fq.gz
@@ -89,9 +137,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L2_R1.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: ae585d838170a5388f6a148328a6cf0a7d85afd1
         - class: File
           identifier: reverse
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L2_R2.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 3b5a6f100e0ee9787b1a8aea7a255ac860e53346
       - class: Collection
         type: paired
         identifier: bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L1_R1.fq.gz
@@ -99,9 +153,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L1_R1.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: f873ddaa1822673498879dd6f4b37e16641fd430
         - class: File
           identifier: reverse
           location: https://zenodo.org/records/17190637/files/bTaeGut2_ARI8_001_USPD16084394-AK5146_HJFMFCCXY_L1_R2.fq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: c70c3e99b70ee81f4262ddba46cdc2a8abb7964b
     Species Name: test
     Assembly Name: test
     Haplotype: Haplotype 1
@@ -113,63 +173,63 @@
   outputs:
     Markdup Stats:
       asserts:
-        - has_text: 
-            text: "Unknown Library	4	16976	3251	4	0	2255	1970	0.132819	390034"
+      - has_text:
+          text: "Unknown Library\t4\t16976\t3251\t4\t0\t2255\t1970\t0.132819\t390034"
     Suffixed AGP:
       asserts:
-        - has_text: 
-            text: "scaffold_1.H1"
+      - has_text:
+          text: "scaffold_1.H1"
     'Reconciliated Scaffolds: gfa':
       asserts:
-        - has_n_lines:
-            n: 5
+      - has_n_lines:
+          n: 5
     Assembly Statistics for s2:
       asserts:
-        - has_text: 
-            text: "Total scaffold length	5,788,676"
+      - has_text:
+          text: "Total scaffold length\t5,788,676"
     Scaffolding Plots:
       asserts:
-        - has_size: 
-            value : 93200
-            delta: 5000
+      - has_size:
+          value: 93200
+          delta: 5000
     Hi-C Alignment Stats scaffolds:
       asserts:
-        - has_text: 
-            text: "SN	reads mapped and paired:	33952"
+      - has_text:
+          text: "SN\treads mapped and paired:\t33952"
     Hi-C alignments stats:
       asserts:
-        - has_text: 
-            text: "Hi-C Alignment Stats scaffolds	1.26353	0.0	0.033956"
+      - has_text:
+          text: "Hi-C Alignment Stats scaffolds\t1.26353\t0.0\t0.033956"
     Hi-C maps:
       asserts:
-        - has_size: 
-            value : 835200
-            delta: 50000
+      - has_size:
+          value: 835200
+          delta: 50000
     Hi-C Alignment Stats pre-scaffolding:
       asserts:
-        - has_text: 
-            text: "SN	reads mapped and paired:	33952"
+      - has_text:
+          text: "SN\treads mapped and paired:\t33952"
     Markduplicates Summary:
       asserts:
-        - has_text: 
-            text: "Unknown Library	4	16976	3251	4	0	2255	1970	0.132819	390034"
+      - has_text:
+          text: "Unknown Library\t4\t16976\t3251\t4\t0\t2255\t1970\t0.132819\t390034"
     Compleasm Full Table Busco:
       asserts:
-        - has_n_lines:
-            n: 3355
+      - has_n_lines:
+          n: 3355
     Summary Numbers Scaffolds:
       asserts:
-        - has_text: 
-            text: "reads mapped and paired:	33952"
+      - has_text:
+          text: "reads mapped and paired:\t33952"
     Merged Alignment stats:
       asserts:
-        - has_text: 
-            text: "bases mapped:	5093400	5093400"
+      - has_text:
+          text: "bases mapped:\t5093400\t5093400"
     Summary Numbers Contigs:
       asserts:
-        - has_text: 
-            text: "bases mapped:	5093400"
+      - has_text:
+          text: "bases mapped:\t5093400"
     Scaffolds Compleasm Summary:
       asserts:
-        - has_text: 
-            text: "S:0.00%, 0"
+      - has_text:
+          text: "S:0.00%, 0"

--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation-tests.yml
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation-tests.yml
@@ -4,24 +4,36 @@
       class: File
       location: https://zenodo.org/records/14230702/files/Haplotype%202.fasta
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: b37d7c2409974cd01f5c602fcdf64a49e27e5e77
     Haplotype 2:
       class: File
       location: https://zenodo.org/records/14230702/files/Haplotype%202.fasta
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: b37d7c2409974cd01f5c602fcdf64a49e27e5e77
     Hi-C reads:
       class: Collection
       collection_type: list:paired
       elements:
-        - class: Collection
-          type: paired
-          identifier: Hi-C reads
-          elements:
-          - identifier: forward
-            class: File
-            path: https://zenodo.org/records/14230702/files/HiC%20forward.fastqsanger.gz
-          - identifier: reverse
-            class: File
-            path: https://zenodo.org/records/14230702/files/HiC%20reverse.fastqsanger.gz
+      - class: Collection
+        type: paired
+        identifier: Hi-C reads
+        elements:
+        - identifier: forward
+          class: File
+          path: https://zenodo.org/records/14230702/files/HiC%20forward.fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 4c49cbc443870ec731c79f3a69123c6de8f8de52
+        - identifier: reverse
+          class: File
+          path: https://zenodo.org/records/14230702/files/HiC%20reverse.fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 0041f9c48ca789a6ce1e1f61d355d9e967f00727
     PacBio reads:
       class: Collection
       collection_type: list
@@ -29,6 +41,9 @@
       - class: File
         identifier: PacBio reads.fastq.gz
         location: https://zenodo.org/records/14230702/files/PacBio%20reads.fastq.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: d154e11c10bf3d3484505901f364d2f9cd50d573
     Do you want to add suffixes to the scaffold names?: true
     Will you use a second haplotype?: false
     First Haplotype suffix: H1
@@ -44,38 +59,38 @@
     Gaps Bed:
       asserts:
         has_text:
-          text: "scaffold_10.H1	835498	835698"
+          text: "scaffold_10.H1\t835498\t835698"
     Seqtk-telo Output:
       asserts:
         has_text:
-          text: "scaffold_10.H1	0	11012	139653677"
+          text: "scaffold_10.H1\t0\t11012\t139653677"
     Gaps Bedgraph:
       asserts:
         has_text:
-          text: "scaffold_10.H1	835498	835698	200"
+          text: "scaffold_10.H1\t835498\t835698\t200"
     BigWig Coverage:
       asserts:
         has_size:
-          value : 100000
+          value: 100000
           delta: 40000
     Telomeres Bedgraph:
       asserts:
         has_text:
-          text: "scaffold_10.H1	0	11012	11012"
+          text: "scaffold_10.H1\t0\t11012\t11012"
     Merged Hi-C Alignments:
       asserts:
         has_size:
-          value : 37000000
+          value: 37000000
           delta: 5000000
     Pretext All tracks:
       asserts:
         has_size:
-          value : 790000
+          value: 790000
           delta: 50000
     Pretext All tracks - Multimapping:
       asserts:
         has_size:
-          value : 1700000
+          value: 1700000
           delta: 500000
 - doc: Test outline for hi-c-map-for-assembly-manual-curation.ga 2
   job:
@@ -83,24 +98,36 @@
       class: File
       location: https://zenodo.org/records/14230702/files/Haplotype%201.fasta
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: dd7f28c1a72f429e2c15485003e1f7ec164f7a82
     Haplotype 2:
       class: File
       location: https://zenodo.org/records/14230702/files/Haplotype%201.fasta
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: dd7f28c1a72f429e2c15485003e1f7ec164f7a82
     Hi-C reads:
       class: Collection
       collection_type: list:paired
       elements:
-        - class: Collection
-          type: paired
-          identifier: Hi-C reads
-          elements:
-          - identifier: forward
-            class: File
-            path: https://zenodo.org/records/14230702/files/HiC%20forward.fastqsanger.gz
-          - identifier: reverse
-            class: File
-            path: https://zenodo.org/records/14230702/files/HiC%20reverse.fastqsanger.gz
+      - class: Collection
+        type: paired
+        identifier: Hi-C reads
+        elements:
+        - identifier: forward
+          class: File
+          path: https://zenodo.org/records/14230702/files/HiC%20forward.fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 4c49cbc443870ec731c79f3a69123c6de8f8de52
+        - identifier: reverse
+          class: File
+          path: https://zenodo.org/records/14230702/files/HiC%20reverse.fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 0041f9c48ca789a6ce1e1f61d355d9e967f00727
     PacBio reads:
       class: Collection
       collection_type: list
@@ -108,6 +135,9 @@
       - class: File
         identifier: PacBio reads.fastq.gz
         location: https://zenodo.org/records/14230702/files/PacBio%20reads.fastq.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: d154e11c10bf3d3484505901f364d2f9cd50d573
     Do you want to add suffixes to the scaffold names?: true
     Will you use a second haplotype?: false
     First Haplotype suffix: H1
@@ -122,28 +152,28 @@
     Gaps Bed:
       asserts:
         has_text:
-          text: "scaffold_10.H1	34145604	34145804"
+          text: "scaffold_10.H1\t34145604\t34145804"
     Gaps Bedgraph:
       asserts:
         has_text:
-          text: "scaffold_10.H1	34145604	34145804	200"
+          text: "scaffold_10.H1\t34145604\t34145804\t200"
     BigWig Coverage:
       asserts:
         has_size:
-          value : 100000
+          value: 100000
           delta: 40000
     Merged Hi-C Alignments:
       asserts:
         has_size:
-          value : 37000000
+          value: 37000000
           delta: 5000000
     Pretext All tracks:
       asserts:
         has_size:
-          value : 780000
+          value: 780000
           delta: 50000
     Pretext All tracks - Multimapping:
       asserts:
         has_size:
-          value : 1600000
+          value: 1600000
           delta: 500000

--- a/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1-tests.yml
+++ b/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1-tests.yml
@@ -7,18 +7,33 @@
       - class: File
         identifier: m54306U_210519_154448
         location: https://zenodo.org/records/17246010/files/Collection%20of%20Pacbio%20Data_m54306U_210519_154448.hifi_reads.fastq.gz.fastqsanger.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 61278426af8c39957816c1646afcfe917466bb0b
       - class: File
         identifier: m54306U_210521_004211
         location: https://zenodo.org/records/17246010/files/Collection%20of%20Pacbio%20Data_m54306U_210521_004211.hifi_reads.fastq.gz.fastqsanger.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 3b1293432d3f93b1168dce65bef7d6d2d0883006
       - class: File
         identifier: m54306Ue_210629_211205
         location: https://zenodo.org/records/17246010/files/Collection%20of%20Pacbio%20Data_m54306Ue_210629_211205.hifi_reads.fastq.gz.fastqsanger.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 8c46ed5c64acd2031a0727816cc7fee8f8763adb
       - class: File
         identifier: m54306Ue_210719_083927
         location: https://zenodo.org/records/17246010/files/Collection%20of%20Pacbio%20Data_m54306Ue_210719_083927.hifi_reads.fastq.gz.fastqsanger.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 9cecd396e3fbfc91d31197f1d226fe6bebcd71ec
       - class: File
         identifier: m64055e_210624_223222.
         location: https://zenodo.org/records/17246010/files/Collection%20of%20Pacbio%20Data_m64055e_210624_223222.hifi_reads.fastq.gz.fastqsanger.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: b9ac2600bd4f2e52dff44d7132c95c2311fbb62b
     Species Name: Test Species
     Assembly Name: toLidId
     K-mer length: 21
@@ -26,41 +41,41 @@
   outputs:
     Data for Interactive HeatMap:
       asserts:
-        - has_text:
-            text: 'm54306U_210521_004211	m54306U_210519_154448	0.0215695'
+      - has_text:
+          text: "m54306U_210521_004211\tm54306U_210519_154448\t0.0215695"
     Merged Meryl Database:
       asserts:
-        - has_size:
-            value: '14000000'
-            delta: '2000000'
+      - has_size:
+          value: '14000000'
+          delta: '2000000'
     GenomeScope summary:
       asserts:
-        - has_text:
-            text: '97.6946%'
+      - has_text:
+          text: '97.6946%'
     GenomeScope Model Parameters:
       asserts:
-        - has_text:
-            text: '0.283605968625878'
+      - has_text:
+          text: '0.283605968625878'
     Montage Genomescope:
       asserts:
-        - has_size:
-            value: '1200000'
-            delta: '200000'
+      - has_size:
+          value: '1200000'
+          delta: '200000'
     Estimated Genome Size File:
       asserts:
-        - has_text:
-            text: '1287751'
+      - has_text:
+          text: '1287751'
     Reads Statistics:
       asserts:
-        - has_text:
-            text: '11080.81'
+      - has_text:
+          text: '11080.81'
     Rdeval report:
       asserts:
-        - has_size:
-            value: '1300000'
-            delta: '200000'
+      - has_size:
+          value: '1300000'
+          delta: '200000'
     HeatMap:
       asserts:
-        - has_size:
-            value: '100000'
-            delta: '20000'
+      - has_size:
+          value: '100000'
+          delta: '20000'

--- a/workflows/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2-tests.yml
+++ b/workflows/amplicon/amplicon-mgnify/mapseq-to-ampvis2/mapseq-to-ampvis2-tests.yml
@@ -7,36 +7,69 @@
       - class: File
         identifier: SRR11032273
         location: https://zenodo.org/records/13347829/files/SRR11032273.tsv
+        hashes:
+        - hash_function: SHA-1
+          hash_value: d2fd3d89b234bbab32970eaf9f0726c58ed29d88
       - class: File
         identifier: SRR11032274
         location: https://zenodo.org/records/13347829/files/SRR11032274.tsv
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 05f4509710e8616a83dd39c2731e032ac3ad1949
       - class: File
         identifier: SRR11032275
         location: https://zenodo.org/records/13347829/files/SRR11032275.tsv
+        hashes:
+        - hash_function: SHA-1
+          hash_value: e80d81e221443905b8219cbeddfbcbea1da4bb59
       - class: File
         identifier: SRR11032276
         location: https://zenodo.org/records/13347829/files/SRR11032276.tsv
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 767b4e0db91d7146d09f1155e2d12d3e0dbf4735
       - class: File
         identifier: SRR11032277
         location: https://zenodo.org/records/13347829/files/SRR11032277.tsv
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 9ddfccd5031022ff22a291ff60c5b310769344ca
       - class: File
         identifier: SRR11038211
         location: https://zenodo.org/records/13347829/files/SRR11038211.tsv
+        hashes:
+        - hash_function: SHA-1
+          hash_value: cdfa0e890e8b643616b6ffbc03ab90e40cbcd0cb
       - class: File
         identifier: SRR11038212
         location: https://zenodo.org/records/13347829/files/SRR11038212.tsv
+        hashes:
+        - hash_function: SHA-1
+          hash_value: c928219b888de07d2e0fab00e28d7f37544fe974
       - class: File
         identifier: SRR11038213
         location: https://zenodo.org/records/13347829/files/SRR11038213.tsv
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 90592603e92455196e4521093ef408cd4515562b
       - class: File
         identifier: SRR11038214
         location: https://zenodo.org/records/13347829/files/SRR11038214.tsv
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 1f115a5823d08bf00976ebd09768f333580b4cbf
       - class: File
         identifier: SRR11038215
         location: https://zenodo.org/records/13347829/files/SRR11038215.tsv
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 63e64aba69f7dfae646f6b06cf939986bdbb39f0
     OTU table metadata:
       class: File
       location: https://zenodo.org/records/13347829/files/test_metadata_formatted.tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 01b1f71016d2fbb1add6e5f36a32f61db40f8bb2
   outputs:
     OTU table:
       location: https://zenodo.org/records/13347829/files/OTU_table.tabular
@@ -44,9 +77,9 @@
       location: https://zenodo.org/records/14745803/files/tax_table.tabular
     Ampvis2 object:
       asserts:
-        - that: has_size
-          value: 15000
-          delta: 1000
+      - that: has_size
+        value: 15000
+        delta: 1000
     Ampvis2 metadata table:
       location: https://zenodo.org/records/13347829/files/metadata_list.tabular
     Ampvis2 taxonomy table:

--- a/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete-tests.yml
+++ b/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete-tests.yml
@@ -3,50 +3,56 @@
     SRA accession list:
       class: File
       location: https://zenodo.org/records/13710235/files/accessions.csv
+      hashes:
+      - hash_function: SHA-1
+        hash_value: cfffa4732996831d4b8521bc90b9b5e7ab77dd6f
     Clan information file:
       class: File
       location: "ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/pipeline-5.0/ref-dbs/rfam_models/ribosomal_models/ribo.claninfo"
+      hashes:
+      - hash_function: SHA-1
+        hash_value: ac1d31c511c0726873c0fd7cad5ab207fed3228c
   outputs:
     Single-end MultiQC report:
       asserts:
-        - that: has_text
-          text: "DRR010481_ambiguous_base_filtering"
-        - that: has_text
-          text: "84.0"
-        - that: has_text
-          text: "DRR010481_initial_reads"
-        - that: has_text
-          text: "84.8"
-        - that: has_text
-          text: "DRR010481_length_filtering"
-        - that: has_text
-          text: "DRR010481_trimming"
+      - that: has_text
+        text: "DRR010481_ambiguous_base_filtering"
+      - that: has_text
+        text: "84.0"
+      - that: has_text
+        text: "DRR010481_initial_reads"
+      - that: has_text
+        text: "84.8"
+      - that: has_text
+        text: "DRR010481_length_filtering"
+      - that: has_text
+        text: "DRR010481_trimming"
     Single-end post quality control FASTA files:
       element_tests:
         DRR010481:
           location: https://zenodo.org/records/13710235/files/DRR010481_SE.fasta
     Single-end MultiQC statistics:
       asserts:
-        - that: has_text
-          text: "DRR010481_ambiguous_base_filtering	84.0	47.0	242.02	244	40.0	2.4999999999999998e-05"
-        - that: has_text
-          text: "DRR010481_initial_reads	84.84848484848484	47.0	545.0454545454545	550	40.0	3.2999999999999996e-05"
-        - that: has_text
-          text: "DRR010481_length_filtering	84.0	47.0	242.02	244	40.0	2.4999999999999998e-05"
-        - that: has_text
-          text: "DRR010481_trimming	84.0	47.0	242.02	244	40.0	2.4999999999999998e-05"
+      - that: has_text
+        text: "DRR010481_ambiguous_base_filtering\t84.0\t47.0\t242.02\t244\t40.0\t2.4999999999999998e-05"
+      - that: has_text
+        text: "DRR010481_initial_reads\t84.84848484848484\t47.0\t545.0454545454545\t550\t40.0\t3.2999999999999996e-05"
+      - that: has_text
+        text: "DRR010481_length_filtering\t84.0\t47.0\t242.02\t244\t40.0\t2.4999999999999998e-05"
+      - that: has_text
+        text: "DRR010481_trimming\t84.0\t47.0\t242.02\t244\t40.0\t2.4999999999999998e-05"
     Paired-end MultiQC report:
       asserts:
-        - that: has_text
-          text: "ERR2715528_ambiguous_base_filtering"
-        - that: has_text
-          text: "ERR2715528_initial_reads"
-        - that: has_text
-          text: "ERR2715528_length_filtering"
-        - that: has_text
-          text: "ERR2715528_trimming"
-        - that: has_text
-          text: "92.2"
+      - that: has_text
+        text: "ERR2715528_ambiguous_base_filtering"
+      - that: has_text
+        text: "ERR2715528_initial_reads"
+      - that: has_text
+        text: "ERR2715528_length_filtering"
+      - that: has_text
+        text: "ERR2715528_trimming"
+      - that: has_text
+        text: "92.2"
     Paired-end MultiQC statistics:
       location: https://zenodo.org/records/14746033/files/general_stats_PE.tabular
     Paired-end post quality control FASTA files:
@@ -62,92 +68,92 @@
       element_tests:
         ERR2715528:
           asserts:
-            - that: has_text
-              text: "# mapseq v1.2.6 (Jan 20 2023)"
-            - that: has_text
-              text: "SILVA"
-            - that: has_n_columns
-              comment: "#"
-              n: 15
+          - that: has_text
+            text: "# mapseq v1.2.6 (Jan 20 2023)"
+          - that: has_text
+            text: "SILVA"
+          - that: has_n_columns
+            comment: "#"
+            n: 15
     SSU OTU tables (SILVA DB):
       element_tests:
         ERR2715528:
           asserts:
-            - that: has_text
-              text: "# Constructed from biom file"
-            - that: has_text
-              text: "# OTU ID"
-            - that: has_text
-              text: "Unspecified"
-            - that: has_text
-              text: "taxonomy"
-            - that: has_text
-              text: "taxid"
-            - that: has_n_columns
-              comment: "#"
-              n: 4
+          - that: has_text
+            text: "# Constructed from biom file"
+          - that: has_text
+            text: "# OTU ID"
+          - that: has_text
+            text: "Unspecified"
+          - that: has_text
+            text: "taxonomy"
+          - that: has_text
+            text: "taxid"
+          - that: has_n_columns
+            comment: "#"
+            n: 4
     LSU OTU tables (SILVA DB):
       element_tests:
         DRR010481:
           asserts:
-            - that: has_text
-              text: "# Constructed from biom file"
-            - that: has_text
-              text: "# OTU ID"
-            - that: has_text
-              text: "Unspecified"
-            - that: has_text
-              text: "taxonomy"
-            - that: has_text
-              text: "taxid"
-            - that: has_n_columns
-              comment: "#"
-              n: 4
+          - that: has_text
+            text: "# Constructed from biom file"
+          - that: has_text
+            text: "# OTU ID"
+          - that: has_text
+            text: "Unspecified"
+          - that: has_text
+            text: "taxonomy"
+          - that: has_text
+            text: "taxid"
+          - that: has_n_columns
+            comment: "#"
+            n: 4
     SSU OTU tables in HDF5 format (SILVA DB):
       element_tests:
         ERR2715528:
           asserts:
-            - that: has_size
-              value: 37000
-              delta: 10000
+          - that: has_size
+            value: 37000
+            delta: 10000
     SSU OTU tables in JSON format (SILVA DB):
       element_tests:
         ERR2715528:
           asserts:
-            - that: has_text
-              text: "\"type\": \"OTU table\""
+          - that: has_text
+            text: "\"type\": \"OTU table\""
     SSU taxonomic abundance pie charts (SILVA DB):
       asserts:
-            - that: has_text
-              text: "ERR2715528"
+      - that: has_text
+        text: "ERR2715528"
     LSU OTU tables in HDF5 format (SILVA DB):
       element_tests:
         DRR010481:
           asserts:
-            - that: has_size
-              value: 37000
-              delta: 10000
+          - that: has_size
+            value: 37000
+            delta: 10000
     LSU OTU tables in JSON format (SILVA DB):
       element_tests:
         DRR010481:
           asserts:
-            - that: has_text
-              text: "\"type\": \"OTU table\""
+          - that: has_text
+            text: "\"type\": \"OTU table\""
     LSU taxonomic abundance pie charts (SILVA DB):
       asserts:
-            - that: has_text
-              text: "DRR010481"
+      - that: has_text
+        text: "DRR010481"
     LSU taxonomic classifications using SILVA DB:
       element_tests:
         DRR010481:
           asserts:
-            - that: has_text
-              text: "# mapseq v1.2.6 (Jan 20 2023)"
-            - that: has_text
-              text: "SILVA"
-            - that: has_n_columns
-              comment: "#"
-              n: 15
+          - that: has_text
+            text: "# mapseq v1.2.6 (Jan 20 2023)"
+          - that: has_text
+            text: "SILVA"
+          - that: has_n_columns
+            comment: "#"
+            n: 15
     SSU FASTA files:
       element_tests:
         ERR2715528:
@@ -163,22 +169,22 @@
       element_tests:
         DRR010481:
           asserts:
-            - that: has_text
-              text: "# mapseq v1.2.6 (Jan 20 2023)"
-            - that: has_text
-              text: "ITSone"
-            - that: has_n_columns
-              comment: "#"
-              n: 15
+          - that: has_text
+            text: "# mapseq v1.2.6 (Jan 20 2023)"
+          - that: has_text
+            text: "ITSone"
+          - that: has_n_columns
+            comment: "#"
+            n: 15
         ERR2715528:
           asserts:
-            - that: has_text
-              text: "# mapseq v1.2.6 (Jan 20 2023)"
-            - that: has_text
-              text: "ITSone"
-            - that: has_n_columns
-              comment: "#"
-              n: 15
+          - that: has_text
+            text: "# mapseq v1.2.6 (Jan 20 2023)"
+          - that: has_text
+            text: "ITSone"
+          - that: has_n_columns
+            comment: "#"
+            n: 15
     ITS FASTA files:
       element_tests:
         DRR010481:
@@ -191,211 +197,211 @@
       element_tests:
         DRR010481:
           asserts:
-            - that: has_text
-              text: "\"type\": \"OTU table\""
+          - that: has_text
+            text: "\"type\": \"OTU table\""
         ERR2715528:
           asserts:
-            - that: has_text
-              text: "\"type\": \"OTU table\""
+          - that: has_text
+            text: "\"type\": \"OTU table\""
     ITS taxonomic abundance pie charts (UNITE DB):
       asserts:
-            - that: has_text
-              text: "DRR010481"
-            - that: has_text
-              text: "ERR2715528"
+      - that: has_text
+        text: "DRR010481"
+      - that: has_text
+        text: "ERR2715528"
     ITS OTU tables in HDF5 format (UNITE DB):
       element_tests:
         DRR010481:
           asserts:
-            - that: has_size
-              value: 37000
-              delta: 10000
+          - that: has_size
+            value: 37000
+            delta: 10000
         ERR2715528:
           asserts:
-            - that: has_size
-              value: 72000
-              delta: 10000
+          - that: has_size
+            value: 72000
+            delta: 10000
     ITS taxonomic abundance pie charts (ITSoneDB):
       asserts:
-        - that: has_text
-          text: "DRR010481"
-        - that: has_text
-          text: "ERR2715528"
+      - that: has_text
+        text: "DRR010481"
+      - that: has_text
+        text: "ERR2715528"
     ITS OTU tables in JSON format (ITSoneDB):
       element_tests:
         DRR010481:
           asserts:
-            - that: has_text
-              text: "\"type\": \"OTU table\""
+          - that: has_text
+            text: "\"type\": \"OTU table\""
         ERR2715528:
           asserts:
-            - that: has_text
-              text: "\"type\": \"OTU table\""
+          - that: has_text
+            text: "\"type\": \"OTU table\""
     ITS OTU tables in HDF5 format (ITSoneDB):
       element_tests:
         DRR010481:
           asserts:
-            - that: has_size
-              value: 37000
-              delta: 10000
+          - that: has_size
+            value: 37000
+            delta: 10000
         ERR2715528:
           asserts:
-            - that: has_size
-              value: 72000
-              delta: 10000
+          - that: has_size
+            value: 72000
+            delta: 10000
     ITS taxonomic classifications using UNITE DB:
       element_tests:
         DRR010481:
           asserts:
-            - that: has_text
-              text: "# mapseq v1.2.6 (Jan 20 2023)"
-            - that: has_text
-              text: "UNITE"
-            - that: has_n_columns
-              comment: "#"
-              n: 15
+          - that: has_text
+            text: "# mapseq v1.2.6 (Jan 20 2023)"
+          - that: has_text
+            text: "UNITE"
+          - that: has_n_columns
+            comment: "#"
+            n: 15
         ERR2715528:
           asserts:
-            - that: has_text
-              text: "# mapseq v1.2.6 (Jan 20 2023)"
-            - that: has_text
-              text: "UNITE"
-            - that: has_n_columns
-              comment: "#"
-              n: 15
+          - that: has_text
+            text: "# mapseq v1.2.6 (Jan 20 2023)"
+          - that: has_text
+            text: "UNITE"
+          - that: has_n_columns
+            comment: "#"
+            n: 15
     ITS OTU tables (UNITE DB):
       element_tests:
         DRR010481:
           asserts:
-            - that: has_text
-              text: "# Constructed from biom file"
-            - that: has_text
-              text: "# OTU ID"
-            - that: has_text
-              text: "Unspecified"
-            - that: has_text
-              text: "taxonomy"
-            - that: has_text
-              text: "taxid"
-            - that: has_n_columns
-              comment: "#"
-              n: 4
+          - that: has_text
+            text: "# Constructed from biom file"
+          - that: has_text
+            text: "# OTU ID"
+          - that: has_text
+            text: "Unspecified"
+          - that: has_text
+            text: "taxonomy"
+          - that: has_text
+            text: "taxid"
+          - that: has_n_columns
+            comment: "#"
+            n: 4
         ERR2715528:
           asserts:
-            - that: has_text
-              text: "# Constructed from biom file"
-            - that: has_text
-              text: "# OTU ID"
-            - that: has_text
-              text: "Unspecified"
-            - that: has_text
-              text: "taxonomy"
-            - that: has_text
-              text: "taxid"
-            - that: has_n_columns
-              comment: "#"
-              n: 4
+          - that: has_text
+            text: "# Constructed from biom file"
+          - that: has_text
+            text: "# OTU ID"
+          - that: has_text
+            text: "Unspecified"
+          - that: has_text
+            text: "taxonomy"
+          - that: has_text
+            text: "taxid"
+          - that: has_n_columns
+            comment: "#"
+            n: 4
     ITS OTU tables (ITSoneDB):
       element_tests:
         DRR010481:
           asserts:
-            - that: has_text
-              text: "# Constructed from biom file"
-            - that: has_text
-              text: "# OTU ID"
-            - that: has_text
-              text: "Unspecified"
-            - that: has_text
-              text: "taxonomy"
-            - that: has_text
-              text: "taxid"
-            - that: has_n_columns
-              comment: "#"
-              n: 4
+          - that: has_text
+            text: "# Constructed from biom file"
+          - that: has_text
+            text: "# OTU ID"
+          - that: has_text
+            text: "Unspecified"
+          - that: has_text
+            text: "taxonomy"
+          - that: has_text
+            text: "taxid"
+          - that: has_n_columns
+            comment: "#"
+            n: 4
         ERR2715528:
           asserts:
-            - that: has_text
-              text: "# Constructed from biom file"
-            - that: has_text
-              text: "# OTU ID"
-            - that: has_text
-              text: "Unspecified"
-            - that: has_text
-              text: "taxonomy"
-            - that: has_text
-              text: "taxid"
-            - that: has_n_columns
-              comment: "#"
-              n: 4
+          - that: has_text
+            text: "# Constructed from biom file"
+          - that: has_text
+            text: "# OTU ID"
+          - that: has_text
+            text: "Unspecified"
+          - that: has_text
+            text: "taxonomy"
+          - that: has_text
+            text: "taxid"
+          - that: has_n_columns
+            comment: "#"
+            n: 4
     ITSoneDB phylum level taxonomic abundance summary table:
       asserts:
-        - that: has_text
-          text: 'superkingdom	kingdom	phylum	DRR010481	ERR2715528'
-        - that: has_n_columns
-          n: 5
-        - that: has_n_lines
-          n: 10
-          delta: 4
+      - that: has_text
+        text: "superkingdom\tkingdom\tphylum\tDRR010481\tERR2715528"
+      - that: has_n_columns
+        n: 5
+      - that: has_n_lines
+        n: 10
+        delta: 4
     ITSoneDB taxonomic abundance summary table:
       asserts:
-        - that: has_text
-          text: '#SampleID	DRR010481	ERR2715528'
-        - that: has_n_columns
-          n: 3
-        - that: has_n_lines
-          n: 117
-          delta: 17
+      - that: has_text
+        text: "#SampleID\tDRR010481\tERR2715528"
+      - that: has_n_columns
+        n: 3
+      - that: has_n_lines
+        n: 117
+        delta: 17
     LSU phylum level taxonomic abundance summary table:
       asserts:
-        - that: has_text
-          text: 'superkingdom	kingdom	phylum	DRR010481'
-        - that: has_n_columns
-          n: 4
-        - that: has_n_lines
-          n: 6
-          delta: 4
+      - that: has_text
+        text: "superkingdom\tkingdom\tphylum\tDRR010481"
+      - that: has_n_columns
+        n: 4
+      - that: has_n_lines
+        n: 6
+        delta: 4
     LSU taxonomic abundance summary table:
       asserts:
-        - that: has_text
-          text: '#SampleID	DRR010481'
-        - that: has_n_columns
-          n: 2
-        - that: has_n_lines
-          n: 6
-          delta: 4
+      - that: has_text
+        text: "#SampleID\tDRR010481"
+      - that: has_n_columns
+        n: 2
+      - that: has_n_lines
+        n: 6
+        delta: 4
     SSU phylum level taxonomic abundance summary table:
       asserts:
-        - that: has_text
-          text: 'superkingdom	kingdom	phylum	ERR2715528'
-        - that: has_n_columns
-          n: 4
-        - that: has_n_lines
-          n: 12
-          delta: 4
+      - that: has_text
+        text: "superkingdom\tkingdom\tphylum\tERR2715528"
+      - that: has_n_columns
+        n: 4
+      - that: has_n_lines
+        n: 12
+        delta: 4
     SSU taxonomic abundance summary table:
       asserts:
-        - that: has_text
-          text: '#SampleID	ERR2715528'
-        - that: has_n_columns
-          n: 2
-        - that: has_n_lines
-          n: 13
-          delta: 4
+      - that: has_text
+        text: "#SampleID\tERR2715528"
+      - that: has_n_columns
+        n: 2
+      - that: has_n_lines
+        n: 13
+        delta: 4
     ITS UNITE DB phylum level taxonomic abundance summary table:
       asserts:
-        - that: has_text
-          text: 'superkingdom	kingdom	phylum	DRR010481	ERR2715528'
-        - that: has_n_columns
-          n: 5
-        - that: has_n_lines
-          n: 13
-          delta: 4
+      - that: has_text
+        text: "superkingdom\tkingdom\tphylum\tDRR010481\tERR2715528"
+      - that: has_n_columns
+        n: 5
+      - that: has_n_lines
+        n: 13
+        delta: 4
     ITS UNITE DB taxonomic abundance summary table:
       asserts:
-        - that: has_text
-          text: '#SampleID	DRR010481	ERR2715528'
-        - that: has_n_columns
-          n: 3
-        - that: has_n_lines
-          n: 130
-          delta: 19
+      - that: has_text
+        text: "#SampleID\tDRR010481\tERR2715528"
+      - that: has_n_columns
+        n: 3
+      - that: has_n_lines
+        n: 130
+        delta: 19

--- a/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-paired-end/mgnify-amplicon-pipeline-v5-quality-control-paired-end-tests.yml
+++ b/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-paired-end/mgnify-amplicon-pipeline-v5-quality-control-paired-end-tests.yml
@@ -11,9 +11,15 @@
         - identifier: forward
           class: File
           location: https://zenodo.org/records/13710235/files/ERR2715528_forward.fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 3defa3fafb76470cce8f37eaf725c80f155c6ac2
         - identifier: reverse
           class: File
           location: https://zenodo.org/records/13710235/files/ERR2715528_reverse.fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 38ca7f72b64c1b27367b61084e95797c4c97bfd5
   outputs:
     Paired-end post quality control FASTA files:
       element_tests:
@@ -23,15 +29,15 @@
       location: https://zenodo.org/records/14746033/files/general_stats_PE.tabular
     Paired-end MultiQC report:
       asserts:
-        - that: has_text
-          text: "ERR2715528_ambiguous_base_filtering"
-        - that: has_text
-          text: "ERR2715528_initial_reads"
-        - that: has_text
-          text: "ERR2715528_length_filtering"
-        - that: has_text
-          text: "ERR2715528_trimming"
-        - that: has_text
-          text: "92.2"
-        - that: has_text
-          text: "51"
+      - that: has_text
+        text: "ERR2715528_ambiguous_base_filtering"
+      - that: has_text
+        text: "ERR2715528_initial_reads"
+      - that: has_text
+        text: "ERR2715528_length_filtering"
+      - that: has_text
+        text: "ERR2715528_trimming"
+      - that: has_text
+        text: "92.2"
+      - that: has_text
+        text: "51"

--- a/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-single-end/mgnify-amplicon-pipeline-v5-quality-control-single-end-tests.yml
+++ b/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-single-end/mgnify-amplicon-pipeline-v5-quality-control-single-end-tests.yml
@@ -7,37 +7,40 @@
       - class: File
         identifier: DRR010481
         location: https://zenodo.org/records/13710235/files/DRR010481.fastqsanger.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: bc6268d53b1836d6e5db43d41de2d5f66d9c8b94
   outputs:
     Single-end MultiQC statistics:
       location: https://zenodo.org/records/14746033/files/general_stats_SE.tabular
     Single-end MultiQC report:
       asserts:
-        - that: has_text
-          text: "DRR010481_ambiguous_base_filtering"
-        - that: has_text
-          text: "84.0"
-        - that: has_text
-          text: "DRR010481_initial_reads"
-        - that: has_text
-          text: "47"
-        - that: has_text
-          text: "DRR010481_length_filtering"
-        - that: has_text
-          text: "DRR010481_trimming"
-        - that: has_text
-          text: "DRR010481_ambiguous_base_filtering"
-        - that: has_text
-          text: "48"
-        - that: has_text
-          text: "553"
-        - that: has_text
-          text: "242"
-        - that: has_text
-          text: "DRR010481_initial_reads"
-        - that: has_text
-          text: "DRR010481_length_filtering"
-        - that: has_text
-          text: "DRR010481_trimming"
+      - that: has_text
+        text: "DRR010481_ambiguous_base_filtering"
+      - that: has_text
+        text: "84.0"
+      - that: has_text
+        text: "DRR010481_initial_reads"
+      - that: has_text
+        text: "47"
+      - that: has_text
+        text: "DRR010481_length_filtering"
+      - that: has_text
+        text: "DRR010481_trimming"
+      - that: has_text
+        text: "DRR010481_ambiguous_base_filtering"
+      - that: has_text
+        text: "48"
+      - that: has_text
+        text: "553"
+      - that: has_text
+        text: "242"
+      - that: has_text
+        text: "DRR010481_initial_reads"
+      - that: has_text
+        text: "DRR010481_length_filtering"
+      - that: has_text
+        text: "DRR010481_trimming"
     Single-end post quality control FASTA files:
       element_tests:
         DRR010481:

--- a/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction-tests.yml
+++ b/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction-tests.yml
@@ -7,12 +7,21 @@
       - class: File
         identifier: DRR010481_FASTQ.fasta
         location: https://zenodo.org/records/13710235/files/DRR010481_SE.fasta
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 99230f36fe6b5536b7c060a252d3b053a15b9d74
       - class: File
         identifier: ERR2715528_MERGED_FASTQ.fasta
         location: https://zenodo.org/records/13710235/files/ERR2715528_PE.fasta
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 9d5e24ff500dd71fc95592018942963a4cc2e6e2
     Clan information file:
       class: File
       location: "ftp://ftp.ebi.ac.uk/pub/databases/metagenomics/pipeline-5.0/ref-dbs/rfam_models/ribosomal_models/ribo.claninfo"
+      hashes:
+      - hash_function: SHA-1
+        hash_value: ac1d31c511c0726873c0fd7cad5ab207fed3228c
   outputs:
     LSU and SSU BED regions:
       element_tests:
@@ -34,89 +43,89 @@
       element_tests:
         ERR2715528_MERGED_FASTQ.fasta:
           asserts:
-            - that: has_text
-              text: "# mapseq v1.2.6 (Jan 20 2023)"
-            - that: has_text
-              text: "SILVA"
-            - that: has_n_columns
-              comment: "#"
-              n: 15
+          - that: has_text
+            text: "# mapseq v1.2.6 (Jan 20 2023)"
+          - that: has_text
+            text: "SILVA"
+          - that: has_n_columns
+            comment: "#"
+            n: 15
     SSU OTU tables (SILVA DB):
       element_tests:
         ERR2715528_MERGED_FASTQ.fasta:
           asserts:
-            - that: has_text
-              text: "# Constructed from biom file"
-            - that: has_text
-              text: "# OTU ID"
-            - that: has_text
-              text: "Unspecified"
-            - that: has_text
-              text: "taxonomy"
-            - that: has_text
-              text: "taxid"
-            - that: has_n_columns
-              comment: "#"
-              n: 4
+          - that: has_text
+            text: "# Constructed from biom file"
+          - that: has_text
+            text: "# OTU ID"
+          - that: has_text
+            text: "Unspecified"
+          - that: has_text
+            text: "taxonomy"
+          - that: has_text
+            text: "taxid"
+          - that: has_n_columns
+            comment: "#"
+            n: 4
     LSU OTU tables (SILVA DB):
       element_tests:
         DRR010481_FASTQ.fasta:
           asserts:
-            - that: has_text
-              text: "# Constructed from biom file"
-            - that: has_text
-              text: "# OTU ID"
-            - that: has_text
-              text: "Unspecified"
-            - that: has_text
-              text: "taxonomy"
-            - that: has_text
-              text: "taxid"
-            - that: has_n_columns
-              comment: "#"
-              n: 4
+          - that: has_text
+            text: "# Constructed from biom file"
+          - that: has_text
+            text: "# OTU ID"
+          - that: has_text
+            text: "Unspecified"
+          - that: has_text
+            text: "taxonomy"
+          - that: has_text
+            text: "taxid"
+          - that: has_n_columns
+            comment: "#"
+            n: 4
     LSU taxonomic classifications using SILVA DB:
       element_tests:
         DRR010481_FASTQ.fasta:
           asserts:
-            - that: has_text
-              text: "# mapseq v1.2.6 (Jan 20 2023)"
-            - that: has_text
-              text: "SILVA"
-            - that: has_n_columns
-              comment: "#"
-              n: 15
+          - that: has_text
+            text: "# mapseq v1.2.6 (Jan 20 2023)"
+          - that: has_text
+            text: "SILVA"
+          - that: has_n_columns
+            comment: "#"
+            n: 15
     SSU OTU tables in HDF5 format (SILVA DB):
       element_tests:
         ERR2715528_MERGED_FASTQ.fasta:
           asserts:
-            - that: has_size
-              value: 37000
-              delta: 10000
+          - that: has_size
+            value: 37000
+            delta: 10000
     SSU OTU tables in JSON format (SILVA DB):
       element_tests:
         ERR2715528_MERGED_FASTQ.fasta:
           asserts:
-            - that: has_text
-              text: "\"type\": \"OTU table\""
+          - that: has_text
+            text: "\"type\": \"OTU table\""
     SSU taxonomic abundance pie charts (SILVA DB):
       asserts:
-            - that: has_text
-              text: "ERR2715528_MERGED_FASTQ_fasta"
+      - that: has_text
+        text: "ERR2715528_MERGED_FASTQ_fasta"
     LSU OTU tables in HDF5 format (SILVA DB):
       element_tests:
         DRR010481_FASTQ.fasta:
           asserts:
-            - that: has_size
-              value: 37000
-              delta: 10000
+          - that: has_size
+            value: 37000
+            delta: 10000
     LSU OTU tables in JSON format (SILVA DB):
       element_tests:
         DRR010481_FASTQ.fasta:
           asserts:
-            - that: has_text
-              text: "\"type\": \"OTU table\""
+          - that: has_text
+            text: "\"type\": \"OTU table\""
     LSU taxonomic abundance pie charts (SILVA DB):
       asserts:
-            - that: has_text
-              text: "DRR010481_FASTQ_fasta"
+      - that: has_text
+        text: "DRR010481_FASTQ_fasta"

--- a/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-taxonomic-summary-tables/mgnify-amplicon-summary-tables-tests.yml
+++ b/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-taxonomic-summary-tables/mgnify-amplicon-summary-tables-tests.yml
@@ -7,19 +7,31 @@
       - class: File
         identifier: ERR3046414_MERGED_FASTQ_SSU_OTU.tabular
         location: https://zenodo.org/records/13710235/files/ERR3046414_MERGED_FASTQ_SSU_OTU.tabular
+        hashes:
+        - hash_function: SHA-1
+          hash_value: b7d84db93bff8ac05ba6cc6abe8c357d80d5ddc6
       - class: File
         identifier: ERR3046440_MERGED_FASTQ_SSU_OTU.tabular
         location: https://zenodo.org/records/13710235/files/ERR3046440_MERGED_FASTQ_SSU_OTU.tabular
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 6416384de86346b5a861e15660ceca9b922cc1a9
       - class: File
         identifier: ERR4319664_MERGED_FASTQ_SSU_OTU.tabular
         location: https://zenodo.org/records/13710235/files/ERR4319664_MERGED_FASTQ_SSU_OTU.tabular
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 5a6f57bf76bd8b55ef67ee6a924edf7bd562e791
       - class: File
         identifier: ERR4319712_MERGED_FASTQ_SSU_OTU.tabular
         location: https://zenodo.org/records/13710235/files/ERR4319712_MERGED_FASTQ_SSU_OTU.tabular
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 2842edc7d83ecfede21ff6565c9cd56ef520298d
     Taxonomic abundance summary table name: 'taxonomic_summary_table'
     Phylum level taxonomic abundance summary table name: 'phylum_taxonomic_summary_table'
   outputs:
-    Taxonomic abundance summary table:       
+    Taxonomic abundance summary table:
       location: https://zenodo.org/records/13710235/files/taxonomic_summary_table.tabular
     phylum level taxonomic abundance summary table:
       location: https://zenodo.org/records/13710235/files/phylum_taxonomic_summary_table.tabular

--- a/workflows/amplicon/amplicon-mgnify/taxonomic-rank-abundance-summary-table/taxonomic-rank-abundance-summary-table-tests.yml
+++ b/workflows/amplicon/amplicon-mgnify/taxonomic-rank-abundance-summary-table/taxonomic-rank-abundance-summary-table-tests.yml
@@ -7,27 +7,39 @@
       - class: File
         identifier: ERR3046414_MERGED_FASTQ_SSU_OTU.tabular
         location: https://zenodo.org/records/13710235/files/ERR3046414_MERGED_FASTQ_SSU_OTU.tabular
+        hashes:
+        - hash_function: SHA-1
+          hash_value: b7d84db93bff8ac05ba6cc6abe8c357d80d5ddc6
       - class: File
         identifier: ERR3046440_MERGED_FASTQ_SSU_OTU.tabular
         location: https://zenodo.org/records/13710235/files/ERR3046440_MERGED_FASTQ_SSU_OTU.tabular
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 6416384de86346b5a861e15660ceca9b922cc1a9
       - class: File
         identifier: ERR4319664_MERGED_FASTQ_SSU_OTU.tabular
         location: https://zenodo.org/records/13710235/files/ERR4319664_MERGED_FASTQ_SSU_OTU.tabular
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 5a6f57bf76bd8b55ef67ee6a924edf7bd562e791
       - class: File
         identifier: ERR4319712_MERGED_FASTQ_SSU_OTU.tabular
         location: https://zenodo.org/records/13710235/files/ERR4319712_MERGED_FASTQ_SSU_OTU.tabular
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 2842edc7d83ecfede21ff6565c9cd56ef520298d
     Taxonomic rank: "family"
   outputs:
-    Taxonomic rank summary table:       
-      asserts: 
+    Taxonomic rank summary table:
+      asserts:
       - that: has_size
         size: 11263
       - that: has_text
-        text: "superkingdom	kingdom	phylum	class	order	family	ERR3046414	ERR3046440	ERR4319664	ERR4319712"
+        text: "superkingdom\tkingdom\tphylum\tclass\torder\tfamily\tERR3046414\tERR3046440\tERR4319664\tERR4319712"
       - that: has_text
-        text: "Bacteria	unassigned	Actinobacteria	Acidimicrobiia	unassigned	unassigned	0	0	1	3"
+        text: "Bacteria\tunassigned\tActinobacteria\tAcidimicrobiia\tunassigned\tunassigned\t0\t0\t1\t3"
       - that: has_text
-        text: "Bacteria	unassigned	Actinobacteria	Actinobacteria	Actinomycetales	Actinomycetaceae	4	1	0	0"
+        text: "Bacteria\tunassigned\tActinobacteria\tActinobacteria\tActinomycetales\tActinomycetaceae\t4\t1\t0\t0"
       - that: has_n_lines
         n: 129
       - that: has_n_columns

--- a/workflows/amplicon/dada2/dada2_paired-tests.yml
+++ b/workflows/amplicon/dada2/dada2_paired-tests.yml
@@ -11,9 +11,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/record/800651/files/F3D0_R1.fastq
+          hashes:
+          - hash_function: SHA-1
+            hash_value: e031c5f2942d995970471f112a52093918cb7fec
         - class: File
           identifier: reverse
           location: https://zenodo.org/record/800651/files/F3D0_R2.fastq
+          hashes:
+          - hash_function: SHA-1
+            hash_value: af06e2cfbe8bd6415023dd8aa49cc8c44541ec0c
       - class: Collection
         type: paired
         identifier: F3D5
@@ -21,9 +27,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/record/800651/files/F3D5_R1.fastq
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 7000705a3f5610ffcb01c79d936779a48c35851f
         - class: File
           identifier: reverse
           location: https://zenodo.org/record/800651/files/F3D5_R2.fastq
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 3233317bde4fd33c640d28d3982afb8f32065b61
       - class: Collection
         type: paired
         identifier: F3D145
@@ -31,9 +43,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/record/800651/files/F3D145_R1.fastq
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 752770a64e7998b6b7eddbe73bdfd44f1029d045
         - class: File
           identifier: reverse
           location: https://zenodo.org/record/800651/files/F3D145_R2.fastq
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 5007557c8f03c5ee7952293b9f39d7eabb538e01
       - class: Collection
         type: paired
         identifier: F3D150
@@ -41,9 +59,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/record/800651/files/F3D150_R1.fastq
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 43e9efbe227ef441e197e68213a3cc05cb7d30e2
         - class: File
           identifier: reverse
           location: https://zenodo.org/record/800651/files/F3D150_R2.fastq
+          hashes:
+          - hash_function: SHA-1
+            hash_value: dde2d7b349bd24d298f5f21bf1103ad3cf4e0a2e
       - class: Collection
         type: paired
         identifier: Mock
@@ -51,9 +75,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/record/800651/files/Mock_R1.fastq
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 664cb4f1feffc1b71a8871bc8d08cb25a488b717
         - class: File
           identifier: reverse
           location: https://zenodo.org/record/800651/files/Mock_R2.fastq
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 5d6e794e37b308a3562dbd93929ea54a561abd0a
     Read length forward read: 240
     Read length reverse read: 160
     Pool samples: 'FALSE'
@@ -62,25 +92,25 @@
     Sequence Table:
       path: test-data/Sequence Table.dada2_sequencetable
       asserts:
-        - has_n_columns:
-            n: 6
-        - has_n_lines:
-            n: 171
+      - has_n_columns:
+          n: 6
+      - has_n_lines:
+          n: 171
     Counts:
       path: test-data/Counts.tabular
       asserts:
-        - has_n_columns:
-            n: 8
-        - has_n_lines:
-            n: 6
+      - has_n_columns:
+          n: 8
+      - has_n_lines:
+          n: 6
     Taxonomy:
       ftype: tabular
       sorted: true
       asserts:
-        - has_text:
-            text: Firmicutes
-            n: 131
-        - has_n_columns:
-            n: 7
-        - has_n_lines:
-            n: 171
+      - has_text:
+          text: Firmicutes
+          n: 131
+      - has_n_columns:
+          n: 7
+      - has_n_lines:
+          n: 171

--- a/workflows/amplicon/qiime2/qiime2-I-import/QIIME2-Ia-multiplexed-data-single-end-tests.yml
+++ b/workflows/amplicon/qiime2/qiime2-I-import/QIIME2-Ia-multiplexed-data-single-end-tests.yml
@@ -5,37 +5,46 @@
       class: File
       location: https://data.qiime2.org/2024.2/tutorials/moving-pictures/emp-single-end-sequences/sequences.fastq.gz
       filetype: fastqsanger.gz
+      hashes:
+      - hash_function: SHA-1
+        hash_value: deb63e94140495c3a51f32e3e95cbcc8f862baa4
     Barcodes:
       class: File
       location: https://data.qiime2.org/2024.2/tutorials/moving-pictures/emp-single-end-sequences/barcodes.fastq.gz
       filetype: fastqsanger.gz
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 450c3c4af2d48cd60c492a485167e807fadb51a8
     Metadata:
       class: File
       location: https://data.qiime2.org/2024.2/tutorials/moving-pictures/sample_metadata.tsv
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: c2def67243e8074d95c98b6a8ffe81dc4e2cdd65
     Metadata parameter: barcode-sequence
     Reverse complement barcodes: false
   outputs:
     Demultiplexed single-end data:
       asserts:
-        - has_size:
-            value: 20M
-            delta: 1M
-        - has_archive_member:
-            path: ".*data/L[0-9]S[0-9]{1,3}_[0-9]{1,2}_L001_R1_001\\.fastq\\.gz"
-            n: 34
-        - has_archive_member:
-            path: ".*/data/metadata.yml"
-            asserts:
-              - has_text:
-                  text: "phred-offset: 33"
-        - has_archive_member:
-            path: "^[^/]*/metadata.yaml"
-            n: 1
-            asserts:
-              - has_text:
-                  text: "uuid:"
-              - has_text:
-                  text: "type: SampleData[SequencesWithQuality]"
-              - has_text:
-                  text: "format: SingleLanePerSampleSingleEndFastqDirFmt"
+      - has_size:
+          value: 20M
+          delta: 1M
+      - has_archive_member:
+          path: ".*data/L[0-9]S[0-9]{1,3}_[0-9]{1,2}_L001_R1_001\\.fastq\\.gz"
+          n: 34
+      - has_archive_member:
+          path: ".*/data/metadata.yml"
+          asserts:
+          - has_text:
+              text: "phred-offset: 33"
+      - has_archive_member:
+          path: "^[^/]*/metadata.yaml"
+          n: 1
+          asserts:
+          - has_text:
+              text: "uuid:"
+          - has_text:
+              text: "type: SampleData[SequencesWithQuality]"
+          - has_text:
+              text: "format: SingleLanePerSampleSingleEndFastqDirFmt"

--- a/workflows/amplicon/qiime2/qiime2-I-import/QIIME2-Ib-multiplexed-data-paired-end-tests.yml
+++ b/workflows/amplicon/qiime2/qiime2-I-import/QIIME2-Ib-multiplexed-data-paired-end-tests.yml
@@ -5,41 +5,53 @@
       class: File
       location: https://data.qiime2.org/2024.2/tutorials/atacama-soils/10p/forward.fastq.gz
       filetype: fastqsanger.gz
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 9bdf2f5fe6c8c72f30c1e42f94be824fd11a5db7
     Reverse sequences:
       class: File
-      location: https://data.qiime2.org/2024.2/tutorials/atacama-soils/10p/reverse.fastq.gz 
+      location: https://data.qiime2.org/2024.2/tutorials/atacama-soils/10p/reverse.fastq.gz
       filetype: fastqsanger.gz
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 9c0798aefa1b6605296cf56e937080559ccbcd47
     Barcodes:
       class: File
       location: https://data.qiime2.org/2024.2/tutorials/atacama-soils/10p/barcodes.fastq.gz
       filetype: fastqsanger.gz
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 8868a5a2863cf07f2dfc97e6cb1414fe8cbea832
     Metadata:
       class: File
       location: https://data.qiime2.org/2024.2/tutorials/atacama-soils/sample_metadata.tsv
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: d765ada8ec0d26a80b60c5963bff222ce5647de0
     Metadata parameter: barcode-sequence
     Reverse complement of barcodes needed?: true
   outputs:
     Demultiplexed paired-end output:
       asserts:
-        - has_size:
-            value: 95M
-            delta: 4M
-        - has_archive_member:
-            path: ".*data/[A-Z]{3}[0-9]+(\\.[0-9])?\\.[0-9]_[0-9]{1,2}_L001_R[12]_001\\.fastq\\.gz"
-            n: 150
-        - has_archive_member:
-            path: ".*/data/metadata.yml"
-            asserts:
-              - has_text:
-                  text: "phred-offset: 33"
-        - has_archive_member:
-            path: "^[^/]*/metadata.yaml"
-            n: 1
-            asserts:
-              - has_text:
-                  text: "uuid:"
-              - has_text:
-                  text: "SampleData[PairedEndSequencesWithQuality]"
-              - has_text:
-                  text: "format: SingleLanePerSamplePairedEndFastqDirFmt"
+      - has_size:
+          value: 95M
+          delta: 4M
+      - has_archive_member:
+          path: ".*data/[A-Z]{3}[0-9]+(\\.[0-9])?\\.[0-9]_[0-9]{1,2}_L001_R[12]_001\\.fastq\\.gz"
+          n: 150
+      - has_archive_member:
+          path: ".*/data/metadata.yml"
+          asserts:
+          - has_text:
+              text: "phred-offset: 33"
+      - has_archive_member:
+          path: "^[^/]*/metadata.yaml"
+          n: 1
+          asserts:
+          - has_text:
+              text: "uuid:"
+          - has_text:
+              text: "SampleData[PairedEndSequencesWithQuality]"
+          - has_text:
+              text: "format: SingleLanePerSamplePairedEndFastqDirFmt"

--- a/workflows/amplicon/qiime2/qiime2-I-import/QIIME2-Ic-demultiplexed-data-single-end-tests.yml
+++ b/workflows/amplicon/qiime2/qiime2-I-import/QIIME2-Ic-demultiplexed-data-single-end-tests.yml
@@ -7,34 +7,43 @@
       - class: File
         identifier: FMT.0093C_5_L001_R1_001.fastq.gz
         location: https://docs.qiime2.org/jupyterbooks/cancer-microbiome-intervention-tutorial/data/020-tutorial-upstream/030-importing/data_to_import/FMT.0093C_5_L001_R1_001.fastq.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: b0a0672a4a67181db595dc08ec3a333e58f8b942
       - class: File
         identifier: FMT.0093D_2_L001_R1_001.fastq.gz
         location: https://docs.qiime2.org/jupyterbooks/cancer-microbiome-intervention-tutorial/data/020-tutorial-upstream/030-importing/data_to_import/FMT.0093D_2_L001_R1_001.fastq.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 32dffff8bb5fc36094fb108620a5b5ad499df8b3
       - class: File
         identifier: FMT.0093E_25_L001_R1_001.fastq.gz
         location: https://docs.qiime2.org/jupyterbooks/cancer-microbiome-intervention-tutorial/data/020-tutorial-upstream/030-importing/data_to_import/FMT.0093E_25_L001_R1_001.fastq.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: cfc8340055c238935ef3b54d958eff5e9becfb8f
   outputs:
     Demultiplexed data:
       asserts:
-        - has_size:
-            value: 12M
-            delta: 1M
-        - has_archive_member:
-            path: ".*fastq.gz"
-            n: 3
-        - has_archive_member:
-            path: ".*/data/metadata.yml"
-            asserts:
-              - has_text:
-                  text: "phred-offset: 33"
-        - has_archive_member:
-            path: "^[^/]*/metadata.yaml"
-            n: 1
-            asserts:
-              - has_text:
-                  text: "uuid:"
-              - has_text:
-                  text: "type: SampleData[SequencesWithQuality]"
-              - has_text:
-                  text: "format: SingleLanePerSampleSingleEndFastqDirFmt"
+      - has_size:
+          value: 12M
+          delta: 1M
+      - has_archive_member:
+          path: ".*fastq.gz"
+          n: 3
+      - has_archive_member:
+          path: ".*/data/metadata.yml"
+          asserts:
+          - has_text:
+              text: "phred-offset: 33"
+      - has_archive_member:
+          path: "^[^/]*/metadata.yaml"
+          n: 1
+          asserts:
+          - has_text:
+              text: "uuid:"
+          - has_text:
+              text: "type: SampleData[SequencesWithQuality]"
+          - has_text:
+              text: "format: SingleLanePerSampleSingleEndFastqDirFmt"
 

--- a/workflows/amplicon/qiime2/qiime2-I-import/QIIME2-Id-demultiplexed-data-paired-end-tests.yml
+++ b/workflows/amplicon/qiime2/qiime2-I-import/QIIME2-Id-demultiplexed-data-paired-end-tests.yml
@@ -7,42 +7,60 @@
       - class: File
         identifier: FMT.0093C_46_L001_R2_001.fastq.gz
         location: https://docs.qiime2.org/jupyterbooks/cancer-microbiome-intervention-tutorial/data/020-tutorial-upstream/030-importing/data_to_import/FMT.0093C_46_L001_R2_001.fastq.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 65bfa6ea09f31d2a967f6f783ada7b1ced545b08
       - class: File
         identifier: FMT.0093C_5_L001_R1_001.fastq.gz
         location: https://docs.qiime2.org/jupyterbooks/cancer-microbiome-intervention-tutorial/data/020-tutorial-upstream/030-importing/data_to_import/FMT.0093C_5_L001_R1_001.fastq.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: b0a0672a4a67181db595dc08ec3a333e58f8b942
       - class: File
         identifier: FMT.0093D_2_L001_R1_001.fastq.gz
         location: https://docs.qiime2.org/jupyterbooks/cancer-microbiome-intervention-tutorial/data/020-tutorial-upstream/030-importing/data_to_import/FMT.0093D_2_L001_R1_001.fastq.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 32dffff8bb5fc36094fb108620a5b5ad499df8b3
       - class: File
         identifier: FMT.0093D_43_L001_R2_001.fastq.gz
         location: https://docs.qiime2.org/jupyterbooks/cancer-microbiome-intervention-tutorial/data/020-tutorial-upstream/030-importing/data_to_import/FMT.0093D_43_L001_R2_001.fastq.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 08320901dc73abb01e9cd1499aa3502bd53989db
       - class: File
         identifier: FMT.0093E_25_L001_R1_001.fastq.gz
         location: https://docs.qiime2.org/jupyterbooks/cancer-microbiome-intervention-tutorial/data/020-tutorial-upstream/030-importing/data_to_import/FMT.0093E_25_L001_R1_001.fastq.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: cfc8340055c238935ef3b54d958eff5e9becfb8f
       - class: File
         identifier: FMT.0093E_66_L001_R2_001.fastq.gz
         location: https://docs.qiime2.org/jupyterbooks/cancer-microbiome-intervention-tutorial/data/020-tutorial-upstream/030-importing/data_to_import/FMT.0093E_66_L001_R2_001.fastq.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 043084d51d1052c073224f4fae82afa9a2d75b47
   outputs:
     Demultiplexed data:
       asserts:
-        - has_size:
-            value: 24M
-            delta: 1M
-        - has_archive_member:
-            path: ".*fastq.gz"
-            n: 6
-        - has_archive_member:
-            path: ".*/data/metadata.yml"
-            asserts:
-              - has_text:
-                  text: "phred-offset: 33"
-        - has_archive_member:
-            path: "^[^/]*/metadata.yaml"
-            n: 1
-            asserts:
-              - has_text:
-                  text: "uuid:"
-              - has_text:
-                  text: "type: SampleData[PairedEndSequencesWithQuality]"
-              - has_text:
-                  text: "format: SingleLanePerSamplePairedEndFastqDirFmt"
+      - has_size:
+          value: 24M
+          delta: 1M
+      - has_archive_member:
+          path: ".*fastq.gz"
+          n: 6
+      - has_archive_member:
+          path: ".*/data/metadata.yml"
+          asserts:
+          - has_text:
+              text: "phred-offset: 33"
+      - has_archive_member:
+          path: "^[^/]*/metadata.yaml"
+          n: 1
+          asserts:
+          - has_text:
+              text: "uuid:"
+          - has_text:
+              text: "type: SampleData[PairedEndSequencesWithQuality]"
+          - has_text:
+              text: "format: SingleLanePerSamplePairedEndFastqDirFmt"

--- a/workflows/amplicon/qiime2/qiime2-II-denoising/QIIME2-IIa-denoising-and-feature-table-creation-single-end-tests.yml
+++ b/workflows/amplicon/qiime2/qiime2-II-denoising/QIIME2-IIa-denoising-and-feature-table-creation-single-end-tests.yml
@@ -4,46 +4,52 @@
       class: File
       location: https://docs.qiime2.org/2021.11/data/tutorials/moving-pictures-usage/sample-metadata.tsv
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 9dbc3213da14db9468fec0e33205d10164f12256
     Demultiplexed sequences:
       class: File
       location: https://docs.qiime2.org/2021.11/data/tutorials/moving-pictures-usage/demux.qza
       filetype: qza
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 740c8177b1bc9fd22a66d38ffc65c8a06dd58e55
     Truncation length: 120
     Trimming length: 0
   outputs:
     Denoising output table:
       asserts:
-        - has_size:
-            min: 20k
-        - has_archive_member:
-            path: "^[^/]*/data/feature-table.biom"
-            n: 1
+      - has_size:
+          min: 20k
+      - has_archive_member:
+          path: "^[^/]*/data/feature-table.biom"
+          n: 1
     Representative denoised sequences:
       asserts:
-        - has_size:
-            min: 20k
-        - has_archive_member:
-            path: "^[^/]*/metadata.yaml"
-            n: 1
-        - has_archive_member:
-            path: "^[^/]*/data/dna-sequences.fasta"
-            n: 1
-            asserts:
-              - has_text_matching:
-                  expression: ">.*"
-                  n: 770
+      - has_size:
+          min: 20k
+      - has_archive_member:
+          path: "^[^/]*/metadata.yaml"
+          n: 1
+      - has_archive_member:
+          path: "^[^/]*/data/dna-sequences.fasta"
+          n: 1
+          asserts:
+          - has_text_matching:
+              expression: ">.*"
+              n: 770
     Denoising statistics:
       asserts:
-        - has_size:
-            min: 0
-        - has_size:
-            min: 10k
-        - has_archive_member:
-            path: "^[^/]*/data/stats.tsv"
-            n: 1
-            asserts:
-              - has_n_columns:
-                  n: 7
+      - has_size:
+          min: 0
+      - has_size:
+          min: 10k
+      - has_archive_member:
+          path: "^[^/]*/data/stats.tsv"
+          n: 1
+          asserts:
+          - has_n_columns:
+              n: 7
               # 2 header lines + 3 samples
-              - has_n_lines:
-                  n: 36
+          - has_n_lines:
+              n: 36

--- a/workflows/amplicon/qiime2/qiime2-II-denoising/QIIME2-IIb-denoising-and-feature-table-creation-paired-end-tests.yml
+++ b/workflows/amplicon/qiime2/qiime2-II-denoising/QIIME2-IIb-denoising-and-feature-table-creation-paired-end-tests.yml
@@ -5,10 +5,16 @@
       class: File
       location: https://docs.qiime2.org/jupyterbooks/cancer-microbiome-intervention-tutorial/data/020-tutorial-upstream/020-metadata/sample-metadata.tsv
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 808f0a8c42b2bf42e0eb663b770db24cd1e9a5c9
     Demultiplexed sequences:
       class: File
       location: https://docs.qiime2.org/jupyterbooks/cancer-microbiome-intervention-tutorial/data/020-tutorial-upstream/030-importing/demultiplexed-sequences.qza
       filetype: qza
+      hashes:
+      - hash_function: SHA-1
+        hash_value: d7c4b3f1d2c8ea5882352a01a991c026d7036ab9
     Truncation length (forward): 204
     Truncation length (reverse): 205
     Trimming length (forward): 1
@@ -16,35 +22,35 @@
   outputs:
     Denoising output table:
       asserts:
-        - has_size:
-            min: 20k
-        - has_archive_member:
-            path: "^[^/]*/data/feature-table.biom"
-            n: 1
+      - has_size:
+          min: 20k
+      - has_archive_member:
+          path: "^[^/]*/data/feature-table.biom"
+          n: 1
     Representative denoised sequences:
       asserts:
-        - has_size:
-            min: 20k
-        - has_archive_member:
-            path: "^[^/]*/metadata.yaml"
-            n: 1
-        - has_archive_member:
-            path: "^[^/]*/data/dna-sequences.fasta"
-            n: 1
-            asserts:
-              - has_text_matching:
-                  expression: ">.*"
-                  n: 661
+      - has_size:
+          min: 20k
+      - has_archive_member:
+          path: "^[^/]*/metadata.yaml"
+          n: 1
+      - has_archive_member:
+          path: "^[^/]*/data/dna-sequences.fasta"
+          n: 1
+          asserts:
+          - has_text_matching:
+              expression: ">.*"
+              n: 661
     Denoising statistics:
       asserts:
-        - has_size:
-            min: 10k
-        - has_archive_member:
-            path: "^[^/]*/data/stats.tsv"
-            n: 1
-            asserts:
-              - has_n_columns:
-                  n: 9
+      - has_size:
+          min: 10k
+      - has_archive_member:
+          path: "^[^/]*/data/stats.tsv"
+          n: 1
+          asserts:
+          - has_n_columns:
+              n: 9
               # 2 header lines + 41 samples
-              - has_n_lines:
-                  n: 43
+          - has_n_lines:
+              n: 43

--- a/workflows/amplicon/qiime2/qiime2-III-VI-downsteam/QIIME2-III-V-Phylogeny-Rarefaction-Taxonomic-Analysis-tests.yml
+++ b/workflows/amplicon/qiime2/qiime2-III-VI-downsteam/QIIME2-III-V-Phylogeny-Rarefaction-Taxonomic-Analysis-tests.yml
@@ -4,105 +4,120 @@
       class: File
       location: https://data.qiime2.org/2024.2/tutorials/pd-mice/sample_metadata.tsv
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: bfad679a672dbe8284586f19c9ce86ee53bd5f9c
     Representative sequences:
       class: File
       location: https://docs.qiime2.org/2024.2/data/tutorials/pd-mice/dada2_rep_set.qza
       filetype: qza
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 3bfd12aba18bc6008c64ab8aa992fc8af678ebbf
     Feature table:
       class: File
       location: https://docs.qiime2.org/2024.2/data/tutorials/pd-mice/dada2_table.qza
       filetype: qza
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 9a205d939eee56bb766e6d8efbcdd772d230bcd3
     Minimum depth: 1
     Maximum depth: 2019
     Taxonomic classifier:
       class: File
       location: https://docs.qiime2.org/2024.10/data/tutorials/pd-mice/gg-13-8-99-515-806-nb-classifier.qza
       filetype: qza
+      hashes:
+      - hash_function: SHA-1
+        hash_value: f13acbfb6ed4cc65843a8223e5ed7c8733ebd1e4
     SEPP fragment insertion reference:
       class: File
       location: https://data.qiime2.org/2024.2/common/sepp-refs-gg-13-8.qza
       filetype: qza
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 3e57b667260647aec575de59adca76f2f54ffe16
   outputs:
     Rooted tree:
       ftype: qza
       asserts:
-        - has_size:
-            min: 2M
-            max: 3M
-        - has_archive_member:
-            path: "^[^/]*/data/tree.nwk"
-            n: 1
-            asserts:
-              - has_text_matching:
-                  expression: "k__Bacteria"
-        - has_archive_member:
-            path: "^[^/]*/metadata.yaml"
-            n: 1
-            asserts:
-              - has_line:
-                  line: "type: Phylogeny[Rooted]"
-              - has_line:
-                  line: "format: NewickDirectoryFormat"
+      - has_size:
+          min: 2M
+          max: 3M
+      - has_archive_member:
+          path: "^[^/]*/data/tree.nwk"
+          n: 1
+          asserts:
+          - has_text_matching:
+              expression: "k__Bacteria"
+      - has_archive_member:
+          path: "^[^/]*/metadata.yaml"
+          n: 1
+          asserts:
+          - has_line:
+              line: "type: Phylogeny[Rooted]"
+          - has_line:
+              line: "format: NewickDirectoryFormat"
 
     Rarefaction curve:
       ftype: qzv
       asserts:
-        - has_size:
-            min: 400k
-            max: 500k
-        - has_archive_member:
-            path: "^[^/]*/data/index.html"
-            n: 1
+      - has_size:
+          min: 400k
+          max: 500k
+      - has_archive_member:
+          path: "^[^/]*/data/index.html"
+          n: 1
         # data per measure
-        - has_archive_member:
-            path: "^[^/]*/data/.*\\.csv"
-            n: 3
+      - has_archive_member:
+          path: "^[^/]*/data/.*\\.csv"
+          n: 3
         # data for each measure and metadata variable (*7)
-        - has_archive_member:
-            path: "^[^/]*/data/.*\\.jsonp"
-            n: 21
+      - has_archive_member:
+          path: "^[^/]*/data/.*\\.jsonp"
+          n: 21
 
     Taxonomy classification:
       ftype: qza
       asserts:
-        - has_size:
-            min: 40k
-            max: 80k
-        - has_archive_member:
-            path: "^[^/]*/metadata.yaml"
-            n: 1
-            asserts:
-              - has_line:
-                  line: "type: FeatureData[Taxonomy]"
-              - has_line:
-                  line: "format: TSVTaxonomyDirectoryFormat"
-        - has_archive_member:
-            path: "^[^/]*/data/taxonomy.tsv"
-            n: 1
-            asserts:
-              - has_n_lines:
-                  n: 288
+      - has_size:
+          min: 40k
+          max: 80k
+      - has_archive_member:
+          path: "^[^/]*/metadata.yaml"
+          n: 1
+          asserts:
+          - has_line:
+              line: "type: FeatureData[Taxonomy]"
+          - has_line:
+              line: "format: TSVTaxonomyDirectoryFormat"
+      - has_archive_member:
+          path: "^[^/]*/data/taxonomy.tsv"
+          n: 1
+          asserts:
+          - has_n_lines:
+              n: 288
     Taxa barplot:
       ftype: qzv
       asserts:
-        - has_size:
-            min: 400k
-            max: 500k
-        - has_archive_member:
-            path: "^[^/]*/data/.*\\.csv"
-            n: 7
-        - has_archive_member:
-            path: "^[^/]*/data/.*\\.jsonp"
-            n: 7
+      - has_size:
+          min: 400k
+          max: 500k
+      - has_archive_member:
+          path: "^[^/]*/data/.*\\.csv"
+          n: 7
+      - has_archive_member:
+          path: "^[^/]*/data/.*\\.jsonp"
+          n: 7
     Taxonomy classification table:
       ftype: qza
       asserts:
-        - has_size:
-            min: 1M
-            max: 2M
-        - has_archive_member:
-            path: "^[^/]*/data/metadata.tsv"
-            n: 1
-            asserts:
-              - has_n_lines:
-                  n: 289
+      - has_size:
+          min: 1M
+          max: 2M
+      - has_archive_member:
+          path: "^[^/]*/data/metadata.tsv"
+          n: 1
+          asserts:
+          - has_n_lines:
+              n: 289

--- a/workflows/amplicon/qiime2/qiime2-III-VI-downsteam/QIIME2-VI-diversity-metrics-and-estimations-tests.yml
+++ b/workflows/amplicon/qiime2/qiime2-III-VI-downsteam/QIIME2-VI-diversity-metrics-and-estimations-tests.yml
@@ -2,100 +2,109 @@
   job:
     Metadata:
       class: File
-      location:  https://data.qiime2.org/2024.2/tutorials/pd-mice/sample_metadata.tsv
+      location: https://data.qiime2.org/2024.2/tutorials/pd-mice/sample_metadata.tsv
       filetype: qiime2.tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: bfad679a672dbe8284586f19c9ce86ee53bd5f9c
     Feature table:
       class: File
       location: https://docs.qiime2.org/2024.2/data/tutorials/pd-mice/dada2_table.qza
       filetype: qza
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 9a205d939eee56bb766e6d8efbcdd772d230bcd3
     Rooted tree:
       class: File
-      location:  https://docs.qiime2.org/2024.2/data/tutorials/pd-mice/tree.qza
+      location: https://docs.qiime2.org/2024.2/data/tutorials/pd-mice/tree.qza
       filetype: qza
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 88fe308ae87e3cdd10b4846df9f43166eb691f9f
     Sampling depth: '2000'
     Target metadata parameter (for beta diversity): cage_id
   outputs:
     Alpha diversity - Pielou's evenness:
       ftype: qzv
       asserts:
-        - has_size:
-            min: 300k
-            max: 400k
-        - has_archive_member:
-            path: "^[^/]*/data/[^/]*\\.csv"
-            n: 6
-        - has_archive_member:
-            path: "^[^/]*/data/[^/]*\\.jsonp"
-            n: 6
+      - has_size:
+          min: 300k
+          max: 400k
+      - has_archive_member:
+          path: "^[^/]*/data/[^/]*\\.csv"
+          n: 6
+      - has_archive_member:
+          path: "^[^/]*/data/[^/]*\\.jsonp"
+          n: 6
     Alpha diversity - Shannon's diversity index:
       ftype: qzv
       asserts:
-        - has_size:
-            min: 300k
-            max: 400k
-        - has_archive_member:
-            path: "^[^/]*/data/[^/]*\\.csv"
-            n: 6
-        - has_archive_member:
-            path: "^[^/]*/data/[^/]*\\.jsonp"
-            n: 6
+      - has_size:
+          min: 300k
+          max: 400k
+      - has_archive_member:
+          path: "^[^/]*/data/[^/]*\\.csv"
+          n: 6
+      - has_archive_member:
+          path: "^[^/]*/data/[^/]*\\.jsonp"
+          n: 6
     Alpha diversity - Observed features:
       ftype: qzv
       asserts:
-        - has_size:
-            min: 300k
-            max: 400k
-        - has_archive_member:
-            path: "^[^/]*/data/[^/]*\\.csv"
-            n: 6
-        - has_archive_member:
-            path: "^[^/]*/data/[^/]*\\.jsonp"
-            n: 6
+      - has_size:
+          min: 300k
+          max: 400k
+      - has_archive_member:
+          path: "^[^/]*/data/[^/]*\\.csv"
+          n: 6
+      - has_archive_member:
+          path: "^[^/]*/data/[^/]*\\.jsonp"
+          n: 6
     Beta diversity - Bray-Curtis distance metrics:
       ftype: qzv
       asserts:
-        - has_size:
-            min: 400k
-            max: 500k
-        - has_archive_member:
-            path: "^[^/]*/data/raw_data\\.tsv"
-            n: 1
-        - has_archive_member:
-            path: "^[^/]*/data/[^/]*\\.png"
-            n: 6
-        - has_archive_member:
-            path: "^[^/]*/data/[^/]*\\.pdf"
-            n: 6
+      - has_size:
+          min: 400k
+          max: 500k
+      - has_archive_member:
+          path: "^[^/]*/data/raw_data\\.tsv"
+          n: 1
+      - has_archive_member:
+          path: "^[^/]*/data/[^/]*\\.png"
+          n: 6
+      - has_archive_member:
+          path: "^[^/]*/data/[^/]*\\.pdf"
+          n: 6
     Beta diversity - Jaccard distance metrics:
       ftype: qzv
       asserts:
-        - has_size:
-            min: 400k
-            max: 500k
-        - has_archive_member:
-            path: "^[^/]*/data/raw_data\\.tsv"
-            n: 1
-        - has_archive_member:
-            path: "^[^/]*/data/[^/]*\\.png"
-            n: 6
-        - has_archive_member:
-            path: "^[^/]*/data/[^/]*\\.pdf"
-            n: 6
+      - has_size:
+          min: 400k
+          max: 500k
+      - has_archive_member:
+          path: "^[^/]*/data/raw_data\\.tsv"
+          n: 1
+      - has_archive_member:
+          path: "^[^/]*/data/[^/]*\\.png"
+          n: 6
+      - has_archive_member:
+          path: "^[^/]*/data/[^/]*\\.pdf"
+          n: 6
     Beta diversity - weighted UniFrac distance metrics:
       ftype: qzv
       asserts:
-        - has_size:
-            min: 400k
-            max: 500k
-        - has_archive_member:
-            path: "^[^/]*/data/raw_data\\.tsv"
-            n: 1
-        - has_archive_member:
-            path: "^[^/]*/data/[^/]*\\.png"
-            n: 6
-        - has_archive_member:
-            path: "^[^/]*/data/[^/]*\\.pdf"
-            n: 6
+      - has_size:
+          min: 400k
+          max: 500k
+      - has_archive_member:
+          path: "^[^/]*/data/raw_data\\.tsv"
+          n: 1
+      - has_archive_member:
+          path: "^[^/]*/data/[^/]*\\.png"
+          n: 6
+      - has_archive_member:
+          path: "^[^/]*/data/[^/]*\\.pdf"
+          n: 6
     Emperor plot collection:
       element_tests:
         'unweighted_unifrac':

--- a/workflows/bacterial_genomics/amr_gene_detection/amr_gene_detection-tests.yml
+++ b/workflows/bacterial_genomics/amr_gene_detection/amr_gene_detection-tests.yml
@@ -3,6 +3,9 @@
     Input sequence fasta:
       class: File
       path: https://zenodo.org/records/15696987/files/shovill_contigs_fasta_contig00089.fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: a3545f886ccca21cba986bf12daa2240f36ef1b6
     Select a taxonomy group point mutation: Enterococcus_faecalis
     Select a AMR genes detection database: amrfinderplus_V3.12_2024-05-02.2
     Select a virulence genes detection database: vfdb
@@ -10,17 +13,17 @@
     Select species for point mutation analysis using PointFinder: enterococcus_faecalis
   outputs:
     staramr_detailed_summary:
-        asserts:
-          has_text:
-            text: "Resistance"
-          has_n_columns:
-            n: 12
+      asserts:
+        has_text:
+          text: "Resistance"
+        has_n_columns:
+          n: 12
     staramr_resfinder_report:
-        asserts:
-          has_text:
-            text: "Chloramphenicol"
-          has_n_columns:
-            n: 13
+      asserts:
+        has_text:
+          text: "Chloramphenicol"
+        has_n_columns:
+          n: 13
     staramr_mlst_report:
       asserts:
         has_text:
@@ -61,9 +64,9 @@
           text: "RESISTANCE"
     tooldistillator_summarize_amr:
       asserts:
-        - that: "has_text"
-          text: "% Identity to reference sequence"
-        - that: "has_text"
-          text: "pointfinder_file"
-        - that: "has_text"
-          text: "LINCOSAMIDE"
+      - that: "has_text"
+        text: "% Identity to reference sequence"
+      - that: "has_text"
+        text: "pointfinder_file"
+      - that: "has_text"
+        text: "LINCOSAMIDE"

--- a/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation-tests.yml
+++ b/workflows/bacterial_genomics/bacterial_genome_annotation/bacterial_genome_annotation-tests.yml
@@ -3,6 +3,9 @@
     Input sequence fasta:
       class: File
       path: https://zenodo.org/records/11488310/files/shovill_contigs_fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: b77e9cf8473eaba8a640a398a0b06b9c87249052
     Select a plasmid detection database: plasmidfinder_81c11f4_2023_12_04
     Select a bacterial genome annotation database: V5.0_2023-02-20
     Select a AMRFinderPlus database: amrfinderplus_V3.12_2024-05-02.2
@@ -53,7 +56,7 @@
           n: 8
     tooldistillator_summarize_annotation:
       asserts:
-        - that: "has_text"
-          text: "CDS12738(DOp1)"
-        - that: "has_text"
-          text: "PFAM"
+      - that: "has_text"
+        text: "CDS12738(DOp1)"
+      - that: "has_text"
+        text: "PFAM"

--- a/workflows/computational-chemistry/gromacs-dctmd/gromacs-dctmd-tests.yml
+++ b/workflows/computational-chemistry/gromacs-dctmd/gromacs-dctmd-tests.yml
@@ -1,15 +1,21 @@
 - doc: Test outline for gromacs-dctmd.ga
   job:
-    Force field: "amber99sb" 
+    Force field: "amber99sb"
     Ligand SDF:
       class: File
       path: "test-data/lig.sdf"
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 6ba678a27103cd6e8f1eae8cd92dee757c77069a
     Number of simulations: "2"
     Number of steps: "100"
     Protein PDB:
       class: File
       path: "test-data/mpro.pdb"
-    Protein pull group: "350 364 378 606 623 658 669 683 721 2164 2184 2203 2217 2224 2235 2543 2558 2585 2841 2853 2877 2894" 
+      hashes:
+      - hash_function: SHA-1
+        hash_value: e70a278f8a971a49b1e92828fadf33fe78b71993
+    Protein pull group: "350 364 378 606 623 658 669 683 721 2164 2184 2203 2217 2224 2235 2543 2558 2585 2841 2853 2877 2894"
     Pull group pbcatom: "606"
     Pulling rate: "0.001"
     Step length (ps): "0.001"

--- a/workflows/computational-chemistry/protein-ligand-complex-parameterization/protein-ligand-complex-parameterization-tests.yml
+++ b/workflows/computational-chemistry/protein-ligand-complex-parameterization/protein-ligand-complex-parameterization-tests.yml
@@ -3,10 +3,16 @@
     Apoprotein PDB:
       class: File
       path: "test-data/mpro.pdb"
+      hashes:
+      - hash_function: SHA-1
+        hash_value: e70a278f8a971a49b1e92828fadf33fe78b71993
     Force field: "amber99sb"
     Ligand SDF:
       class: File
       path: "test-data/lig.sdf"
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 6ba678a27103cd6e8f1eae8cd92dee757c77069a
     Water model: "tip3p"
   outputs:
     Complex GRO:

--- a/workflows/data-fetching/parallel-accession-download/parallel-accession-download-tests.yml
+++ b/workflows/data-fetching/parallel-accession-download/parallel-accession-download-tests.yml
@@ -3,6 +3,9 @@
     Run accessions:
       class: File
       path: test-data/input_accession_single_end.txt
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 82f7d1a023352b8d99bdf262ccbc0c87723b754b
   outputs:
     Single End Reads:
       element_tests:
@@ -16,6 +19,9 @@
     Run accessions:
       class: File
       path: test-data/input_accession_paired_end.txt
+      hashes:
+      - hash_function: SHA-1
+        hash_value: cc855f075b8473f89364415d7f30fada8182a40a
   outputs:
     Paired End Reads:
       element_tests:

--- a/workflows/data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs-tests.yml
+++ b/workflows/data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs-tests.yml
@@ -3,6 +3,9 @@
     SRA_manifest:
       class: File
       path: test-data/SRA.txt
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 9b267d141fe2b577d6096ac5573a72b86abc33ba
     Column number with SRA ID: 1
     Column number with final identifier: 22
   outputs:

--- a/workflows/epigenetics/atacseq/atacseq-tests.yml
+++ b/workflows/epigenetics/atacseq/atacseq-tests.yml
@@ -12,10 +12,16 @@
           class: File
           location: https://zenodo.org/record/3862793/files/SRR891268_chr22_enriched_R1.fastq.gz
           filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 0fd546fe61d5dcdec0d91c91c6ad02b4de1b40fc
         - identifier: reverse
           class: File
           location: https://zenodo.org/record/3862793/files/SRR891268_chr22_enriched_R2.fastq.gz
           filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 8572153e721ba209a716128854b4560664bdf23d
     reference_genome: hg19
     effective_genome_size: 2700000000
     bin_size: 1000
@@ -24,17 +30,17 @@
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
-            - that: "has_text"
-              text: "7282 (2.59%) aligned concordantly 0 times"
-            - that: "has_text"
-              text: "121059 (43.09%) aligned concordantly exactly 1 time"
-            - that: "has_text"
-              text: "152623 (54.32%) aligned concordantly >1 times"
+          - that: "has_text"
+            text: "7282 (2.59%) aligned concordantly 0 times"
+          - that: "has_text"
+            text: "121059 (43.09%) aligned concordantly exactly 1 time"
+          - that: "has_text"
+            text: "152623 (54.32%) aligned concordantly >1 times"
     MarkDuplicates metrics:
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
-            has_text: 
+            has_text:
               text: "0.02"
     BAM filtered rmDup:
       element_tests:
@@ -54,16 +60,16 @@
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
-            has_n_lines: 
+            has_n_lines:
               n: 236
     MACS2 report:
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
-            - that: "has_text"
-              text: "# tag size is determined as 47 bps"
-            - that: "has_text"
-              text: "# total tags in treatment: 262080"
+          - that: "has_text"
+            text: "# tag size is determined as 47 bps"
+          - that: "has_text"
+            text: "# total tags in treatment: 262080"
     Coverage from MACS2 (bigwig):
       element_tests:
         SRR891268_chr22_enriched:
@@ -75,13 +81,13 @@
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
-            has_n_lines: 
+            has_n_lines:
               n: 217
     Nb of reads in summits +-500bp:
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
-            has_line: 
+            has_line:
               line: "9548"
     bigwig_norm:
       element_tests:
@@ -100,14 +106,14 @@
     'MultiQC on input dataset(s): Stats':
       asserts:
         has_line:
-          line: "Sample	MACS2_mqc_generalstats_macs2_d	MACS2_mqc_generalstats_macs2_peak_count	Picard: Mark Duplicates_mqc_generalstats_picard_mark_duplicates_PERCENT_DUPLICATION	Bowtie 2 / HiSAT2_mqc_generalstats_bowtie_2_hisat2_overall_alignment_rate	Cutadapt_mqc_generalstats_cutadapt_percent_trimmed"
+          line: "Sample\tMACS2_mqc_generalstats_macs2_d\tMACS2_mqc_generalstats_macs2_peak_count\tPicard: Mark Duplicates_mqc_generalstats_picard_mark_duplicates_PERCENT_DUPLICATION\tBowtie 2 / HiSAT2_mqc_generalstats_bowtie_2_hisat2_overall_alignment_rate\tCutadapt_mqc_generalstats_cutadapt_percent_trimmed"
         has_text_matching:
           expression: "SRR891268_chr22_enriched\t200.0\t236\t2.7[0-9]*\t98.[0-9]*\t4.7[0-9]*"
     MultiQC webpage:
-          asserts:
-            - that: "has_text"
-              text: "<a href=\"#cutadapt_filtered_reads\" class=\"nav-l2\">Filtered Reads</a>"
-            - that: "has_text"
-              text: "<td>% Aligned</td>"
-            - that: "has_text"
-              text: "<td>% BP Trimmed</td>"
+      asserts:
+      - that: "has_text"
+        text: "<a href=\"#cutadapt_filtered_reads\" class=\"nav-l2\">Filtered Reads</a>"
+      - that: "has_text"
+        text: "<td>% Aligned</td>"
+      - that: "has_text"
+        text: "<td>% BP Trimmed</td>"

--- a/workflows/epigenetics/average-bigwig-between-replicates/average-bigwig-between-replicates-tests.yml
+++ b/workflows/epigenetics/average-bigwig-between-replicates/average-bigwig-between-replicates-tests.yml
@@ -8,18 +8,30 @@
         class: File
         location: https://www.ncbi.nlm.nih.gov/geo/download/?acc=GSM6152756&format=file&file=GSM6152756%5FATAC%5FHH19%5FPT%5Frep1%2Ebigwig
         filetype: bigwig
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 85e05349f1d3353cf5c56221c2d8d90ced1ca6b3
       - identifier: ATAC_HH19_PT_rep2
         class: File
         location: https://www.ncbi.nlm.nih.gov/geo/download/?acc=GSM6152757&format=file&file=GSM6152757%5FATAC%5FHH19%5FPT%5Frep2%2Ebigwig
         filetype: bigwig
+        hashes:
+        - hash_function: SHA-1
+          hash_value: d709cb76a683fcd2f98cd467535cdbeff82cb851
       - identifier: ATAC_HH35_DS_rep1
         class: File
         location: https://www.ncbi.nlm.nih.gov/geo/download/?acc=GSM6152758&format=file&file=GSM6152758%5FATAC%5FHH35%5FDS%5Frep1%2Ebigwig
         filetype: bigwig
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 86ac9190cc7971cec4f63509cf3b2b7fc2f56157
       - identifier: ATAC_HH35_DS_rep2
         class: File
         location: https://www.ncbi.nlm.nih.gov/geo/download/?acc=GSM6152759&format=file&file=GSM6152759%5FATAC%5FHH35%5FDS%5Frep2%2Ebigwig
         filetype: bigwig
+        hashes:
+        - hash_function: SHA-1
+          hash_value: fa3a2c20757ab94d0c9618d2186a108329e206cf
     bin_size: 50
   outputs:
     average_bigwigs:

--- a/workflows/epigenetics/chipseq-pe/chipseq-pe-tests.yml
+++ b/workflows/epigenetics/chipseq-pe/chipseq-pe-tests.yml
@@ -12,10 +12,16 @@
           class: File
           location: https://zenodo.org/record/1324070/files/wt_H3K4me3_read1.fastq.gz
           filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 60cef994485a6bddf9e2b7efca464efc34559c12
         - identifier: reverse
           class: File
           location: https://zenodo.org/record/1324070/files/wt_H3K4me3_read2.fastq.gz
           filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: beaa36e4cfd92910672d1c2948d6a94204dc9788
     Percentage of bad quality bases per read: 70
     Reference genome: 'mm10'
     Effective genome size: 1870000000
@@ -23,16 +29,16 @@
   outputs:
     MultiQC webpage:
       asserts:
-        - that: "has_text"
-          text: "wt_H3K4me3"
-        - that: "has_text"
-          text: <a href="#fastp" class="nav-l1">fastp</a>
-        - that: "has_text"
-          text: <a href="#bowtie2" class="nav-l1">Bowtie 2 / HiSAT2</a>
+      - that: "has_text"
+        text: "wt_H3K4me3"
+      - that: "has_text"
+        text: <a href="#fastp" class="nav-l1">fastp</a>
+      - that: "has_text"
+        text: <a href="#bowtie2" class="nav-l1">Bowtie 2 / HiSAT2</a>
     'MultiQC on input dataset(s): Stats':
       asserts:
         has_line:
-          line: "Sample	macs2-d	macs2-treatment_redundant_rate	macs2-peak_count	bowtie_2_hisat2-overall_alignment_rate	fastp-pct_duplication	fastp-after_filtering_q30_rate	fastp-after_filtering_q30_bases	fastp-filtering_result_passed_filter_reads	fastp-after_filtering_gc_content	fastp-pct_surviving	fastp-pct_adapter"
+          line: "Sample\tmacs2-d\tmacs2-treatment_redundant_rate\tmacs2-peak_count\tbowtie_2_hisat2-overall_alignment_rate\tfastp-pct_duplication\tfastp-after_filtering_q30_rate\tfastp-after_filtering_q30_bases\tfastp-filtering_result_passed_filter_reads\tfastp-after_filtering_gc_content\tfastp-pct_surviving\tfastp-pct_adapter"
         has_text_matching:
           expression: "wt_H3K4me3\t20[12].0\t0.0\t13\t98.[0-9]*\t0.002\t93.[0-9]*\t4.5[0-9]*\t0.095[0-9]*\t57.[0-9]*\t95.[0-9]*\t0.19[0-9]*"
     filtered BAM:
@@ -52,42 +58,42 @@
       element_tests:
         wt_H3K4me3:
           asserts:
-            - that: "has_text"
-              text: "# effective genome size = 1.87e+09"
-            - that: "has_text_matching"
-              expression: "# fragment size is determined as 20[12] bps"
-            - that: "has_text"
-              text: "# fragments after filtering in treatment: 42745"
+          - that: "has_text"
+            text: "# effective genome size = 1.87e+09"
+          - that: "has_text_matching"
+            expression: "# fragment size is determined as 20[12] bps"
+          - that: "has_text"
+            text: "# fragments after filtering in treatment: 42745"
     MACS2 narrowPeak:
       element_tests:
         wt_H3K4me3:
           asserts:
-            has_n_lines: 
+            has_n_lines:
               n: 13
     MACS2 report:
       element_tests:
         wt_H3K4me3:
           asserts:
-            - that: "has_text"
-              text: "# effective genome size = 1.87e+09"
-            - that: "has_text_matching"
-              expression: "# fragment size is determined as 20[12] bps"
-            - that: "has_text"
-              text: "# fragments after filtering in treatment: 42745"
+          - that: "has_text"
+            text: "# effective genome size = 1.87e+09"
+          - that: "has_text_matching"
+            expression: "# fragment size is determined as 20[12] bps"
+          - that: "has_text"
+            text: "# fragments after filtering in treatment: 42745"
     coverage from MACS2:
       element_tests:
         wt_H3K4me3:
-           asserts:
-              has_size:
-                value: 568174
-                delta: 50000
+          asserts:
+            has_size:
+              value: 568174
+              delta: 50000
     mapping stats:
       element_tests:
         wt_H3K4me3:
-            asserts:
-            - that: "has_text"
-              text: "1344 (2.82%) aligned concordantly 0 times"
-            - that: "has_text"
-              text: "42961 (90.29%) aligned concordantly exactly 1 time"
-            - that: "has_text"
-              text: "3276 (6.89%) aligned concordantly >1 times"
+          asserts:
+          - that: "has_text"
+            text: "1344 (2.82%) aligned concordantly 0 times"
+          - that: "has_text"
+            text: "42961 (90.29%) aligned concordantly exactly 1 time"
+          - that: "has_text"
+            text: "3276 (6.89%) aligned concordantly >1 times"

--- a/workflows/epigenetics/chipseq-sr/chipseq-sr-tests.yml
+++ b/workflows/epigenetics/chipseq-sr/chipseq-sr-tests.yml
@@ -8,6 +8,9 @@
         class: File
         location: https://zenodo.org/record/1324070/files/wt_H3K4me3_read1.fastq.gz
         filetype: fastqsanger.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 60cef994485a6bddf9e2b7efca464efc34559c12
     Adapter sequence: 'GATCGGAAGAGCACACGTCTGAACTCCAGTCAC'
     Percentage of bad quality bases per read: 70
     Reference genome: 'mm10'
@@ -16,16 +19,16 @@
   outputs:
     MultiQC webpage:
       asserts:
-        - that: "has_text"
-          text: "wt_H3K4me3"
-        - that: "has_text"
-          text: <a href="#fastp" class="nav-l1">fastp</a>
-        - that: "has_text"
-          text: <a href="#bowtie2" class="nav-l1">Bowtie 2 / HiSAT2</a>
+      - that: "has_text"
+        text: "wt_H3K4me3"
+      - that: "has_text"
+        text: <a href="#fastp" class="nav-l1">fastp</a>
+      - that: "has_text"
+        text: <a href="#bowtie2" class="nav-l1">Bowtie 2 / HiSAT2</a>
     'MultiQC on input dataset(s): Stats':
       asserts:
         has_line:
-          line: "Sample	macs2-d	macs2-treatment_redundant_rate	macs2-peak_count	bowtie_2_hisat2-overall_alignment_rate	fastp-pct_duplication	fastp-after_filtering_q30_rate	fastp-after_filtering_q30_bases	fastp-filtering_result_passed_filter_reads	fastp-after_filtering_gc_content	fastp-pct_surviving	fastp-pct_adapter"
+          line: "Sample\tmacs2-d\tmacs2-treatment_redundant_rate\tmacs2-peak_count\tbowtie_2_hisat2-overall_alignment_rate\tfastp-pct_duplication\tfastp-after_filtering_q30_rate\tfastp-after_filtering_q30_bases\tfastp-filtering_result_passed_filter_reads\tfastp-after_filtering_gc_content\tfastp-pct_surviving\tfastp-pct_adapter"
         has_text_matching:
           expression: "wt_H3K4me3\t200.0\t0.0\t9\t98.[0-9]*\t0.22[0-9]*\t93.[0-9]*\t2.3[0-9]*\t0.049[0-9]*\t57.[0-9]*\t99.[0-9]*\t0.12[0-9]*"
     filtered BAM:
@@ -45,42 +48,42 @@
       element_tests:
         wt_H3K4me3:
           asserts:
-            - that: "has_text"
-              text: "# effective genome size = 1.87e+09"
-            - that: "has_text"
-              text: "# d = 200"
-            - that: "has_text"
-              text: "# tags after filtering in treatment: 44528"
+          - that: "has_text"
+            text: "# effective genome size = 1.87e+09"
+          - that: "has_text"
+            text: "# d = 200"
+          - that: "has_text"
+            text: "# tags after filtering in treatment: 44528"
     MACS2 narrowPeak:
       element_tests:
         wt_H3K4me3:
           asserts:
-            has_n_lines: 
+            has_n_lines:
               n: 9
     MACS2 report:
       element_tests:
         wt_H3K4me3:
           asserts:
-            - that: "has_text"
-              text: "# effective genome size = 1.87e+09"
-            - that: "has_text"
-              text: "# d = 200"
-            - that: "has_text"
-              text: "# tags after filtering in treatment: 44528"
+          - that: "has_text"
+            text: "# effective genome size = 1.87e+09"
+          - that: "has_text"
+            text: "# d = 200"
+          - that: "has_text"
+            text: "# tags after filtering in treatment: 44528"
     coverage from MACS2:
       element_tests:
         wt_H3K4me3:
-           asserts:
-              has_size:
-                value: 563563
-                delta: 10000
+          asserts:
+            has_size:
+              value: 563563
+              delta: 10000
     mapping stats:
       element_tests:
         wt_H3K4me3:
-            asserts:
-            - that: "has_text"
-              text: "49813 reads; of these:"
-            - that: "has_text"
-              text: "44357 (89.05%) aligned exactly 1 time"
-            - that: "has_text"
-              text: "98.27% overall alignment rate"
+          asserts:
+          - that: "has_text"
+            text: "49813 reads; of these:"
+          - that: "has_text"
+            text: "44357 (89.05%) aligned exactly 1 time"
+          - that: "has_text"
+            text: "98.27% overall alignment rate"

--- a/workflows/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun-tests.yml
+++ b/workflows/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun-tests.yml
@@ -8,14 +8,23 @@
         identifier: rep1
         path: test-data/rep1.bam
         dbkey: mm10
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 531c7f2726f25c23e1c153df9bc6a6e3fa4b91e7
       - class: File
         identifier: rep2
         path: test-data/rep2.bam
         dbkey: mm10
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 37b8544b15f08e7ccf36ff0b71894c935090f0b1
       - class: File
         identifier: rep3
         path: test-data/rep3.bam
         dbkey: mm10
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 5174415aa59d740664e17238cd48143a257a7bc0
     Minimum number of overlap: 2
     effective_genome_size: 1870000000
     bin_size: 50

--- a/workflows/epigenetics/consensus-peaks/consensus-peaks-chip-pe-tests.yml
+++ b/workflows/epigenetics/consensus-peaks/consensus-peaks-chip-pe-tests.yml
@@ -8,14 +8,23 @@
         identifier: rep1
         path: test-data/rep1.bam
         dbkey: mm10
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 531c7f2726f25c23e1c153df9bc6a6e3fa4b91e7
       - class: File
         identifier: rep2
         path: test-data/rep2.bam
         dbkey: mm10
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 37b8544b15f08e7ccf36ff0b71894c935090f0b1
       - class: File
         identifier: rep3
         path: test-data/rep3.bam
         dbkey: mm10
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 5174415aa59d740664e17238cd48143a257a7bc0
     Minimum number of overlap: 2
     effective_genome_size: 1870000000
     bin_size: 50

--- a/workflows/epigenetics/consensus-peaks/consensus-peaks-chip-sr-tests.yml
+++ b/workflows/epigenetics/consensus-peaks/consensus-peaks-chip-sr-tests.yml
@@ -8,14 +8,23 @@
         identifier: rep1
         path: test-data/ChIP_SR_rep1.bam
         dbkey: mm10
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 6eb0213baf8b0ad9bcd231f265a2b546ccf27c86
       - class: File
         identifier: rep2
         path: test-data/ChIP_SR_rep2.bam
         dbkey: mm10
+        hashes:
+        - hash_function: SHA-1
+          hash_value: bc0af156a886d7db3301d43c27f868c8ac20e4ab
       - class: File
         identifier: rep3
         path: test-data/ChIP_SR_rep3.bam
         dbkey: mm10
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 04fc480496751761d8535e7df522a7f3144810a4
     Minimum number of overlap: 2
     effective_genome_size: 1870000000
     bin_size: 50

--- a/workflows/epigenetics/cutandrun/cutandrun-tests.yml
+++ b/workflows/epigenetics/cutandrun/cutandrun-tests.yml
@@ -12,10 +12,16 @@
           class: File
           location: https://zenodo.org/record/6823059/files/Rep1_R1.fastq
           filetype: fastqsanger
+          hashes:
+          - hash_function: SHA-1
+            hash_value: f60788cf7767330c960afb7ae6ba8f4009a11770
         - identifier: reverse
           class: File
           location: https://zenodo.org/record/6823059/files/Rep1_R2.fastq
           filetype: fastqsanger
+          hashes:
+          - hash_function: SHA-1
+            hash_value: a0af1b73fa1b24d2abe5d816091f544133149b25
     adapter_forward: 'GATCGGAAGAGCACACGTCTGAACTCCAGTCAC'
     adapter_reverse: 'GATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT'
     reference_genome: 'hg38canon'
@@ -77,10 +83,16 @@
           class: File
           path: test-data/SRR15904259_subset_forward.fastqsanger.gz
           filetype: fastqsanger
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 78bc3a979ba69eb1e208fa1ef02cc4eaf2558204
         - identifier: reverse
           class: File
           path: test-data/SRR15904259_subset_reverse.fastqsanger.gz
           filetype: fastqsanger
+          hashes:
+          - hash_function: SHA-1
+            hash_value: fc08c3fc612a5562566f5e7d987ebd89a6e3f43f
     adapter_forward: 'GATCGGAAGAGCACACGTCTGAACTCCAGTCAC'
     adapter_reverse: 'GATCGGAAGAGCGTCGTGTAGGGAAAGAGTGT'
     reference_genome: 'dm6'

--- a/workflows/epigenetics/hic-hicup-cooler/chic-fastq-to-cool-hicup-cooler-tests.yml
+++ b/workflows/epigenetics/hic-hicup-cooler/chic-fastq-to-cool-hicup-cooler-tests.yml
@@ -12,10 +12,16 @@
           identifier: forward
           location: https://github.com/bgruening/galaxytools/raw/master/tools/hicup/test-data/dataset1.fastq
           filetype: fastqsanger
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 44e770082bebc78d3fd4a0ab36a310e3a9b2b30b
         - class: File
           identifier: reverse
           location: https://github.com/bgruening/galaxytools/raw/master/tools/hicup/test-data/dataset2.fastq
           filetype: fastqsanger
+          hashes:
+          - hash_function: SHA-1
+            hash_value: fad880234676f3402c2293baf559ff75d5106b81
     genome name: hg19
     Restriction enzyme: A^AGCTT,HindIII
     No fill-in: 'false'
@@ -43,22 +49,22 @@
       element_tests:
         test_dataset:
           asserts:
-            - that: "has_line"
-              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
-            - that: "has_line"
-              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
-            - that: "has_line"
-              line: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
+          - that: "has_line"
+            line: "1\t1\tchr10\t100023987\t28055\t1\tchr10\t101500419\t28474\t42\t42"
+          - that: "has_line"
+            line: "2\t1\tchr10\t100091500\t28079\t1\tchr10\t122245984\t34516\t38\t42"
+          - that: "has_line"
+            line: "3\t0\tchr10\t100127492\t28094\t1\tchr10\t50864290\t13489\t0\t42"
     valid pairs in juicebox format MAPQ filtered:
       element_tests:
         test_dataset:
           asserts:
-            - that: "has_line"
-              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
-            - that: "has_line"
-              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
-            - that: "not_has_text"
-              text: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
+          - that: "has_line"
+            line: "1\t1\tchr10\t100023987\t28055\t1\tchr10\t101500419\t28474\t42\t42"
+          - that: "has_line"
+            line: "2\t1\tchr10\t100091500\t28079\t1\tchr10\t122245984\t34516\t38\t42"
+          - that: "not_has_text"
+            text: "3\t0\tchr10\t100127492\t28094\t1\tchr10\t50864290\t13489\t0\t42"
     valid pairs filtered and sorted:
       element_tests:
         test_dataset:

--- a/workflows/epigenetics/hic-hicup-cooler/hic-fastq-to-cool-hicup-cooler-tests.yml
+++ b/workflows/epigenetics/hic-hicup-cooler/hic-fastq-to-cool-hicup-cooler-tests.yml
@@ -12,10 +12,16 @@
           identifier: forward
           location: https://github.com/bgruening/galaxytools/raw/master/tools/hicup/test-data/dataset1.fastq
           filetype: fastqsanger
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 44e770082bebc78d3fd4a0ab36a310e3a9b2b30b
         - class: File
           identifier: reverse
           location: https://github.com/bgruening/galaxytools/raw/master/tools/hicup/test-data/dataset2.fastq
           filetype: fastqsanger
+          hashes:
+          - hash_function: SHA-1
+            hash_value: fad880234676f3402c2293baf559ff75d5106b81
     genome name: hg19
     Restriction enzyme: A^AGCTT,HindIII
     No fill-in: 'false'
@@ -41,22 +47,22 @@
       element_tests:
         test_dataset:
           asserts:
-            - that: "has_line"
-              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
-            - that: "has_line"
-              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
-            - that: "has_line"
-              line: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
+          - that: "has_line"
+            line: "1\t1\tchr10\t100023987\t28055\t1\tchr10\t101500419\t28474\t42\t42"
+          - that: "has_line"
+            line: "2\t1\tchr10\t100091500\t28079\t1\tchr10\t122245984\t34516\t38\t42"
+          - that: "has_line"
+            line: "3\t0\tchr10\t100127492\t28094\t1\tchr10\t50864290\t13489\t0\t42"
     valid pairs in juicebox format MAPQ filtered:
       element_tests:
         test_dataset:
           asserts:
-            - that: "has_line"
-              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
-            - that: "has_line"
-              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
-            - that: "not_has_text"
-              text: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
+          - that: "has_line"
+            line: "1\t1\tchr10\t100023987\t28055\t1\tchr10\t101500419\t28474\t42\t42"
+          - that: "has_line"
+            line: "2\t1\tchr10\t100091500\t28079\t1\tchr10\t122245984\t34516\t38\t42"
+          - that: "not_has_text"
+            text: "3\t0\tchr10\t100127492\t28094\t1\tchr10\t50864290\t13489\t0\t42"
     valid pairs filtered and sorted:
       element_tests:
         test_dataset:

--- a/workflows/epigenetics/hic-hicup-cooler/hic-fastq-to-pairs-hicup-tests.yml
+++ b/workflows/epigenetics/hic-hicup-cooler/hic-fastq-to-pairs-hicup-tests.yml
@@ -12,10 +12,16 @@
           identifier: forward
           location: https://github.com/bgruening/galaxytools/raw/master/tools/hicup/test-data/dataset1.fastq
           filetype: fastqsanger
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 44e770082bebc78d3fd4a0ab36a310e3a9b2b30b
         - class: File
           identifier: reverse
           location: https://github.com/bgruening/galaxytools/raw/master/tools/hicup/test-data/dataset2.fastq
           filetype: fastqsanger
+          hashes:
+          - hash_function: SHA-1
+            hash_value: fad880234676f3402c2293baf559ff75d5106b81
     genome name: hg19
     Restriction enzyme: A^AGCTT,HindIII
     No fill-in: 'false'
@@ -38,19 +44,19 @@
       element_tests:
         test_dataset:
           asserts:
-            - that: "has_line"
-              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
-            - that: "has_line"
-              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
-            - that: "has_line"
-              line: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
+          - that: "has_line"
+            line: "1\t1\tchr10\t100023987\t28055\t1\tchr10\t101500419\t28474\t42\t42"
+          - that: "has_line"
+            line: "2\t1\tchr10\t100091500\t28079\t1\tchr10\t122245984\t34516\t38\t42"
+          - that: "has_line"
+            line: "3\t0\tchr10\t100127492\t28094\t1\tchr10\t50864290\t13489\t0\t42"
     valid pairs in juicebox format MAPQ filtered:
       element_tests:
         test_dataset:
           asserts:
-            - that: "has_line"
-              line: "1	1	chr10	100023987	28055	1	chr10	101500419	28474	42	42"
-            - that: "has_line"
-              line: "2	1	chr10	100091500	28079	1	chr10	122245984	34516	38	42"
-            - that: "not_has_text"
-              text: "3	0	chr10	100127492	28094	1	chr10	50864290	13489	0	42"
+          - that: "has_line"
+            line: "1\t1\tchr10\t100023987\t28055\t1\tchr10\t101500419\t28474\t42\t42"
+          - that: "has_line"
+            line: "2\t1\tchr10\t100091500\t28079\t1\tchr10\t122245984\t34516\t38\t42"
+          - that: "not_has_text"
+            text: "3\t0\tchr10\t100127492\t28094\t1\tchr10\t50864290\t13489\t0\t42"

--- a/workflows/epigenetics/hic-hicup-cooler/hic-juicermediumtabix-to-cool-cooler-tests.yml
+++ b/workflows/epigenetics/hic-hicup-cooler/hic-juicermediumtabix-to-cool-cooler-tests.yml
@@ -4,10 +4,13 @@
       class: Collection
       collection_type: list
       elements:
-        - class: File
-          identifier: test_dataset
-          path: test-data/valid_pairs_filtered_and_sorted.juicer_medium_tabix.gz
-          filetype: juicer_medium_tabix.gz
+      - class: File
+        identifier: test_dataset
+        path: test-data/valid_pairs_filtered_and_sorted.juicer_medium_tabix.gz
+        filetype: juicer_medium_tabix.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 16c634960b43d37ad104d20bc3ed435accc223a9
     genome name: hg19
     Bin size in bp: 1000000
     Interactions to consider to calculate weights in normalization step: --cis-only

--- a/workflows/genome-assembly/assembly-with-flye/Genome-assembly-with-Flye-tests.yml
+++ b/workflows/genome-assembly/assembly-with-flye/Genome-assembly-with-Flye-tests.yml
@@ -4,6 +4,9 @@
       class: File
       path: test-data/Input_reads.fastqsanger.gz
       filetype: fastqsanger.gz
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 18f30f2a901e027bb3b8e9d99a102b15c2648477
   outputs:
     Flye assembly (consensus):
       asserts:
@@ -36,7 +39,7 @@
           min: 250k
           max: 400k
     Flye assembly statistics:
-      asserts: 
+      asserts:
         has_text:
           text: "Scaffold L50"
     'Bandage Image: Assembly Graph Image':

--- a/workflows/genome-assembly/polish-with-long-reads/Assembly-polishing-with-long-reads-tests.yml
+++ b/workflows/genome-assembly/polish-with-long-reads/Assembly-polishing-with-long-reads-tests.yml
@@ -4,10 +4,16 @@
       class: File
       path: test-data/assembly.fasta
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 3de02c8cb8b7dfc02428093c08c4bba63b966bcb
     long reads:
       class: File
       path: test-data/long_reads.fastqsanger.gz
       filetype: fastqsanger.gz
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 18f30f2a901e027bb3b8e9d99a102b15c2648477
     'minimap setting (for long reads) ': map-ont
   outputs:
     Assembly polished by long reads using Racon:

--- a/workflows/genome_annotation/functional-annotation/functional-annotation-protein-sequences/Functional_annotation_of_protein_sequences-tests.yml
+++ b/workflows/genome_annotation/functional-annotation/functional-annotation-protein-sequences/Functional_annotation_of_protein_sequences-tests.yml
@@ -4,20 +4,23 @@
       class: File
       location: https://zenodo.org/record/8414802/files/protein_sequences.fasta?download=1
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 0e1026d6917ac03bcd174a85b18e69c2a6470f98
   outputs:
-      eggNOG Mapper seed_orthologs:
-        location: https://zenodo.org/records/13951790/files/eggNOG_Mapper_seed_orthologs.tabular?download=1&preview=1
-        compare: sim_size
-        delta: 50000          
-      eggNOG Mapper annotations:
-        location: https://zenodo.org/records/13951790/files/eggNOG_Mapper_annot.tabular?download=1&preview=1
-        compare: sim_size
-        delta: 100000
-      interproscan xml:
-        location: https://zenodo.org/records/13951790/files/interProScan.xml?download=1&preview=1
-        compare: sim_size
-        delta: 7000000
-      interproscan tabular:
-        location: https://zenodo.org/records/13951790/files/interProScan.tabular?download=1&preview=1
-        compare: sim_size
-        delta: 2000000
+    eggNOG Mapper seed_orthologs:
+      location: https://zenodo.org/records/13951790/files/eggNOG_Mapper_seed_orthologs.tabular?download=1&preview=1
+      compare: sim_size
+      delta: 50000
+    eggNOG Mapper annotations:
+      location: https://zenodo.org/records/13951790/files/eggNOG_Mapper_annot.tabular?download=1&preview=1
+      compare: sim_size
+      delta: 100000
+    interproscan xml:
+      location: https://zenodo.org/records/13951790/files/interProScan.xml?download=1&preview=1
+      compare: sim_size
+      delta: 7000000
+    interproscan tabular:
+      location: https://zenodo.org/records/13951790/files/interProScan.tabular?download=1&preview=1
+      compare: sim_size
+      delta: 2000000

--- a/workflows/imaging/fluorescence-nuclei-segmentation-and-counting/segmentation-and-counting-tests.yml
+++ b/workflows/imaging/fluorescence-nuclei-segmentation-and-counting/segmentation-and-counting-tests.yml
@@ -4,6 +4,9 @@
       class: File
       path: test-data/input_image.tiff
       filetype: tiff
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 42c34939d896d133ce9f0f2af6efd79b02ed52e6
   outputs:
     overlay_image:
       path: test-data/overlay_image.png

--- a/workflows/imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml
+++ b/workflows/imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml
@@ -4,14 +4,23 @@
       class: File
       path: test-data/Markers File.csv
       filetype: csv
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 86ea28bf240a1df678342c69eae5fad1f0e3af24
     Manual Gates:
       class: File
       path: test-data/Manual Gates.csv
       filetype: csv
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 3fe438f11f1e50942e512e34fb139e636a13cf73
     Phenotype workflow:
       class: File
       path: test-data/Phenotype workflow.csv
       filetype: csv
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 96b25445f1cdf974d6be55cc69a392bcf27a77f9
     Registered Images:
       class: Collection
       collection_type: list
@@ -20,82 +29,85 @@
         identifier: image
         location: https://zenodo.org/records/15710828/files/Registered%20Images_registered%20image.ome.tiff?download=1
         filetype: ome.tiff
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 1e2e08fc7196d52db117ad30247b5431b56eed61
   outputs:
     Spatial Scatterplot Montage:
       asserts:
-        - has_size:
-            size: 181K
-            delta: 50K
+      - has_size:
+          size: 181K
+          delta: 50K
     Spatial Interaction Montage:
       asserts:
-        - has_size:
-            size: 39K
-            delta: 20K
+      - has_size:
+          size: 39K
+          delta: 20K
     Merged anndata:
       asserts:
-        - has_h5_keys:
-            keys: obs/Area,obs/CellID,obs/Eccentricity,obs/Extent,obs/MajorAxisLength,obs/MinorAxisLength,obs/Orientation,obs/Solidity,obs/X_centroid,obs/Y_centroid,obs/imageid,obs/imageid/categories,obs/imageid/codes
+      - has_h5_keys:
+          keys: obs/Area,obs/CellID,obs/Eccentricity,obs/Extent,obs/MajorAxisLength,obs/MinorAxisLength,obs/Orientation,obs/Solidity,obs/X_centroid,obs/Y_centroid,obs/imageid,obs/imageid/categories,obs/imageid/codes
     Multisample barplot:
       asserts:
-        - has_size:
-            size: 60K
-            delta: 30K
+      - has_size:
+          size: 60K
+          delta: 30K
     Background subtracted images:
       element_tests:
         image:
           asserts:
-            - has_image_channels:
-                channels: 7
+          - has_image_channels:
+              channels: 7
     Background subtracted markers:
       element_tests:
         image:
           asserts:
-            - has_line:
-                line: marker_name,background,exposure
-            - has_line:
-                line: DNA_7,,
+          - has_line:
+              line: marker_name,background,exposure
+          - has_line:
+              line: DNA_7,,
     Primary Mask Quantification:
       element_tests:
         image:
           asserts:
-            - has_line:
-                line: CellID,DNA_7,CD11B,SMA,CD16,ECAD,FOXP3,NCAM,X_centroid,Y_centroid,Area,MajorAxisLength,MinorAxisLength,Eccentricity,Solidity,Extent,Orientation
+          - has_line:
+              line: CellID,DNA_7,CD11B,SMA,CD16,ECAD,FOXP3,NCAM,X_centroid,Y_centroid,Area,MajorAxisLength,MinorAxisLength,Eccentricity,Solidity,Extent,Orientation
     Segmented Multiplexed Mask:
       element_tests:
         image:
           asserts:
-            - has_image_channels:
-                channels: 1
+          - has_image_channels:
+              channels: 1
     phenotyped adata:
       element_tests:
         image:
           asserts:
-            - has_h5_keys:
-                keys: obs/Area,obs/CellID,obs/Eccentricity,obs/Extent,obs/MajorAxisLength,obs/MinorAxisLength,obs/Orientation,obs/Solidity,obs/X_centroid,obs/Y_centroid,obs/imageid,obs/imageid/categories,obs/imageid/codes
+          - has_h5_keys:
+              keys: obs/Area,obs/CellID,obs/Eccentricity,obs/Extent,obs/MajorAxisLength,obs/MinorAxisLength,obs/Orientation,obs/Solidity,obs/X_centroid,obs/Y_centroid,obs/imageid,obs/imageid/categories,obs/imageid/codes
     Interaction Matrix Plot:
       element_tests:
         image:
           asserts:
-            - has_size:
-                size: 43K
-                delta: 20K
+          - has_size:
+              size: 43K
+              delta: 20K
     Interaction Matrix Anndata:
       element_tests:
         image:
           asserts:
-            - has_h5_keys:
-                keys: obs/Area,obs/CellID,obs/Eccentricity,obs/Extent,obs/MajorAxisLength,obs/MinorAxisLength,obs/Orientation,obs/Solidity,obs/X_centroid,obs/Y_centroid,obs/imageid,obs/imageid/categories,obs/imageid/codes
+          - has_h5_keys:
+              keys: obs/Area,obs/CellID,obs/Eccentricity,obs/Extent,obs/MajorAxisLength,obs/MinorAxisLength,obs/Orientation,obs/Solidity,obs/X_centroid,obs/Y_centroid,obs/imageid,obs/imageid/categories,obs/imageid/codes
     Squidpy Spatial Scatterplots:
       element_tests:
         image:
           asserts:
-            - has_size:
-                size: 181K
-                delta: 50K
+          - has_size:
+              size: 181K
+              delta: 50K
     Vitessce Dashboard:
       element_tests:
         image:
           asserts:
-            - has_json_property_with_text:
-                property: version
-                text: "1.0.17"
+          - has_json_property_with_text:
+              property: version
+              text: "1.0.17"

--- a/workflows/imaging/tissue-microarray-analysis/tissue-microarray-analysis/tissue-micro-array-analysis-tests.yml
+++ b/workflows/imaging/tissue-microarray-analysis/tissue-microarray-analysis/tissue-micro-array-analysis-tests.yml
@@ -4,10 +4,16 @@
       class: File
       path: test-data/markers.csv
       filetype: csv
+      hashes:
+      - hash_function: SHA-1
+        hash_value: c41762ad4f53996e78d7f4e94a73876c20f6184a
     PhenotypeWorkflow:
       class: File
       path: test-data/phenotypes.csv
       filetype: csv
+      hashes:
+      - hash_function: SHA-1
+        hash_value: c38de0118dfba72da9c9180822eb0c7bffbe7201
     Raw cycle images:
       class: Collection
       collection_type: list
@@ -16,22 +22,37 @@
         identifier: exemplar-001-cycle-04
         location: https://zenodo.org/records/15203994/files/exemplar-001-cycle-04.ome.tiff?download=1
         filetype: ome.tiff
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 2871acf4534e55b73d2387a32a8e28e38a4d9026
       - class: File
         identifier: exemplar-001-cycle-05
         location: https://zenodo.org/records/15203994/files/exemplar-001-cycle-05.ome.tiff?download=1
         filetype: ome.tiff
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 2871acf4534e55b73d2387a32a8e28e38a4d9026
       - class: File
         identifier: exemplar-001-cycle-06
         location: https://zenodo.org/records/15203994/files/exemplar-001-cycle-06.ome.tiff?download=1
         filetype: ome.tiff
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 2871acf4534e55b73d2387a32a8e28e38a4d9026
       - class: File
         identifier: exemplar-001-cycle-07
         location: https://zenodo.org/records/15203994/files/exemplar-001-cycle-07.ome.tiff?download=1
         filetype: ome.tiff
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 2871acf4534e55b73d2387a32a8e28e38a4d9026
       - class: File
         identifier: exemplar-001-cycle-08
         location: https://zenodo.org/records/15203994/files/exemplar-001-cycle-08.ome.tiff?download=1
         filetype: ome.tiff
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 9c53b7098f2cb6ed4dd75206aa68cad44015f22a
   outputs:
     Registered image:
       has_size:

--- a/workflows/metabolomics/gcms-metams/Mass-spectrometry__GCMS-with-metaMS-tests.yml
+++ b/workflows/metabolomics/gcms-metams/Mass-spectrometry__GCMS-with-metaMS-tests.yml
@@ -4,6 +4,9 @@
       class: File
       location: https://zenodo.org/record/3631074/files/sampleMetadata.tsv
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: f53ce5d942cb0a100271d9d30522f7907fe73539
     Mass-spectrometry Dataset Collection:
       class: Collection
       collection_type: list
@@ -12,43 +15,61 @@
         identifier: alg11.mzData
         location: https://zenodo.org/record/3631074/files/alg11.mzData
         filetype: mzdata
+        hashes:
+        - hash_function: SHA-1
+          hash_value: a22551846483b168a0f3e1e5b96dc92546cffea0
       - class: File
         identifier: alg2.mzData
         location: https://zenodo.org/record/3631074/files/alg2.mzData
         filetype: mzdata
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 0518c82e67395a56d5d7682beca956822ce1181e
       - class: File
         identifier: alg3.mzData
         location: https://zenodo.org/record/3631074/files/alg3.mzData
         filetype: mzdata
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 97ba20db9d6fe759390c81ff75b52dbdaf1bcd4b
       - class: File
         identifier: alg7.mzData
         location: https://zenodo.org/record/3631074/files/alg7.mzData
         filetype: mzdata
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 089fd36d4e2c9071a3279e84b741422b374a482d
       - class: File
         identifier: alg8.mzData
         location: https://zenodo.org/record/3631074/files/alg8.mzData
         filetype: mzdata
+        hashes:
+        - hash_function: SHA-1
+          hash_value: bc11441555d93ce2188aae82ae0c40a390426ddf
       - class: File
         identifier: alg9.mzData
         location: https://zenodo.org/record/3631074/files/alg9.mzData
         filetype: mzdata
+        hashes:
+        - hash_function: SHA-1
+          hash_value: dba9cbd014e0e15f4188d7ac18a133b27497953d
   outputs:
     metaMS.runGC dataMatrix:
       path: test-data/metaMS.runGC_dataMatrix.tabular
       lines_diff: 16
     Multivariate variableMetadata:
       asserts:
-          - that: has_n_lines
-            n: 42
-          - that: has_text
-            text: "Unknown 1\tUnknown\t0.0046\t19.499\t-0.17"
-          - that: has_text
-            text: "Unknown 41\tUnknown\t0.0039\t14.857\t-0.08"
+      - that: has_n_lines
+        n: 42
+      - that: has_text
+        text: "Unknown 1\tUnknown\t0.0046\t19.499\t-0.17"
+      - that: has_text
+        text: "Unknown 41\tUnknown\t0.0039\t14.857\t-0.08"
     Multivariate sampleMetadata:
       asserts:
-          - that: has_n_lines
-            n: 7
-          - that: has_text
-            text: "alg11\tFWS_100perNaCl\t-6."
-          - that: has_text
-            text: "alg8\tFWS_5percNaCL\t-0.6"
+      - that: has_n_lines
+        n: 7
+      - that: has_text
+        text: "alg11\tFWS_100perNaCl\t-6."
+      - that: has_text
+        text: "alg8\tFWS_5percNaCL\t-0.6"

--- a/workflows/metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml
+++ b/workflows/metabolomics/lcms-preprocessing/Mass_spectrometry__LC-MS_preprocessing_with_XCMS-tests.yml
@@ -5,6 +5,9 @@
       identifier: sampleMetadata.tsv
       location: https://zenodo.org/records/10130758/files/sampleMetadata_12samp_completed.tsv
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 9cda46eac7cbb29508975327e410f729a4f1681c
     Mass-spectrometry Dataset Collection:
       class: Collection
       collection_type: list
@@ -13,52 +16,88 @@
         identifier: Blanc05.mzML
         location: https://zenodo.org/record/10130758/files/Blanc05.mzML
         filetype: mzml
+        hashes:
+        - hash_function: SHA-1
+          hash_value: e98d5a4cd8849a145a032bdc31c348ad97cb59c3
       - class: File
         identifier: Blanc10.mzML
         location: https://zenodo.org/record/10130758/files/Blanc10.mzML
         filetype: mzml
+        hashes:
+        - hash_function: SHA-1
+          hash_value: f94160cbf0ad978addf22c4095bf71e63399b0ee
       - class: File
         identifier: Blanc16.mzML
         location: https://zenodo.org/record/10130758/files/Blanc16.mzML
         filetype: mzml
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 3b02bc4fea276877085a8eb4c46e3640aa8a3805
       - class: File
         identifier: HU_neg_048.mzML
         location: https://zenodo.org/record/10130758/files/HU_neg_048.mzML
         filetype: mzml
+        hashes:
+        - hash_function: SHA-1
+          hash_value: a15d71219866c685bd1d2a606d53ce1ea0e746af
       - class: File
         identifier: HU_neg_090.mzML
         location: https://zenodo.org/record/10130758/files/HU_neg_090.mzML
         filetype: mzml
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 5f74defa70257351e83d3fd023647efd6968d4c1
       - class: File
         identifier: HU_neg_123.mzML
         location: https://zenodo.org/record/10130758/files/HU_neg_123.mzML
         filetype: mzml
+        hashes:
+        - hash_function: SHA-1
+          hash_value: f2bc442c5def3b43ed2b5d0016a70bf787003eb5
       - class: File
         identifier: HU_neg_157.mzML
         location: https://zenodo.org/record/10130758/files/HU_neg_157.mzML
         filetype: mzml
+        hashes:
+        - hash_function: SHA-1
+          hash_value: dbd3f58bb565fea8e4e6931544714248e406f3a5
       - class: File
         identifier: HU_neg_173.mzML
         location: https://zenodo.org/record/10130758/files/HU_neg_173.mzML
         filetype: mzml
+        hashes:
+        - hash_function: SHA-1
+          hash_value: e4563814b88ee417de98f8dfefa672a09f8360c3
       - class: File
         identifier: HU_neg_192.mzML
         location: https://zenodo.org/record/10130758/files/HU_neg_192.mzML
         filetype: mzml
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 9feab3fc9a93f3f27989273eb8949a31a10793ec
       - class: File
         identifier: QC1_002.mzML
         location: https://zenodo.org/record/10130758/files/QC1_002.mzML
         filetype: mzml
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 0a3b086d6cd18dde58545765dd04510db866d652
       - class: File
         identifier: QC1_008.mzML
         location: https://zenodo.org/record/10130758/files/QC1_008.mzML
         filetype: mzml
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 70f5050107061c5fe9e06395d886472ae71177e8
       - class: File
         identifier: QC1_014.mzML
         location: https://zenodo.org/record/10130758/files/QC1_014.mzML
         filetype: mzml
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 6440a20460d754aa984e75f371259eef0acef1c0
   outputs:
     dataMatrix:
-      file: test-data/xset.merged.groupChromPeaks.adjustRtime.groupChromPeaks.fillpeaks.dataMatrix.tsv 
+      file: test-data/xset.merged.groupChromPeaks.adjustRtime.groupChromPeaks.fillpeaks.dataMatrix.tsv
     CAMERA.annotate variableMetadata:
       file: test-data/xset.merged.groupChromPeaks.adjustRtime.groupChromPeaks.fillChromPeaks.annotate.variableMetadata.tsv

--- a/workflows/metabolomics/mfassignr/mfassignr-tests.yml
+++ b/workflows/metabolomics/mfassignr/mfassignr-tests.yml
@@ -4,6 +4,9 @@
       class: File
       path: https://zenodo.org/records/13768009/files/mfassignr_input.txt
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 3df0ba47c756a4b90f39b73f19471cb595823e23
   outputs:
     SNplot:
       has_size:

--- a/workflows/metabolomics/qcxms-sdf/QCxMS-Spectra-Prediction-from-SDF-tests.yml
+++ b/workflows/metabolomics/qcxms-sdf/QCxMS-Spectra-Prediction-from-SDF-tests.yml
@@ -4,6 +4,9 @@
       class: File
       path: test-data/Input SDF File.sdf
       filetype: sdf
+      hashes:
+      - hash_function: SHA-1
+        hash_value: bf1965b691224555b5c5e182e9791c1758569679
   outputs:
     Predicted Spectra:
       asserts:

--- a/workflows/microbiome/mags-building/MAGs-generation-tests.yml
+++ b/workflows/microbiome/mags-building/MAGs-generation-tests.yml
@@ -8,12 +8,18 @@
         type: paired
         identifier: 50contig_reads
         elements:
-          - class: File
-            identifier: forward
-            location: https://zenodo.org/records/15089018/files/MAG_reads_forward.fastqsanger.gz
-          - class: File
-            identifier: reverse
-            location: https://zenodo.org/records/15089018/files/MAG_reads_reverse.fastqsanger.gz
+        - class: File
+          identifier: forward
+          location: https://zenodo.org/records/15089018/files/MAG_reads_forward.fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 0ee81cd4a9503acea42b8de5f28ad57cdc4b8f38
+        - class: File
+          identifier: reverse
+          location: https://zenodo.org/records/15089018/files/MAG_reads_reverse.fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 2a4ad06c93902e25274ef9c026feb7168f089b57
     Trimmed reads:
       class: Collection
       collection_type: list:paired
@@ -22,14 +28,20 @@
         type: paired
         identifier: 50contig_reads
         elements:
-          - class: File
-            identifier: forward
-            location: https://zenodo.org/records/15089018/files/MAG_reads_forward.fastqsanger.gz
-          - class: File
-            identifier: reverse
-            location: https://zenodo.org/records/15089018/files/MAG_reads_reverse.fastqsanger.gz
+        - class: File
+          identifier: forward
+          location: https://zenodo.org/records/15089018/files/MAG_reads_forward.fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 0ee81cd4a9503acea42b8de5f28ad57cdc4b8f38
+        - class: File
+          identifier: reverse
+          location: https://zenodo.org/records/15089018/files/MAG_reads_reverse.fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 2a4ad06c93902e25274ef9c026feb7168f089b57
     Choose Assembler: MEGAHIT
-    Custom Assemblies: null
+    Custom Assemblies:
     Minimum length of contigs to output: '200'
     Read length (CONCOCT): '100'
     Environment for the built-in model (SemiBin): global
@@ -47,21 +59,20 @@
   outputs:
     Full MultiQC Report:
       asserts:
-        - that: has_text
-          text: "50contig_reads_bin"
-        - that: has_text
-          text: "QUAST"
-        - that: has_text
-          text: "CheckM"
+      - that: has_text
+        text: "50contig_reads_bin"
+      - that: has_text
+        text: "QUAST"
+      - that: has_text
+        text: "CheckM"
     Assembly Report:
       element_tests:
         50contig_reads:
           asserts:
-            - that: has_text
-              text: "All statistics are based on contigs of size"
-            - that: has_size
-              value: 372000
-              delta: 50000
+          - that: has_text
+            text: "All statistics are based on contigs of size"
+          - that: has_size
+            value: 372000
+            delta: 50000
 
-  
-  
+

--- a/workflows/microbiome/pathogen-identification/allele-based-pathogen-identification/Allele-based-Pathogen-Identification-tests.yml
+++ b/workflows/microbiome/pathogen-identification/allele-based-pathogen-identification/Allele-based-Pathogen-Identification-tests.yml
@@ -4,6 +4,9 @@
       class: File
       location: https://zenodo.org/record/12190648/files/reference_genome_of_tested_strain.fasta.gz
       filetype: fasta.gz
+      hashes:
+      - hash_function: SHA-1
+        hash_value: aeb6264c50f216061cac85426da2b7e1af20fec4
     collection_of_preprocessed_samples:
       class: Collection
       collection_type: list
@@ -12,11 +15,17 @@
         identifier: nanopore_preprocessed_collection_of_all_samples_Spike3bBarcode10
         location: https://zenodo.org/record/12190648/files/nanopore_preprocessed_collection_of_all_samples_Spike3bBarcode10.fastq.gz
         filetype: fastqsanger.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: bd6e7a3eb3c8e8fbb2e0f0508fab39dd09f289e9
       - class: File
         identifier: nanopore_preprocessed_collection_of_all_samples_Spike3bBarcode12
         location: https://zenodo.org/record/12190648/files/nanopore_preprocessed_collection_of_all_samples_Spike3bBarcode12.fastq.gz
         filetype: fastqsanger.gz
-    samples_profile: null
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 225b4650e7358c2b76cef6067884742d1bec374e
+    samples_profile:
   outputs:
     mapping_mean_depth_per_sample:
       path: test-data/mapping_mean_depth_per_sample.tabular

--- a/workflows/microbiome/pathogen-identification/gene-based-pathogen-identification/Gene-based-Pathogen-Identification-tests.yml
+++ b/workflows/microbiome/pathogen-identification/gene-based-pathogen-identification/Gene-based-Pathogen-Identification-tests.yml
@@ -8,10 +8,16 @@
         identifier: nanopore_preprocessed_collection_of_all_samples_Spike3bBarcode10
         location: https://zenodo.org/record/12190648/files/nanopore_preprocessed_collection_of_all_samples_Spike3bBarcode10.fastq.gz
         filetype: fastqsanger.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: bd6e7a3eb3c8e8fbb2e0f0508fab39dd09f289e9
       - class: File
         identifier: nanopore_preprocessed_collection_of_all_samples_Spike3bBarcode12
         location: https://zenodo.org/record/12190648/files/nanopore_preprocessed_collection_of_all_samples_Spike3bBarcode12.fastq.gz
         filetype: fastqsanger.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 225b4650e7358c2b76cef6067884742d1bec374e
   outputs:
     extracted_samples_IDs:
       path: test-data/extracted_samples_IDs.txt

--- a/workflows/microbiome/pathogen-identification/nanopore-pre-processing/Nanopore-Pre-Processing-tests.yml
+++ b/workflows/microbiome/pathogen-identification/nanopore-pre-processing/Nanopore-Pre-Processing-tests.yml
@@ -8,10 +8,16 @@
         identifier: collection_of_all_samples_Spike3bBarcode10
         location: https://zenodo.org/record/12190648/files/collection_of_all_samples_Spike3bBarcode10.fastq.gz
         filetype: fastqsanger.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 8596672e0eeb5b32bc29c16977cffa69916938f9
       - class: File
         identifier: collection_of_all_samples_Spike3bBarcode12
         location: https://zenodo.org/record/12190648/files/collection_of_all_samples_Spike3bBarcode12.fastq.gz
         filetype: fastqsanger.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: e9e4213145438bf23b1a43dd78742da2bbd52771
     samples_profile: map-pb
     host_reference_genome: apiMel3
   outputs:
@@ -20,6 +26,6 @@
       element_tests:
         collection_of_all_samples_Spike3bBarcode12:
           asserts:
-            has_n_lines: 
+            has_n_lines:
               n: 24
           path: test-data/nanoplot_qc_on_reads_after_preprocessing_nanostats_collection_of_all_samples_Spike3bBarcode12.tabular

--- a/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation-tests.yml
+++ b/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation-tests.yml
@@ -4,18 +4,30 @@
       class: File
       path: test-data/removed_hosts_percentage_tabular.tabular
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: f5bdde2c09581c0ec26e8ad607455f7c7809ef54
     mapping_mean_depth_per_sample:
       class: File
       path: test-data/mapping_mean_depth_per_sample.tabular
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 37589c3035f25664c117fbad0b14461577fbba7a
     mapping_coverage_percentage_per_sample:
       class: File
       path: test-data/mapping_coverage_percentage_per_sample.tabular
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 27b1d9cc84d9351c37ddf5482c599d20b70bd101
     number_of_variants_per_sample:
       class: File
       path: test-data/number_of_variants_per_sample.tabular
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: f283641459f70d99d1ae4126fbe14685b462ab7b
     amr_identified_by_ncbi:
       class: Collection
       collection_type: list
@@ -23,9 +35,15 @@
       - class: File
         identifier: collection_of_all_samples_Spike3bBarcode10.fastq.gz
         path: test-data/amr_identified_by_ncbi_collection_of_all_samples_Spike3bBarcode10.fastq.gz.tabular
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 8457f2ecd441a94c29e4d665f3be8839b16725a8
       - class: File
         identifier: collection_of_all_samples_Spike3bBarcode12.fastq.gz
         path: test-data/amr_identified_by_ncbi_collection_of_all_samples_Spike3bBarcode12.fastq.gz.tabular
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 2837b90eda64659bb9290b75d7ed88f4fd301085
     vfs_of_genes_identified_by_vfdb:
       class: Collection
       collection_type: list
@@ -33,9 +51,15 @@
       - class: File
         identifier: collection_of_all_samples_Spike3bBarcode10.fastq.gz
         path: test-data/vfs_of_genes_identified_by_vfdb_collection_of_all_samples_Spike3bBarcode10.fastq.gz.tabular
+        hashes:
+        - hash_function: SHA-1
+          hash_value: f06964d8f1789332f0dcda23c33c067eb7db02d7
       - class: File
         identifier: collection_of_all_samples_Spike3bBarcode12.fastq.gz
         path: test-data/vfs_of_genes_identified_by_vfdb_collection_of_all_samples_Spike3bBarcode12.fastq.gz.tabular
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 9aafe49ae6f007d6ba93a0f5af2db679503d73af
     amrs:
       class: Collection
       collection_type: list
@@ -43,9 +67,15 @@
       - class: File
         identifier: split_file_000000.txt
         path: test-data/amrs_split_file_000000.txt.tabular
+        hashes:
+        - hash_function: SHA-1
+          hash_value: cc391252df19f7a178eb20c79dd96d6af16377b2
       - class: File
         identifier: split_file_000001.txt
         path: test-data/amrs_split_file_000001.txt.tabular
+        hashes:
+        - hash_function: SHA-1
+          hash_value: cf1e7fe6da00b5e130b9ded67354be38e741ca3b
     vfs:
       class: Collection
       collection_type: list
@@ -53,9 +83,15 @@
       - class: File
         identifier: split_file_000000.txt
         path: test-data/vfs_split_file_000000.txt.tabular
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 6c54ef48c847aa243986e6793ea3b2f6b45b414b
       - class: File
         identifier: split_file_000001.txt
         path: test-data/vfs_split_file_000001.txt.tabular
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 219dadc2efbeb7e0e1d8fa73858bed12f1ac3d1a
     contigs:
       class: Collection
       collection_type: list
@@ -63,10 +99,16 @@
       - class: File
         identifier: split_file_000000.txt
         path: test-data/contigs_split_file_000000.txt.fasta
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 001d3d71487ead2b4f385bd932f159aaed3cd806
       - class: File
         identifier: split_file_000001.txt
         path: test-data/contigs_split_file_000001.txt.fasta
-    metadata: null
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 918299a8e0bb26fc024b8715b91460638cfc68c8
+    metadata:
   outputs:
     adjusted_abricate_vfs_tabular_part1:
       attributes: {}

--- a/workflows/microbiome/pathogen-identification/taxonomy-profiling-and-visualization-with-krona/Taxonomy-Profiling-and-Visualization-with-Krona-tests.yml
+++ b/workflows/microbiome/pathogen-identification/taxonomy-profiling-and-visualization-with-krona/Taxonomy-Profiling-and-Visualization-with-Krona-tests.yml
@@ -8,10 +8,16 @@
         identifier: nanopore_preprocessed_collection_of_all_samples_Spike3bBarcode10
         location: https://zenodo.org/record/12190648/files/nanopore_preprocessed_collection_of_all_samples_Spike3bBarcode10.fastq.gz
         filetype: fastqsanger.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: bd6e7a3eb3c8e8fbb2e0f0508fab39dd09f289e9
       - class: File
         identifier: nanopore_preprocessed_collection_of_all_samples_Spike3bBarcode12
         location: https://zenodo.org/record/12190648/files/nanopore_preprocessed_collection_of_all_samples_Spike3bBarcode12.fastq.gz
-        filetype: fastqsanger.gz        
+        filetype: fastqsanger.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 225b4650e7358c2b76cef6067884742d1bec374e
     kraken_database: k2_minusb_20210517
   outputs:
     converted_kraken_report:

--- a/workflows/proteomics/clinicalmp/clinicalmp-database-generation/iwc-clinicalmp-database-generation-tests.yml
+++ b/workflows/proteomics/clinicalmp/clinicalmp-database-generation/iwc-clinicalmp-database-generation-tests.yml
@@ -4,44 +4,65 @@
       class: File
       location: https://zenodo.org/records/14181725/files/HUMAN-SwissProt-Protein-Database.fasta?download=1
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 79c3abb625d59ad68874ad09b66b25c4131b187f
     Species UniProt Protein Database:
       class: File
       location: https://zenodo.org/records/14181725/files/Species_UniProt_FASTA.fasta?download=1
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: da39a3ee5e6b4b0d3255bfef95601890afd80709
     Contaminants cRAP Protein Database:
       class: File
       location: https://zenodo.org/records/14181725/files/Contaminants(cRAP)-Protein-Database.fasta?download=1
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: be5d772342f1e8d6f79cfe07ffcdfaf7bae85654
     Tandem Mass Spectrometry (MS/MS) datasets:
       class: Collection
       collection_type: list
       elements:
-        - class: File
-          identifier: PTRC_Skubitz_Plex2_F15_9Aug19_Rage_Rep-19-06-08.mgf
-          location: https://zenodo.org/records/14181725/files/PTRC_Skubitz_Plex2_F15_9Aug19_Rage_Rep-19-06-08.mgf?download=1
-        - class: File
-          identifier: PTRC_Skubitz_Plex2_F13_9Aug19_Rage_Rep-19-06-08.mgf
-          location: https://zenodo.org/records/14181725/files/PTRC_Skubitz_Plex2_F13_9Aug19_Rage_Rep-19-06-08.mgf?download=1
-        - class: File
-          identifier: PTRC_Skubitz_Plex2_F11_9Aug19_Rage_Rep-19-06-08.mgf
-          location: https://zenodo.org/records/14181725/files/PTRC_Skubitz_Plex2_F11_9Aug19_Rage_Rep-19-06-08.mgf?download=1
-        - class: File
-          identifier: PTRC_Skubitz_Plex2_F10_9Aug19_Rage_Rep-19-06-08.mgf
-          location: https://zenodo.org/records/14181725/files/PTRC_Skubitz_Plex2_F10_9Aug19_Rage_Rep-19-06-08.mgf?download=1
+      - class: File
+        identifier: PTRC_Skubitz_Plex2_F15_9Aug19_Rage_Rep-19-06-08.mgf
+        location: https://zenodo.org/records/14181725/files/PTRC_Skubitz_Plex2_F15_9Aug19_Rage_Rep-19-06-08.mgf?download=1
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 74b0db7ef696b05fa115190ffd0c854b8c420aca
+      - class: File
+        identifier: PTRC_Skubitz_Plex2_F13_9Aug19_Rage_Rep-19-06-08.mgf
+        location: https://zenodo.org/records/14181725/files/PTRC_Skubitz_Plex2_F13_9Aug19_Rage_Rep-19-06-08.mgf?download=1
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 6320f5feb043422ddff8285f0496e4d9a016287c
+      - class: File
+        identifier: PTRC_Skubitz_Plex2_F11_9Aug19_Rage_Rep-19-06-08.mgf
+        location: https://zenodo.org/records/14181725/files/PTRC_Skubitz_Plex2_F11_9Aug19_Rage_Rep-19-06-08.mgf?download=1
+        hashes:
+        - hash_function: SHA-1
+          hash_value: da39a3ee5e6b4b0d3255bfef95601890afd80709
+      - class: File
+        identifier: PTRC_Skubitz_Plex2_F10_9Aug19_Rage_Rep-19-06-08.mgf
+        location: https://zenodo.org/records/14181725/files/PTRC_Skubitz_Plex2_F10_9Aug19_Rage_Rep-19-06-08.mgf?download=1
+        hashes:
+        - hash_function: SHA-1
+          hash_value: da39a3ee5e6b4b0d3255bfef95601890afd80709
   outputs:
     Human UniProt Microbial Proteins cRAP for MetaNovo:
       asserts:
-        - that: has_text
-          text: ">sp|"
+      - that: has_text
+        text: ">sp|"
     Metanovo Compact database:
       asserts:
-        - that: has_text
-          text: ">sp|"
+      - that: has_text
+        text: ">sp|"
     Metanovo Compact CSV database:
       asserts:
-        - that: has_text
-          text: "index"
+      - that: has_text
+        text: "index"
     Human UniProt Microbial Proteins from MetaNovo cRAP:
       asserts:
-        - that: has_text
-          text: ">sp|"
+      - that: has_text
+        text: ">sp|"

--- a/workflows/proteomics/clinicalmp/clinicalmp-discovery/iwc-clinicalmp-discovery-workflow-tests.yml
+++ b/workflows/proteomics/clinicalmp/clinicalmp-discovery/iwc-clinicalmp-discovery-workflow-tests.yml
@@ -4,10 +4,16 @@
       class: File
       location: https://zenodo.org/records/10720030/files/Human_UniProt_Microbial_Proteins_(from_MetaNovo)_and_cRAP.fasta
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 72bc60bb5733ba38866f3f4cfc5583ed823e6446
     Experimental Design Discovery MaxQuant:
       class: File
       path: test-data/Experimental Design Discovery MaxQuant.tabular
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 099a2b3dadf1423df07a5452a2573ed5cafe4dd6
     Tandem Mass Spectrometry MSMS files:
       class: Collection
       collection_type: list
@@ -15,10 +21,13 @@
       - class: File
         identifier: PTRC_Skubitz_Plex2_F10_9Aug19_Rage_Rep-19-06-08.raw
         location: https://zenodo.org/records/14182981/files/PTRC_Skubitz_Plex2_F10_9Aug19_Rage_Rep-19-06-08.raw
+        hashes:
+        - hash_function: SHA-1
+          hash_value: da39a3ee5e6b4b0d3255bfef95601890afd80709
   outputs:
     SGPS MQ Peptides:
       asserts:
-        - has_n_columns:
-            n: 1
-        - has_text: 
-            text: "AAFPNVTAMNITTNNGK"
+      - has_n_columns:
+          n: 1
+      - has_text:
+          text: "AAFPNVTAMNITTNNGK"

--- a/workflows/proteomics/clinicalmp/clinicalmp-quantitation/iwc-clinicalmp-quantitation-tests.yml
+++ b/workflows/proteomics/clinicalmp/clinicalmp-quantitation/iwc-clinicalmp-quantitation-tests.yml
@@ -4,10 +4,16 @@
       class: File
       location: https://zenodo.org/records/10720030/files/Quantitation_Database_for_MaxQuant.fasta
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 9e9fb4fe077313f4cf5e50c3d9d0710f76df695d
     Experimental-Design Discovery MaxQuant:
       class: File
       location: https://zenodo.org/records/10720030/files/Experimental-Design_Discovery_MaxQuant.tabular
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: d7fd3857af8d391031261a385b76ba90be4084b0
     Input Raw-files:
       class: Collection
       collection_type: list
@@ -15,15 +21,27 @@
       - class: File
         identifier: PTRC_Skubitz_Plex2_F15_9Aug19_Rage_Rep-19-06-08.raw
         location: https://zenodo.org/records/10720030/files/PTRC_Skubitz_Plex2_F15_9Aug19_Rage_Rep-19-06-08.raw
+        hashes:
+        - hash_function: SHA-1
+          hash_value: da39a3ee5e6b4b0d3255bfef95601890afd80709
       - class: File
         identifier: PTRC_Skubitz_Plex2_F13_9Aug19_Rage_Rep-19-06-08.raw
         location: https://zenodo.org/records/10720030/files/PTRC_Skubitz_Plex2_F13_9Aug19_Rage_Rep-19-06-08.raw
+        hashes:
+        - hash_function: SHA-1
+          hash_value: da39a3ee5e6b4b0d3255bfef95601890afd80709
       - class: File
         identifier: PTRC_Skubitz_Plex2_F11_9Aug19_Rage_Rep-19-06-08.raw
         location: https://zenodo.org/records/10720030/files/PTRC_Skubitz_Plex2_F11_9Aug19_Rage_Rep-19-06-08.raw
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 1a43f2d47279794cd30bf4adb052bf824583ea83
       - class: File
         identifier: PTRC_Skubitz_Plex2_F10_9Aug19_Rage_Rep-19-06-08.raw
         location: https://zenodo.org/records/10720030/files/PTRC_Skubitz_Plex2_F10_9Aug19_Rage_Rep-19-06-08.raw
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 1d4eec13f0efd6d13d9cc9c4f3ee8c1103d6f5b8
   outputs:
     Quantified-Proteins:
       path: test-data/Quantified-Proteins.tabular

--- a/workflows/proteomics/clinicalmp/clinicalmp-verification/clinicalmp-verification-tests.yml
+++ b/workflows/proteomics/clinicalmp/clinicalmp-verification/clinicalmp-verification-tests.yml
@@ -4,14 +4,23 @@
       class: File
       path: test-data/SGPS_peptide-report.tabular
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: aa0ca3a35a0e82fb4c235fd13fea948691e9c889
     Distinct Peptides for PepQuery:
       class: File
       path: test-data/Distinct_Peptides_for_PepQuery.tabular
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 09e302f52683504e29616fbc1425dff7b65223c0
     MaxQuant peptide report:
       class: File
       path: test-data/MaxQuant-peptide-report.tabular
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 889cfa767fc9dba084b1bb17b325562d55895ae9
     Tandem Mass Spectrometry (MS/MS) datasets:
       class: Collection
       collection_type: list
@@ -19,25 +28,37 @@
       - class: File
         identifier: PTRC_Skubitz_Plex2_F15_9Aug19_Rage_Rep-19-06-08.mgf
         location: https://zenodo.org/records/14181725/files/PTRC_Skubitz_Plex2_F15_9Aug19_Rage_Rep-19-06-08.mgf
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 74b0db7ef696b05fa115190ffd0c854b8c420aca
       - class: File
         identifier: PTRC_Skubitz_Plex2_F13_9Aug19_Rage_Rep-19-06-08.mgf
         location: https://zenodo.org/records/14181725/files/PTRC_Skubitz_Plex2_F13_9Aug19_Rage_Rep-19-06-08.mgf
+        hashes:
+        - hash_function: SHA-1
+          hash_value: da39a3ee5e6b4b0d3255bfef95601890afd80709
       - class: File
         identifier: PTRC_Skubitz_Plex2_F11_9Aug19_Rage_Rep-19-06-08.mgf
         location: https://zenodo.org/records/14181725/files/PTRC_Skubitz_Plex2_F11_9Aug19_Rage_Rep-19-06-08.mgf
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 63d72e72e02c7c10fbb3248bfeed1d77c2ffc897
       - class: File
         identifier: PTRC_Skubitz_Plex2_F10_9Aug19_Rage_Rep-19-06-08.mgf
         location: https://zenodo.org/records/14181725/files/PTRC_Skubitz_Plex2_F10_9Aug19_Rage_Rep-19-06-08.mgf
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 7d8d9cfaf29b048929ff2f1f14b0ea474cae02c0
   outputs:
     Human UniProt+Isoforms FASTA:
       asserts:
-        has_text: 
+        has_text:
           text: ">sp"
     cRAP:
       path: test-data/cRAP.fasta
     Human UniProt+Isoforms+cRAP FASTA:
       asserts:
-        has_text: 
+        has_text:
           text: ">sp"
     Peptide and Protein from Peptide Reports:
       path: test-data/Peptide_and_Protein_from_Peptide_Reports.tabular
@@ -45,5 +66,5 @@
       path: test-data/Uniprot-ID_from_verified_Peptides.tabular
     Quantitation Database for MaxQuant:
       asserts:
-        has_text: 
+        has_text:
           text: ">tr"

--- a/workflows/proteomics/openms-metaprosip/metaprosip-tests.yml
+++ b/workflows/proteomics/openms-metaprosip/metaprosip-tests.yml
@@ -4,6 +4,9 @@
       class: File
       location: https://abibuilder.cs.uni-tuebingen.de/archive/openms/galaxy-testdata/metaprosip/Zeitz_1and2_454AllContigs_HEX.fasta
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 2aa683a162aef61679d46e14508ca0cecf16e24a
     Centroided LC-MS datasets:
       class: Collection
       collection_type: list
@@ -12,6 +15,9 @@
         identifier: Zeitz_SIP_13-II_020_picked.mzML
         location: https://abibuilder.cs.uni-tuebingen.de/archive/openms/galaxy-testdata/metaprosip/Zeitz_SIP_13-II_020_picked.mzML
         filetype: mzml
+        hashes:
+        - hash_function: SHA-1
+          hash_value: cda64713a3466f7bf74af2a42da97351aaff691b
     Precursor monoisotopic mass tolerance (ppm): 10.0
     Fixed modifications: Carbamidomethyl (C)
     Variable modifications: Oxidation (M)
@@ -36,4 +42,4 @@
           - that: has_text
             text: Group 1
           - that: has_text
-            text: LYSFHTLHQTYMK 
+            text: LYSFHTLHQTYMK

--- a/workflows/repeatmasking/Repeat-masking-with-RepeatModeler-and-RepeatMasker-tests.yml
+++ b/workflows/repeatmasking/Repeat-masking-with-RepeatModeler-and-RepeatMasker-tests.yml
@@ -5,6 +5,9 @@
       location: https://zenodo.org/record/8116008/files/sequence.fasta?download=1
       filetype: fasta
 
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 2ac5ce0eadf871798a5e8a978a3ddd42e341d15e
   outputs:
     RepeatModeler consensus sequences:
       path: test-data/repeatmodeler_output_sequences.fasta

--- a/workflows/repeatmasking/RepeatMasking-Workflow-tests.yml
+++ b/workflows/repeatmasking/RepeatMasking-Workflow-tests.yml
@@ -5,6 +5,9 @@
       location: https://zenodo.org/record/8364146/files/eco.fasta?download=1
       filetype: fasta
 
+      hashes:
+      - hash_function: SHA-1
+        hash_value: c961faa16abf19e76db9899646e8a9bde1cd4293
   outputs:
     RepeatModeler consensus sequences:
       location: https://zenodo.org/record/8364146/files/repeatmodeler_output_sequences.fasta?download=1

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation-tests.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-consensus-from-variation/consensus-from-variation-tests.yml
@@ -3,20 +3,29 @@
     Reference genome:
       class: File
       location: 'https://zenodo.org/record/4555735/files/NC_045512.2_reference.fasta?download=1'
+      hashes:
+      - hash_function: SHA-1
+        hash_value: db3759c2e1d9ce8827ba4aa1749e759313591240
     aligned reads data for depth calculation:
       class: Collection
       collection_type: 'list'
       elements:
-        - identifier: SRR11578257
-          class: File
-          path: test-data/aligned_reads_for_coverage.bam
+      - identifier: SRR11578257
+        class: File
+        path: test-data/aligned_reads_for_coverage.bam
+        hashes:
+        - hash_function: SHA-1
+          hash_value: fb632fc771f69772a4415fdf0ed16fdcd580882b
     Variant calls:
       class: Collection
       collection_type: 'list'
       elements:
-        - identifier: SRR11578257
-          class: File
-          path: test-data/final_snpeff_annotated_variants.vcf
+      - identifier: SRR11578257
+        class: File
+        path: test-data/final_snpeff_annotated_variants.vcf
+        hashes:
+        - hash_function: SHA-1
+          hash_value: edd0f9478e437c727acaea19407fe087e5adbdff
   outputs:
     multisample_consensus_fasta:
       file: test-data/masked_consensus.fa

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation-tests.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation-tests.yml
@@ -3,17 +3,26 @@
     NC_045512.2 FASTA sequence of SARS-CoV-2:
       class: File
       location: 'https://zenodo.org/record/4555735/files/NC_045512.2_reference.fasta?download=1'
+      hashes:
+      - hash_function: SHA-1
+        hash_value: db3759c2e1d9ce8827ba4aa1749e759313591240
     Primer binding sites info in BED format:
       class: File
       location: 'https://zenodo.org/record/4555735/files/ARTIC_nCoV-2019_v3.bed?download=1'
+      hashes:
+      - hash_function: SHA-1
+        hash_value: d0864546dca524fc5cd057f48ee7f5671faba83a
     ONT-sequenced reads:
       class: Collection
       collection_type: 'list'
       elements:
-        - identifier: SRR12447380
-          class: File
-          filetype: fastqsanger.gz
-          location: "https://www.be-md.ncbi.nlm.nih.gov/Traces/sra-reads-be/fastq?acc=SRR12447380"
+      - identifier: SRR12447380
+        class: File
+        filetype: fastqsanger.gz
+        location: "https://www.be-md.ncbi.nlm.nih.gov/Traces/sra-reads-be/fastq?acc=SRR12447380"
+        hashes:
+        - hash_function: SHA-1
+          hash_value: e26a9711e1d1201ed49cd3e98bbc0837f4c90533
   outputs:
     annotated_softfiltered_variants:
       attributes: {}

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-ivar-analysis/pe-wgs-ivar-analysis-test.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-ivar-analysis/pe-wgs-ivar-analysis-test.yml
@@ -4,31 +4,43 @@
       class: File
       location: 'https://zenodo.org/record/4944064/files/MN908947_3_Wuhan-Hu-1.fasta'
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 3c0b3d1b80897633ba94aec9d0440f197506a477
     Primer BED:
       class: File
       location: 'https://zenodo.org/record/4944064/files/SARS-CoV-2-ARTICv3.bed'
       filetype: bed
+      hashes:
+      - hash_function: SHA-1
+        hash_value: d0864546dca524fc5cd057f48ee7f5671faba83a
     Paired read collection for samples:
       class: Collection
       collection_type: 'list:paired'
       elements:
-        - class: Collection
-          type: paired
-          identifier: ERR4970105
-          elements:
-          - identifier: forward
-            class: File
-            location: "https://zenodo.org/record/4944064/files/ERR4970105_1.fastq.gz"
-            filetype: fastqsanger.gz
-          - identifier: reverse
-            class: File
-            location: "https://zenodo.org/record/4944064/files/ERR4970105_2.fastq.gz"
-            filetype: fastqsanger.gz
+      - class: Collection
+        type: paired
+        identifier: ERR4970105
+        elements:
+        - identifier: forward
+          class: File
+          location: "https://zenodo.org/record/4944064/files/ERR4970105_1.fastq.gz"
+          filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 941f7c228f42cb07423252ae86dbeffd016bb68f
+        - identifier: reverse
+          class: File
+          location: "https://zenodo.org/record/4944064/files/ERR4970105_2.fastq.gz"
+          filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 52890d3130f8e2bdc83bd6f9186f433f438bbd52
   outputs:
     all_samples_nextclade:
       asserts:
         has_text:
-          text: '20B	1'
+          text: "20B\t1"
         has_text_matching:
           expression: "seqName\tclade\tNextclade_pango\tpartiallyAliased\tclade_nextstrain\tclade_who\tclade_display\tqc.overallScore\tqc.overallStatus\ttotalSubstitutions\ttotalDeletions\ttotalInsertions\ttotalFrameShifts\ttotalAminoacidSubstitutions\ttotalAminoacidDeletions\ttotalAminoacidInsertions\ttotalMissing\ttotalNonACGTNs\ttotalPcrPrimerChanges\tsubstitutions\tdeletions\tinsertions\tprivateNucMutations.reversionSubstitutions\tprivateNucMutations.labeledSubstitutions\tprivateNucMutations.unlabeledSubstitutions\tprivateNucMutations.totalReversionSubstitutions\tprivateNucMutations.totalLabeledSubstitutions\tprivateNucMutations.totalUnlabeledSubstitutions\tprivateNucMutations.totalPrivateSubstitutions\tframeShifts\taaSubstitutions\taaDeletions\taaInsertions\tmissing\tnonACGTNs\tpcrPrimerChanges\talignmentScore\talignmentStart\talignmentEnd\tcoverage\tqc.missingData.missingDataThreshold\tqc.missingData.score\tqc.missingData.status\tqc.missingData.totalMissing\tqc.mixedSites.mixedSitesThreshold\tqc.mixedSites.score\tqc.mixedSites.status\tqc.mixedSites.totalMixedSites\tqc.privateMutations.cutoff\tqc.privateMutations.excess\tqc.privateMutations.score\tqc.privateMutations.status\tqc.privateMutations.total\tqc.snpClusters.clusteredSNPs\tqc.snpClusters.score\tqc.snpClusters.status\tqc.snpClusters.totalSNPs\tqc.frameShifts.frameShifts\tqc.frameShifts.totalFrameShifts\tqc.frameShifts.frameShiftsIgnored\tqc.frameShifts.totalFrameShiftsIgnored\tqc.frameShifts.score\tqc.frameShifts.status\tqc.stopCodons.stopCodons\tqc.stopCodons.totalStopCodons\tqc.stopCodons.score\tqc.stopCodons.status\tisReverseComplement\tfailedGenes\twarnings\terrors"
     all_samples_pangolin:

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/pe-wgs-variation-tests.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-wgs-variant-calling/pe-wgs-variation-tests.yml
@@ -3,20 +3,29 @@
     NC_045512.2 FASTA sequence of SARS-CoV-2:
       class: File
       location: 'https://zenodo.org/record/4555735/files/NC_045512.2_reference.fasta?download=1'
+      hashes:
+      - hash_function: SHA-1
+        hash_value: db3759c2e1d9ce8827ba4aa1749e759313591240
     Paired Collection:
       class: Collection
       collection_type: 'list:paired'
       elements:
-        - class: Collection
-          type: paired
-          identifier: SRR11578257
-          elements:
-          - identifier: forward
-            class: File
-            location: "https://zenodo.org/records/10174466/files/SRR11578257_R1.fastq.gz?download=1"
-          - identifier: reverse
-            class: File
-            location: "https://zenodo.org/records/10174466/files/SRR11578257_R2.fastq.gz?download=1"
+      - class: Collection
+        type: paired
+        identifier: SRR11578257
+        elements:
+        - identifier: forward
+          class: File
+          location: "https://zenodo.org/records/10174466/files/SRR11578257_R1.fastq.gz?download=1"
+          hashes:
+          - hash_function: SHA-1
+            hash_value: db2f908fbbb6c4920ee0de73265acdeb92c9895f
+        - identifier: reverse
+          class: File
+          location: "https://zenodo.org/records/10174466/files/SRR11578257_R2.fastq.gz?download=1"
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 4f754a7023bcc3cb1a240d3fb03532338c5c1107
   outputs:
     annotated_variants:
       attributes: {}

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting-tests.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-variation-reporting/variation-reporting-tests.yml
@@ -3,22 +3,37 @@
     gene products translations:
       class: File
       location: 'https://zenodo.org/record/4555735/files/NC_045512.2_feature_mapping.tsv?download=1'
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 5ae9f8f1b7bc969827ad4c5ce357ef45a904e132
     Variation data to report:
       class: Collection
       collection_type: 'list'
       elements:
-        - identifier: artic
-          class: File
-          path: test-data/ont-artic.vcf
-        - identifier: illumina-wgs-se
-          class: File
-          path: test-data/se-illumina-wgs.vcf
-        - identifier: illumina-wgs-pe
-          class: File
-          path: test-data/pe-illumina-wgs.vcf
-        - identifier: pe-artic
-          class: File
-          path: test-data/pe-artic.vcf
+      - identifier: artic
+        class: File
+        path: test-data/ont-artic.vcf
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 559d78f2ac9dd2d2c138da503a287fa459183ad3
+      - identifier: illumina-wgs-se
+        class: File
+        path: test-data/se-illumina-wgs.vcf
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 7f0637fcb95af2954fdac2533df299746afae0b3
+      - identifier: illumina-wgs-pe
+        class: File
+        path: test-data/pe-illumina-wgs.vcf
+        hashes:
+        - hash_function: SHA-1
+          hash_value: edd0f9478e437c727acaea19407fe087e5adbdff
+      - identifier: pe-artic
+        class: File
+        path: test-data/pe-artic.vcf
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 091e20087dba5179c10a2453b0666084876d9876
   outputs:
     by_variant_report:
       file: test-data/by_variant_report.tsv

--- a/workflows/scRNAseq/baredsc/baredSC-1d-logNorm-tests.yml
+++ b/workflows/scRNAseq/baredsc/baredSC-1d-logNorm-tests.yml
@@ -4,6 +4,9 @@
       class: File
       path: test-data/nih3t3_generated_2d_2.txt
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: fb6d76850b1226a65b5ce292f4562e86eaf5990e
     Gene name: 0.5_0_0_0.5_x
     Maximum value in logNorm: '2.5'
     Maximum number of Gaussians to study: '4'
@@ -142,12 +145,12 @@
               expression: "6.[0-9]*e-01"
         posterior_andco:
           asserts:
-            has_size: 
+            has_size:
               value: 197980
               delta: 10000
         posterior_individuals:
           asserts:
-            has_size: 
+            has_size:
               value: 105262
               delta: 10000
         posterior_per_cell:
@@ -158,7 +161,7 @@
               expression: "mu\tsd"
         with_posterior:
           asserts:
-            has_size: 
+            has_size:
               value: 234303
               delta: 20000
     combined_pdf:
@@ -171,4 +174,3 @@
       path: test-data/combined_1d_plot.png
       compare: sim_size
       delta_frac: 0.1
-  

--- a/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml
+++ b/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml
@@ -12,10 +12,16 @@
           class: File
           location: https://zenodo.org/records/10412836/files/GEX_R1.fastqsanger.gz
           filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: c23fb98763b959fbf4ac51fc5ef6e690e378ef0d
         - identifier: reverse
           class: File
           location: https://zenodo.org/records/10412836/files/GEX_R2.fastqsanger.gz
           filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: bba127e369535d226290a74858efafd7f359168e
     reference genome: dm6 # To test on usegalaxy.eu dm6full
     Barcode Size is same size of the Read: false
     gtf:
@@ -23,10 +29,16 @@
       location: https://zenodo.org/record/6457007/files/Drosophila_melanogaster.BDGP6.32.109_UCSC.gtf.gz
       decompress: true
       filetype: gtf
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 3cbdd2f0eed28bd10af66cb83aa3f6d688779d51
     cellranger_barcodes_3M-february-2018.txt:
       class: File
       path: test-data/all_cell_barcodes_both_versions.txt
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: f4bc47a31f6aba7aa45c8ebddad1d5ea51fb4797
     fastq PE collection CMO:
       class: Collection
       collection_type: list:paired
@@ -39,10 +51,16 @@
           class: File
           location: https://zenodo.org/records/10412836/files/CMO_R1.fastqsanger.gz
           filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 277fd1637b8615f70081b72427b6920713c1aa14
         - identifier: reverse
           class: File
           location: https://zenodo.org/records/10412836/files/CMO_R2.fastqsanger.gz
           filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: f65316ed442c2d13e4ba5feace4adebcbc758420
     sample name and CMO sequence collection:
       class: Collection
       collection_type: list
@@ -51,6 +69,9 @@
         identifier: subsample
         location: https://zenodo.org/records/10229382/files/CMO.csv
         filetype: csv
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 03a74c7c22810d354c4030fd0e4991cf9578f592
     Number of expected cells: 500
   outputs:
     MultiQC_STARsolo:
@@ -59,7 +80,7 @@
           expression: |-
             <span class="val">33.[0-9]<span class=['"]mqc_small_space['"]>
     Seurat input for gene expression (filtered):
-      attributes: { collection_type: list:list }
+      attributes: {collection_type: list:list}
       element_tests:
         subsample:
           elements:
@@ -74,22 +95,22 @@
             genes:
               asserts:
                 has_line:
-                  line: "FBgn0250732	gfzf"
+                  line: "FBgn0250732\tgfzf"
     CITE-seq-Count report:
-      attributes: { collection_type: list }
+      attributes: {collection_type: list}
       element_tests:
         subsample:
           asserts:
-            - that: "has_line"
-              line: "CITE-seq-Count Version: 1.4.4"
-            - that: "has_line"
-              line: "Reads processed: 116993"
-            - that: "has_line"
-              line: "Percentage mapped: 99"
-            - that: "has_line"
-              line: "Percentage unmapped: 1"
+          - that: "has_line"
+            line: "CITE-seq-Count Version: 1.4.4"
+          - that: "has_line"
+            line: "Reads processed: 116993"
+          - that: "has_line"
+            line: "Percentage mapped: 99"
+          - that: "has_line"
+            line: "Percentage unmapped: 1"
     Seurat input for CMO (UMI):
-      attributes: { collection_type: list:list }
+      attributes: {collection_type: list:list}
       element_tests:
         subsample:
           elements:

--- a/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-v3-tests.yml
+++ b/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-v3-tests.yml
@@ -12,10 +12,16 @@
           class: File
           location: https://zenodo.org/records/10412836/files/GEX_R1.fastqsanger.gz
           filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: c23fb98763b959fbf4ac51fc5ef6e690e378ef0d
         - identifier: reverse
           class: File
           location: https://zenodo.org/records/10412836/files/GEX_R2.fastqsanger.gz
           filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: bba127e369535d226290a74858efafd7f359168e
     reference genome: dm6
     Barcode Size is same size of the Read: false
     gtf:
@@ -23,10 +29,16 @@
       location: https://zenodo.org/record/6457007/files/Drosophila_melanogaster.BDGP6.32.109_UCSC.gtf.gz
       decompress: true
       filetype: gtf
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 3cbdd2f0eed28bd10af66cb83aa3f6d688779d51
     cellranger_barcodes_3M-february-2018.txt:
       class: File
       path: test-data/all_cell_barcodes_both_versions.txt
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: f4bc47a31f6aba7aa45c8ebddad1d5ea51fb4797
   outputs:
     'MultiQC on input dataset(s): Webpage':
       asserts:
@@ -34,7 +46,7 @@
           expression: |-
             <span class="val">33.[0-9]<span class=['"]mqc_small_space['"]>
     Seurat input for gene expression (filtered):
-      attributes: { collection_type: list:list }
+      attributes: {collection_type: list:list}
       element_tests:
         subsample:
           elements:
@@ -49,4 +61,4 @@
             genes:
               asserts:
                 has_line:
-                  line: "FBgn0250732	gfzf"
+                  line: "FBgn0250732\tgfzf"

--- a/workflows/scRNAseq/velocyto/Velocyto-on10X-filtered-barcodes-tests.yml
+++ b/workflows/scRNAseq/velocyto/Velocyto-on10X-filtered-barcodes-tests.yml
@@ -5,6 +5,9 @@
       location: https://zenodo.org/record/6457007/files/Drosophila_melanogaster.BDGP6.32.109_UCSC.gtf.gz
       decompress: true
       filetype: gtf
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 3cbdd2f0eed28bd10af66cb83aa3f6d688779d51
     BAM files with CB and UB:
       class: Collection
       collection_type: list
@@ -13,6 +16,9 @@
         identifier: subsample
         location: https://zenodo.org/records/10572348/files/subsample.bam
         filetype: bam
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 0084c8b35be58ac58079ce79d7b57172602623a5
     filtered barcodes:
       class: Collection
       collection_type: list
@@ -21,6 +27,9 @@
         identifier: subsample
         location: https://zenodo.org/records/10572348/files/barcodes.tsv
         filetype: tsv
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 332a0a5ac99b06315b2c946faa333c4684423b0b
   outputs:
     velocyto loom:
       element_tests:

--- a/workflows/scRNAseq/velocyto/Velocyto-on10X-from-bundled-tests.yml
+++ b/workflows/scRNAseq/velocyto/Velocyto-on10X-from-bundled-tests.yml
@@ -5,6 +5,9 @@
       location: https://zenodo.org/record/6457007/files/Drosophila_melanogaster.BDGP6.32.109_UCSC.gtf.gz
       decompress: true
       filetype: gtf
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 3cbdd2f0eed28bd10af66cb83aa3f6d688779d51
     BAM files with CB and UB:
       class: Collection
       collection_type: list
@@ -13,6 +16,9 @@
         identifier: subsample
         location: https://zenodo.org/records/10572348/files/subsample.bam
         filetype: bam
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 0084c8b35be58ac58079ce79d7b57172602623a5
     filtered matrices in bundle:
       class: Collection
       collection_type: list:list
@@ -25,14 +31,23 @@
           identifier: barcodes
           location: https://zenodo.org/records/10572348/files/barcodes.tsv
           filetype: tsv
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 332a0a5ac99b06315b2c946faa333c4684423b0b
         - class: File
           identifier: genes
           location: https://zenodo.org/records/10572348/files/genes.tsv
           filetype: tsv
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 0050f249ab6c35024b9c5ada8f86381ec2a16646
         - class: File
           identifier: matrix
           location: https://zenodo.org/records/10572348/files/matrix.mtx
           filetype: mtx
+          hashes:
+          - hash_function: SHA-1
+            hash_value: c84cc0a02031b55acbbb944a0f865af39aa3448d
   outputs:
     velocyto loom:
       element_tests:

--- a/workflows/transcriptomics/brew3r/BREW3R-tests.yml
+++ b/workflows/transcriptomics/brew3r/BREW3R-tests.yml
@@ -4,6 +4,9 @@
       class: File
       path: test-data/input.gtf
       filetype: gtf
+      hashes:
+      - hash_function: SHA-1
+        hash_value: c5522d850332b88271e717eb3826623d08dee070
     BAM collection:
       class: Collection
       collection_type: list
@@ -11,12 +14,21 @@
       - class: File
         identifier: GSM4196550
         path: test-data/GSM4196550_subset.bam
+        hashes:
+        - hash_function: SHA-1
+          hash_value: b71f31509922fadf686558258aae79f1b46fe558
       - class: File
         identifier: GSM4196551
         path: test-data/GSM4196551_subset.bam
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 05501357163159db31b2b842efba87f123027d95
       - class: File
         identifier: GSM4196552
         path: test-data/GSM4196552_subset.bam
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 95c0dfde9dcae450ff848dbaa1ba2ff38ffe5891
     strandedness: 'stranded - reverse'
     minimum coverage: 10
     minimum FPKM for merge: 1.0
@@ -24,6 +36,6 @@
     extended_gtf:
       asserts:
         has_line:
-          line: 'chr12	HAVANA	exon	11206402	11208972	.	-	.	gene_id "ENSMUSG00000047002.2"; gene_type "protein_coding"; gene_name "Msgn1"; level "2"; mgi_id "MGI:1860483"; havana_gene "OTTMUSG00000065713.1"; transcript_id "ENSMUST00000049877.2"; transcript_type "protein_coding"; transcript_name "Msgn1-201"; protein_id "ENSMUSP00000055001.1"; transcript_support_level "NA"; tag "CCDS"; ccdsid "CCDS25814.1"; havana_transcript "OTTMUST00000159929.1"; exon_number "1"; exon_id "ENSMUSE00000372682.2.ext"'
+          line: "chr12\tHAVANA\texon\t11206402\t11208972\t.\t-\t.\tgene_id \"ENSMUSG00000047002.2\"; gene_type \"protein_coding\"; gene_name \"Msgn1\"; level \"2\"; mgi_id \"MGI:1860483\"; havana_gene \"OTTMUSG00000065713.1\"; transcript_id \"ENSMUST00000049877.2\"; transcript_type \"protein_coding\"; transcript_name \"Msgn1-201\"; protein_id \"ENSMUSP00000055001.1\"; transcript_support_level \"NA\"; tag \"CCDS\"; ccdsid \"CCDS25814.1\"; havana_transcript \"OTTMUST00000159929.1\"; exon_number \"1\"; exon_id \"ENSMUSE00000372682.2.ext\""
         has_text:
           text: "CDS"

--- a/workflows/transcriptomics/goseq/goseq-go-kegg-enrichment-analsis-tests.yml
+++ b/workflows/transcriptomics/goseq/goseq-go-kegg-enrichment-analsis-tests.yml
@@ -4,86 +4,95 @@
       class: File
       location: https://zenodo.org/records/14033254/files/de-result.tabular
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 34770cded41b8a39b0056aa8bff47b6382a3c558
     gene length:
       class: File
       location: https://zenodo.org/records/14033254/files/gene-length.tabular
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: bab691634c770bf6b150251c66278d90c727123c
     KEGG pathways:
       class: File
       location: https://zenodo.org/records/14033254/files/kegg-pathways.tabular
       filetype: tabular
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 9807280a33f5842b965eb82826f90c9c54597c27
     Select genome to use: mm10
     Select gene ID format: ensGene
   outputs:
     goseq Enrichment Table (Cellular Component):
       asserts:
-        - that: "has_text_matching"
-          expression: "category\tover_represented_pvalue\tunder_represented_pvalue\tnumDEInCat\tnumInCat\tterm\tontology\tp_adjust_over_represented\tp_adjust_under_represented"
-        - that: "has_text_matching"
-          expression: "GO:0005737\t4.79[0-9]+e-08\t1\t4810\t8312\tcytoplasm\tCC\t9.31[0-9]+e-05\t1"
-        - that: "has_text_matching"
-          expression: "over_represented_pvalue"
-        - that: "has_text_matching"
-          expression: "under_represented_pvalue"
+      - that: "has_text_matching"
+        expression: "category\tover_represented_pvalue\tunder_represented_pvalue\tnumDEInCat\tnumInCat\tterm\tontology\tp_adjust_over_represented\tp_adjust_under_represented"
+      - that: "has_text_matching"
+        expression: "GO:0005737\t4.79[0-9]+e-08\t1\t4810\t8312\tcytoplasm\tCC\t9.31[0-9]+e-05\t1"
+      - that: "has_text_matching"
+        expression: "over_represented_pvalue"
+      - that: "has_text_matching"
+        expression: "under_represented_pvalue"
     goseq Top Categories plot (Cellular Component):
-      asserts:  
-        - that: "has_size"
-          size: 7078
+      asserts:
+      - that: "has_size"
+        size: 7078
     goseq Differential Genes in each Category (Cellular Component):
       asserts:
-        - that: "has_text_matching"
-          expression: "category\tde_genes"
-        - that: "has_text_matching"
-          expression: "GO:0005737\tENSMUSG00000045545,ENSMUSG00000029802,ENSMUSG00000058056"
+      - that: "has_text_matching"
+        expression: "category\tde_genes"
+      - that: "has_text_matching"
+        expression: "GO:0005737\tENSMUSG00000045545,ENSMUSG00000029802,ENSMUSG00000058056"
     goseq Differential Genes in each Category (Biological Process):
       asserts:
-        - that: "has_text_matching"
-          expression: "category\tde_genes"
-        - that: "has_text_matching"
-          expression: "GO:0043254\tENSMUSG00000023951,ENSMUSG00000032060,ENSMUSG00000031284,"
+      - that: "has_text_matching"
+        expression: "category\tde_genes"
+      - that: "has_text_matching"
+        expression: "GO:0043254\tENSMUSG00000023951,ENSMUSG00000032060,ENSMUSG00000031284,"
     goseq Top Categories plot (Biological Process):
       asserts:
-        - that: "has_size"
-          size: 7092
+      - that: "has_size"
+        size: 7092
     goseq Enrichment Table (Biological Process):
       asserts:
-        - that: "has_text_matching"
-          expression: "category\tover_represented_pvalue\tunder_represented_pvalue\tnumDEInCat\tnumInCat\tterm\tontology\tp_adjust_over_represented\tp_adjust_under_represented"
-        - that: "has_text_matching"
-          expression: "GO:0043254\t3.41[0-9]+e-07\t1\t239\t345\tregulation of protein-containing complex assembly\tBP\t0.0034[0-9]+\t1"
-        - that: "has_text_matching"
-          expression: "over_represented_pvalue"
-        - that: "has_text_matching"
-          expression: "under_represented_pvalue"
+      - that: "has_text_matching"
+        expression: "category\tover_represented_pvalue\tunder_represented_pvalue\tnumDEInCat\tnumInCat\tterm\tontology\tp_adjust_over_represented\tp_adjust_under_represented"
+      - that: "has_text_matching"
+        expression: "GO:0043254\t3.41[0-9]+e-07\t1\t239\t345\tregulation of protein-containing complex assembly\tBP\t0.0034[0-9]+\t1"
+      - that: "has_text_matching"
+        expression: "over_represented_pvalue"
+      - that: "has_text_matching"
+        expression: "under_represented_pvalue"
     goseq Differential Genes in each Category (KEGG):
       asserts:
-        - that: "has_text_matching"
-          expression: "category\tde_genes"
-        - that: "has_text_matching"
-          expression: "04540\tENSMUSG00000063358,ENSMUSG00000045136,ENSMUSG00000025856,ENSMUSG00000028019"
+      - that: "has_text_matching"
+        expression: "category\tde_genes"
+      - that: "has_text_matching"
+        expression: "04540\tENSMUSG00000063358,ENSMUSG00000045136,ENSMUSG00000025856,ENSMUSG00000028019"
     goseq Top Categories plot (Molecular Function):
       asserts:
-        - that: "has_size"
-          size: 7166
+      - that: "has_size"
+        size: 7166
     goseq Enrichment Table (Molecular Function):
       asserts:
-        - that: "has_text_matching"
-          expression: "category\tover_represented_pvalue\tunder_represented_pvalue\tnumDEInCat\tnumInCat\tterm\tontology\tp_adjust_over_represented\tp_adjust_under_represented"
-        - that: "has_text_matching"
-          expression: "GO:0005515\t1.4094[0-9]+e-07\t1\t3758\t6415\tprotein binding\tMF\t0.0006[0-9]+\t1"
-        - that: "has_text_matching"
-          expression: "over_represented_pvalue"
-        - that: "has_text_matching"
-          expression: "under_represented_pvalue"
+      - that: "has_text_matching"
+        expression: "category\tover_represented_pvalue\tunder_represented_pvalue\tnumDEInCat\tnumInCat\tterm\tontology\tp_adjust_over_represented\tp_adjust_under_represented"
+      - that: "has_text_matching"
+        expression: "GO:0005515\t1.4094[0-9]+e-07\t1\t3758\t6415\tprotein binding\tMF\t0.0006[0-9]+\t1"
+      - that: "has_text_matching"
+        expression: "over_represented_pvalue"
+      - that: "has_text_matching"
+        expression: "under_represented_pvalue"
     goseq Differential Genes in each Category (Molecular Function):
       asserts:
-        - that: "has_text_matching"
-          expression: "category\tde_genes"
-        - that: "has_text_matching"
-          expression: "GO:0005515\tENSMUSG00000045545,ENSMUSG00000029802,ENSMUSG00000058056,ENSMUSG00000004044,"
+      - that: "has_text_matching"
+        expression: "category\tde_genes"
+      - that: "has_text_matching"
+        expression: "GO:0005515\tENSMUSG00000045545,ENSMUSG00000029802,ENSMUSG00000058056,ENSMUSG00000004044,"
     goseq Enrichment Table (KEGG):
       asserts:
-        - that: "has_text_matching"
-          expression: "category\tover_represented_pvalue\tunder_represented_pvalue\tnumDEInCat\tnumInCat\tp_adjust_over_represented\tp_adjust_under_represented\tID\tName"
-        - that: "has_text_matching"
-          expression: "04540\t0.0031[0-9]+\t0.99[0-9]+\t47\t61\t0.46[0-9]+\t1\t04540\tGap junction - mmus"
+      - that: "has_text_matching"
+        expression: "category\tover_represented_pvalue\tunder_represented_pvalue\tnumDEInCat\tnumInCat\tp_adjust_over_represented\tp_adjust_under_represented\tID\tName"
+      - that: "has_text_matching"
+        expression: "04540\t0.0031[0-9]+\t0.99[0-9]+\t47\t61\t0.46[0-9]+\t1\t04540\tGap junction - mmus"

--- a/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml
+++ b/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml
@@ -4,6 +4,9 @@
       class: File
       location: https://zenodo.org/records/13987631/files/Saccharomyces_cerevisiae.R64-1-1.113.gtf
       filetype: gtf
+      hashes:
+      - hash_function: SHA-1
+        hash_value: afc40f49d008ba2a68b0ee0db130669b07cd445e
     Collection paired FASTQ files:
       class: Collection
       collection_type: list:paired
@@ -15,9 +18,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/records/13987631/files/SRR5085167_forward.fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: f910a2a7764249b690e28d8dcf4d7097d3c533f6
         - class: File
           identifier: reverse
           location: https://zenodo.org/records/13987631/files/SRR5085167_reverse.fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 7558d21e69e0d7117a20305becdfdfc49769753e
     Forward adapter: AGATCGGAAGAG
     Reverse adapter: GATCGTCGGACT
     Generate additional QC reports: true
@@ -25,17 +34,17 @@
     Use featureCounts for generating count tables: true
     Strandedness: stranded - forward
     Compute Cufflinks FPKM: true
-    GTF with regions to exclude from FPKM normalization with Cufflinks: null
+    GTF with regions to exclude from FPKM normalization with Cufflinks:
     Compute StringTie FPKM: true
   outputs:
     MultiQC stats:
       asserts:
-        - that: "has_text_matching"
-          expression: "SRR5085167\t0.10[0-9]*\t16.45[0-9]*\t43.38[0-9]*\t0.32[0-9]*\t0.30[0-9]*\t93.75\t0.11[0-9]*\t34.29\t0.19[0-9]*\t17.6[0-9]*\t91.8[0-9]*\t30.0[0-9]*\t0.64[0-9]*\t43.5[0-9]*\t81.0[0-9]*\t72.6[0-9]*\t"
-        - that: "has_text_matching"
-          expression: "SRR5085167_forward\t*36.33[0-9]*\t46.0\t75.0\t75\t27.27[0-9]*\t0.39[0-9]*"
-        - that: "has_text_matching"
-          expression: "SRR5085167_reverse\t*35.31[0-9]*\t46.0\t75.0\t75\t45.45[0-9]*\t0.39[0-9]*"
+      - that: "has_text_matching"
+        expression: "SRR5085167\t0.10[0-9]*\t16.45[0-9]*\t43.38[0-9]*\t0.32[0-9]*\t0.30[0-9]*\t93.75\t0.11[0-9]*\t34.29\t0.19[0-9]*\t17.6[0-9]*\t91.8[0-9]*\t30.0[0-9]*\t0.64[0-9]*\t43.5[0-9]*\t81.0[0-9]*\t72.6[0-9]*\t"
+      - that: "has_text_matching"
+        expression: "SRR5085167_forward\t*36.33[0-9]*\t46.0\t75.0\t75\t27.27[0-9]*\t0.39[0-9]*"
+      - that: "has_text_matching"
+        expression: "SRR5085167_reverse\t*35.31[0-9]*\t46.0\t75.0\t75\t45.45[0-9]*\t0.39[0-9]*"
     Stranded Coverage:
       element_tests:
         SRR5085167_forward:
@@ -73,16 +82,16 @@
         SRR5085167:
           asserts:
             has_line:
-              line: "YAL038W	-	-	YAL038W	CDC19	-	chrI:71785-73288	-	-	3437.1	3211.44	3662.76	OK"
+              line: "YAL038W\t-\t-\tYAL038W\tCDC19\t-\tchrI:71785-73288\t-\t-\t3437.1\t3211.44\t3662.76\tOK"
     Transcripts Expression from Cufflinks:
       element_tests:
         SRR5085167:
           asserts:
             has_line:
-              line: "YAL038W_mRNA	-	-	YAL038W	CDC19	-	chrI:71785-73288	1503	102.837	3437.1	3211.44	3662.76	OK"
+              line: "YAL038W_mRNA\t-\t-\tYAL038W\tCDC19\t-\tchrI:71785-73288\t1503\t102.837\t3437.1\t3211.44\t3662.76\tOK"
     Counts Table:
       element_tests:
         SRR5085167:
           asserts:
             has_line:
-              line: "YAL038W	1591"
+              line: "YAL038W\t1591"

--- a/workflows/transcriptomics/rnaseq-sr/rnaseq-sr-tests.yml
+++ b/workflows/transcriptomics/rnaseq-sr/rnaseq-sr-tests.yml
@@ -4,6 +4,9 @@
       class: File
       location: https://zenodo.org/records/13987631/files/Saccharomyces_cerevisiae.R64-1-1.113.gtf
       filetype: gtf
+      hashes:
+      - hash_function: SHA-1
+        hash_value: afc40f49d008ba2a68b0ee0db130669b07cd445e
     Collection of FASTQ files:
       class: Collection
       collection_type: list
@@ -11,13 +14,16 @@
       - class: File
         identifier: SRR5085167
         location: https://zenodo.org/records/13987631/files/SRR5085167_forward.fastqsanger.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: f910a2a7764249b690e28d8dcf4d7097d3c533f6
     Forward adapter: AGATCGGAAGAG
     Generate additional QC reports: true
     Reference genome: sacCer3
     Strandedness: stranded - forward
     Use featureCounts for generating count tables: true
     Compute Cufflinks FPKM: true
-    GTF with regions to exclude from FPKM normalization with Cufflinks: null
+    GTF with regions to exclude from FPKM normalization with Cufflinks:
     Compute StringTie FPKM: true
   outputs:
     MultiQC stats:
@@ -29,7 +35,7 @@
         SRR5085167:
           asserts:
             has_line:
-              line: "YAL038W	1775"
+              line: "YAL038W\t1775"
     Mapped Reads:
       element_tests:
         SRR5085167:
@@ -48,13 +54,13 @@
         SRR5085167:
           asserts:
             has_line:
-              line: "YAL038W	-	-	YAL038W	CDC19	-	chrI:71785-73288	-	-	3375.85	3161.36	3590.33	OK"
+              line: "YAL038W\t-\t-\tYAL038W\tCDC19\t-\tchrI:71785-73288\t-\t-\t3375.85\t3161.36\t3590.33\tOK"
     Transcripts Expression from Cufflinks:
       element_tests:
         SRR5085167:
           asserts:
             has_line:
-              line: "YAL038W_mRNA	-	-	YAL038W	CDC19	-	chrI:71785-73288	1503	57.5601	3375.85	3161.36	3590.33	OK"
+              line: "YAL038W_mRNA\t-\t-\tYAL038W\tCDC19\t-\tchrI:71785-73288\t1503\t57.5601\t3375.85\t3161.36\t3590.33\tOK"
     Stranded Coverage:
       element_tests:
         SRR5085167_forward:

--- a/workflows/variant-calling/generic-variant-calling-wgs-pe/Generic-variation-analysis-on-WGS-PE-data-tests.yml
+++ b/workflows/variant-calling/generic-variant-calling-wgs-pe/Generic-variation-analysis-on-WGS-PE-data-tests.yml
@@ -4,21 +4,30 @@
       class: File
       filetype: genbank
       path: test-data/GenBank genome.genbank
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 586d54741cb8b8f7d2e473827d3b25e5a235f9f7
     Name for genome database: mpxv
     Paired Collection:
       class: Collection
       collection_type: list:paired
       elements:
-        - class: Collection
-          type: paired
-          identifier: ERR3485802
-          elements:
-          - identifier: forward
-            class: File
-            path: test-data/ERR3485802.forward.fastq.gz
-          - identifier: reverse
-            class: File
-            path: test-data/ERR3485802.reverse.fastq.gz
+      - class: Collection
+        type: paired
+        identifier: ERR3485802
+        elements:
+        - identifier: forward
+          class: File
+          path: test-data/ERR3485802.forward.fastq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 00db6798ebbb520c28bc4d0e52c0fabac0bb37ac
+        - identifier: reverse
+          class: File
+          path: test-data/ERR3485802.reverse.fastq.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 9a9f61098507023fab3e1fa0383ca628759108c1
   outputs:
     Fasta sequences for genbank file:
       path: test-data/Fasta sequences for genbank file.fasta

--- a/workflows/variant-calling/haploid-variant-calling-wgs-pe/WGS-PE-variant-calling-in-haploid-system-tests.yml
+++ b/workflows/variant-calling/haploid-variant-calling-wgs-pe/WGS-PE-variant-calling-in-haploid-system-tests.yml
@@ -4,10 +4,16 @@
       class: File
       location: https://zenodo.org/records/14009320/files/Annotation%20GTF.gtf?download=1
       filetype: gtf
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 7332cabb96a767d5cf6efbb5f3eb2dc8a40fb3d0
     Genome fasta:
       class: File
       location: https://zenodo.org/records/14009320/files/Genome%20fasta.fasta.gz?download=1
       filetype: fasta.gz
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 912f1de146158d59bbd93b8fe3b2f63eb9a49162
     Paired Collection:
       class: Collection
       collection_type: list:paired
@@ -19,9 +25,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/records/14009320/files/ERR018930_forward.fastqsanger.gz?download=1
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 043b41d132449b815266061832f0d25d8f50bda6
         - class: File
           identifier: reverse
           location: https://zenodo.org/records/14009320/files/ERR018930_reverse.fastqsanger.gz?download=1
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 693dfe7dad64030b72b59ffe07e7e711ae11606d
       - class: Collection
         type: paired
         identifier: ERR1035492
@@ -29,9 +41,15 @@
         - class: File
           identifier: forward
           location: https://zenodo.org/records/14009320/files/ERR1035492_forward.fastqsanger.gz?download=1
+          hashes:
+          - hash_function: SHA-1
+            hash_value: b27dac7ed0a11942f8288b1c49868c81d6a8bff1
         - class: File
           identifier: reverse
           location: https://zenodo.org/records/14009320/files/ERR1035492_reverse.fastqsanger.gz?download=1
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 1bad1ab8552365da08b86c0a8210ccba083b4550
   outputs:
     Annotated Variants:
       path: test-data/Annotated Variants.tabular
@@ -39,11 +57,11 @@
       element_tests:
         ERR018930:
           asserts:
-            - has_line:
-                line: 'NC_009906.1	3204	.	A	G	120.0	PASS	DP=22;AF=0.727273;SB=2;DP4=2,3,3,14;EFF=INTRAGENIC(MODIFIER|||||PVX_087665||NON_CODING|||G)'
-            - has_line:
-                line: 'NC_009906.1	3261	.	C	A	52.0	PASS	DP=15;AF=0.333333;SB=0;DP4=3,7,2,3;EFF=INTRAGENIC(MODIFIER|||||PVX_087665||NON_CODING|||A)'
+          - has_line:
+              line: "NC_009906.1\t3204\t.\tA\tG\t120.0\tPASS\tDP=22;AF=0.727273;SB=2;DP4=2,3,3,14;EFF=INTRAGENIC(MODIFIER|||||PVX_087665||NON_CODING|||G)"
+          - has_line:
+              line: "NC_009906.1\t3261\t.\tC\tA\t52.0\tPASS\tDP=15;AF=0.333333;SB=0;DP4=3,7,2,3;EFF=INTRAGENIC(MODIFIER|||||PVX_087665||NON_CODING|||A)"
         ERR1035492:
           asserts:
             has_line:
-              line: 'NC_009906.1	2975	.	A	G	75.0	PASS	DP=26;AF=0.692308;SB=0;DP4=5,3,12,6;EFF=INTRAGENIC(MODIFIER|||||PVX_087665||NON_CODING|||G)'
+              line: "NC_009906.1\t2975\t.\tA\tG\t75.0\tPASS\tDP=26;AF=0.692308;SB=0;DP4=5,3,12,6;EFF=INTRAGENIC(MODIFIER|||||PVX_087665||NON_CODING|||G)"

--- a/workflows/variant-calling/variation-reporting/Generic-variation-analysis-reporting-tests.yml
+++ b/workflows/variant-calling/variation-reporting/Generic-variation-analysis-reporting-tests.yml
@@ -10,6 +10,9 @@
       - class: File
         identifier: filtered variants ERR3485802
         path: test-data/Variation data to report_filtered variants ERR3485802.vcf
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 2e8678ff28911100ad231d536a508937250176c9
   outputs:
     af_recalculated:
       element_tests:

--- a/workflows/virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml
+++ b/workflows/virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml
@@ -4,43 +4,60 @@
       class: File
       location: "https://www.ebi.ac.uk/ena/browser/api/fasta/AF325528.1?download=true"
       filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 927d0d00b7db6ad60524bb9e50d3ab41c4ac5ecf
     Primer Scheme:
       class: File
       path: test-data/CaPV-V1_primer_scheme.bed6
       filetype: bed
+      hashes:
+      - hash_function: SHA-1
+        hash_value: bc97311fadc503436695575450f2148d686f5b40
     PE Reads Pool1:
       class: Collection
       collection_type: list:paired
       elements:
-        - class: Collection
-          type: paired
-          identifier: 20L70 # SRR15145276
-          elements:
-            - identifier: forward
-              class: File
-              location: "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR151/076/SRR15145276/SRR15145276_1.fastq.gz"
-              filetype: fastqsanger.gz
-            - identifier: reverse
-              class: File
-              location: "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR151/076/SRR15145276/SRR15145276_2.fastq.gz"
-              filetype: fastqsanger.gz
+      - class: Collection
+        type: paired
+        identifier: 20L70   # SRR15145276
+        elements:
+        - identifier: forward
+          class: File
+          location: "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR151/076/SRR15145276/SRR15145276_1.fastq.gz"
+          filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: da39a3ee5e6b4b0d3255bfef95601890afd80709
+        - identifier: reverse
+          class: File
+          location: "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR151/076/SRR15145276/SRR15145276_2.fastq.gz"
+          filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: da39a3ee5e6b4b0d3255bfef95601890afd80709
     PE Reads Pool2:
       class: Collection
       collection_type: list:paired
       elements:
-        - class: Collection
-          type: paired
-          identifier: 20L70 # SRX11452708
-          elements:
-            - identifier: forward
-              class: File
-              location: "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR151/075/SRR15145275/SRR15145275_1.fastq.gz"
-              filetype: fastqsanger.gz
-            - identifier: reverse
-              class: File
-              location: "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR151/075/SRR15145275/SRR15145275_2.fastq.gz"
-              filetype: fastqsanger.gz
+      - class: Collection
+        type: paired
+        identifier: 20L70   # SRX11452708
+        elements:
+        - identifier: forward
+          class: File
+          location: "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR151/075/SRR15145275/SRR15145275_1.fastq.gz"
+          filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: c11cf67a30caa9a713dd8cdae91f6ba08a17da06
+        - identifier: reverse
+          class: File
+          location: "ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR151/075/SRR15145275/SRR15145275_2.fastq.gz"
+          filetype: fastqsanger.gz
+          hashes:
+          - hash_function: SHA-1
+            hash_value: 825cfcacf1029066cd2ceb3989e31736fd5b7c8a
   outputs:
     combined_consensus_multifasta:
       file: test-data/combined_consensus_multifasta.fasta
-    


### PR DESCRIPTION
Workflows that have somewhat invalid yaml (with duplicate keys) are skipped

FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
