### PR TITLE
Updating workflows/microbiome/host-contamination-removal/host-contamination-removal-short-reads from 0.1 to 0.2

### DIFF
--- a/workflows/microbiome/host-contamination-removal/host-contamination-removal-short-reads/CHANGELOG.md
+++ b/workflows/microbiome/host-contamination-removal/host-contamination-removal-short-reads/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ## [0.2] - 2025-12-08
 
+### Changes
+
+- Remove `ZIP_COLLECTION` step which is not needed anymore because latest `bowtie` version outputs the unmapped reads in a list of paired datasets.
+
 ### Automatic update
 - `toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.5.3+galaxy1` was updated to `toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.5.4+galaxy0`
 - `toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy3` was updated to `toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy4`
 
-## [0.1] 2025-12-03
+## [0.1] - 2025-12-03
 
 First release.

--- a/workflows/microbiome/host-contamination-removal/host-contamination-removal-short-reads/host-or-contamination-removal-on-short-reads.ga
+++ b/workflows/microbiome/host-contamination-removal/host-contamination-removal-short-reads/host-or-contamination-removal-on-short-reads.ga
@@ -11,7 +11,7 @@
         {
             "class": "Person",
             "identifier": "https://orcid.org/0000-0001-9852-1987",
-            "name": "Bérénice Batut"
+            "name": "B\u00e9r\u00e9nice Batut"
         }
     ],
     "format-version": "0.1",
@@ -77,52 +77,10 @@
             "workflow_outputs": []
         },
         "2": {
-            "annotation": "Take two collections and create a paired collection from them.",
-            "content_id": "__ZIP_COLLECTION__",
-            "errors": null,
-            "id": 2,
-            "input_connections": {},
-            "inputs": [],
-            "label": "Create a paired collection",
-            "name": "Zip collections",
-            "outputs": [
-                {
-                    "name": "output",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 620,
-                "top": 0
-            },
-            "post_job_actions": {
-                "RenameDatasetActionoutput": {
-                    "action_arguments": {
-                        "newname": "Reads without host or contaminant reads"
-                    },
-                    "action_type": "RenameDatasetAction",
-                    "output_name": "output"
-                }
-            },
-            "tool_id": "__ZIP_COLLECTION__",
-            "tool_state": "{\"input_forward\": {\"__class__\": \"ConnectedValue\"}, \"input_reverse\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "1.0.0",
-            "type": "tool",
-            "uuid": "63e069fd-7c6d-48e1-b891-9ad0a93a5516",
-            "when": null,
-            "workflow_outputs": [
-                {
-                    "label": "Contamination Filtered Reads",
-                    "output_name": "output",
-                    "uuid": "02423350-1d61-4be2-a743-9dca7bae63b8"
-                }
-            ]
-        },
-        "3": {
             "annotation": "Map the reads against a reference genome and output the ones not mapping the reference genome",
             "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.5.4+galaxy0",
             "errors": null,
-            "id": 3,
+            "id": 2,
             "input_connections": {
                 "library|input_1": {
                     "id": 0,
@@ -185,6 +143,13 @@
                     },
                     "action_type": "RenameDatasetAction",
                     "output_name": "mapping_stats"
+                },
+                "RenameDatasetActionoutput_unaligned_read_pairs": {
+                    "action_arguments": {
+                        "newname": "Reads without host or contaminant reads"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output_unaligned_read_pairs"
                 }
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/bowtie2/2.5.4+galaxy0",
@@ -201,20 +166,25 @@
             "when": null,
             "workflow_outputs": [
                 {
+                    "label": "Contamination Filtered Reads",
+                    "output_name": "output_unaligned_read_pairs",
+                    "uuid": "6b919dad-1cf0-4c28-bd7f-3e43d2aedfc9"
+                },
+                {
                     "label": "Bowtie2 Mapping Statistics",
                     "output_name": "mapping_stats",
                     "uuid": "76c58935-0b96-4549-8ff4-bd17952c903f"
                 }
             ]
         },
-        "4": {
+        "3": {
             "annotation": "Aggregation of the mapping statistics for all samples",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.27+galaxy4",
             "errors": null,
-            "id": 4,
+            "id": 3,
             "input_connections": {
                 "results_0|software_cond|input": {
-                    "id": 3,
+                    "id": 2,
                     "output_name": "mapping_stats"
                 }
             },
@@ -280,7 +250,7 @@
         "contamination",
         "short_reads"
     ],
-    "uuid": "1d991799-d956-475b-b54a-a660676ecf4a",
-    "version": 1,
+    "uuid": "d31ffe9d-0fdc-470d-a70c-2e6b121e77d3",
+    "version": 2,
     "release": "0.2"
 }


### PR DESCRIPTION
Replace #1039

FOR CONTRIBUTOR:
* [X] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [X] License permits unrestricted use (educational + commercial)
* [X] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
