### PR TITLE
Add workflow glyphs for visual identification

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13,6 +13,7 @@
         "@vueuse/core": "^14.1.0",
         "astro": "^5.16.12",
         "fuse.js": "^7.1.0",
+        "jdenticon": "^3.3.0",
         "lucide-vue-next": "^0.562.0",
         "marked": "^17.0.1",
         "mermaid": "^11.12.2",
@@ -3207,7 +3208,6 @@
       "version": "25.0.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
       "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -4456,6 +4456,15 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-renderer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/canvas-renderer/-/canvas-renderer-2.2.1.tgz",
+      "integrity": "sha512-RrBgVL5qCEDIXpJ6NrzyRNoTnXxYarqm/cS/W6ERhUJts5UQtt/XPEosGN3rqUkZ4fjBArlnCbsISJ+KCFnIAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -6968,6 +6977,21 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/jdenticon": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/jdenticon/-/jdenticon-3.3.0.tgz",
+      "integrity": "sha512-DhuBRNRIybGPeAjMjdHbkIfiwZCCmf8ggu7C49jhp6aJ7DYsZfudnvnTY5/1vgUhrGA7JaDAx1WevnpjCPvaGg==",
+      "license": "MIT",
+      "dependencies": {
+        "canvas-renderer": "~2.2.0"
+      },
+      "bin": {
+        "jdenticon": "bin/jdenticon.js"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -10329,7 +10353,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/website/package.json
+++ b/website/package.json
@@ -20,6 +20,7 @@
     "@vueuse/core": "^14.1.0",
     "astro": "^5.16.12",
     "fuse.js": "^7.1.0",
+    "jdenticon": "^3.3.0",
     "lucide-vue-next": "^0.562.0",
     "marked": "^17.0.1",
     "mermaid": "^11.12.2",

--- a/website/src/components/WorkflowCard.vue
+++ b/website/src/components/WorkflowCard.vue
@@ -6,6 +6,7 @@ import Card from "./ui/Card.vue";
 import CardHeader from "./ui/CardHeader.vue";
 import CardContent from "./ui/CardContent.vue";
 import Badge from "./ui/Badge.vue";
+import WorkflowGlyph from "./WorkflowGlyph.vue";
 import { Tag, Clock } from "lucide-vue-next";
 
 const props = defineProps<{
@@ -53,7 +54,14 @@ const workflowUuid = computed(() => {
             ]">
             <!-- Header -->
             <CardHeader :class="compact ? 'p-3' : 'px-6 py-4 pb-2'">
-                <a :href="`/workflow/${encodeURIComponent(workflow.iwcID)}/`" class="group/link">
+                <a
+                    :href="`/workflow/${encodeURIComponent(workflow.iwcID)}/`"
+                    class="group/link flex items-center gap-3">
+                    <WorkflowGlyph
+                        :identifier="workflowUuid"
+                        :name="workflowName"
+                        :collections="workflow.collections"
+                        :size="compact ? 32 : 40" />
                     <h2
                         :class="[
                             'font-bold text-ebony-clay-900 group-hover/link:text-hokey-pokey-600 transition-colors duration-200',

--- a/website/src/components/WorkflowContent.vue
+++ b/website/src/components/WorkflowContent.vue
@@ -6,6 +6,7 @@ import MarkdownRenderer from "./MarkdownRenderer.vue";
 import Author from "./Author.vue";
 import GalaxyInstanceSelector from "./GalaxyInstanceSelector.vue";
 import CodeBlock from "./CodeBlock.vue";
+import WorkflowGlyph from "./WorkflowGlyph.vue";
 import Button from "./ui/Button.vue";
 import Tabs from "./ui/Tabs.vue";
 import TabsList from "./ui/TabsList.vue";
@@ -339,9 +340,16 @@ onMounted(() => {
         <!-- Right sidebar -->
         <div class="lg:w-80 xl:w-96 2xl:w-1/4 shrink-0">
             <div class="sticky top-4 bg-white border border-ebony-clay-100 rounded-lg p-6 shadow-sm">
-                <h2 class="font-bold text-xl mb-4 text-ebony-clay-900 border-b-2 border-hokey-pokey-500 pb-2">
-                    {{ workflow.definition.name }}
-                </h2>
+                <div class="flex items-center gap-4 mb-4 border-b-2 border-hokey-pokey-500 pb-3">
+                    <WorkflowGlyph
+                        :identifier="workflow.definition.uuid"
+                        :name="workflow.definition.name"
+                        :collections="workflow.collections"
+                        :size="64" />
+                    <h2 class="font-bold text-xl text-ebony-clay-900">
+                        {{ workflow.definition.name }}
+                    </h2>
+                </div>
                 <p class="mb-4 text-chicago-700">
                     {{ workflow.definition.annotation }}
                 </p>

--- a/website/src/components/WorkflowGlyph.vue
+++ b/website/src/components/WorkflowGlyph.vue
@@ -1,0 +1,215 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import * as jdenticon from "jdenticon";
+import { getWorkflowTheme, galaxyColors, type ShapeType } from "../utils/collectionThemes";
+import { extractInitials } from "../utils/initialsExtractor";
+
+const props = withDefaults(
+    defineProps<{
+        /** Unique identifier (uuid) for pattern generation */
+        identifier: string;
+        /** Workflow name for initials extraction */
+        name: string;
+        /** Collections array - primary collection determines theme */
+        collections?: string[];
+        /** Size in pixels (default: 40) */
+        size?: number;
+        /** Optional custom icon URL to override generated glyph */
+        customIconUrl?: string;
+    }>(),
+    {
+        size: 40,
+        collections: () => [],
+        customIconUrl: undefined,
+    },
+);
+
+const patternSvg = ref<string>("");
+const theme = computed(() => getWorkflowTheme(props.collections));
+const initials = computed(() => extractInitials(props.name));
+
+// SVG path data for each shape type
+const shapePaths: Record<ShapeType, (size: number) => string> = {
+    circle: (s) => {
+        const r = s / 2;
+        return `M ${r},0 A ${r},${r} 0 1,1 ${r},${s} A ${r},${r} 0 1,1 ${r},0`;
+    },
+    "rounded-square": (s) => {
+        const r = s * 0.18;
+        return `M ${r},0 H ${s - r} Q ${s},0 ${s},${r} V ${s - r} Q ${s},${s} ${s - r},${s} H ${r} Q 0,${s} 0,${s - r} V ${r} Q 0,0 ${r},0`;
+    },
+    hexagon: (s) => {
+        const cx = s / 2;
+        const cy = s / 2;
+        const r = s / 2;
+        const points: string[] = [];
+        for (let i = 0; i < 6; i++) {
+            const angle = (Math.PI / 3) * i - Math.PI / 2;
+            points.push(`${cx + r * Math.cos(angle)},${cy + r * Math.sin(angle)}`);
+        }
+        return `M ${points.join(" L ")} Z`;
+    },
+    octagon: (s) => {
+        const cx = s / 2;
+        const cy = s / 2;
+        const r = s / 2;
+        const points: string[] = [];
+        for (let i = 0; i < 8; i++) {
+            const angle = (Math.PI / 4) * i - Math.PI / 8;
+            points.push(`${cx + r * Math.cos(angle)},${cy + r * Math.sin(angle)}`);
+        }
+        return `M ${points.join(" L ")} Z`;
+    },
+    diamond: (s) => {
+        const h = s / 2;
+        return `M ${h},0 L ${s},${h} L ${h},${s} L 0,${h} Z`;
+    },
+    pill: (s) => {
+        const r = s * 0.35;
+        const w = s;
+        const h = s * 0.7;
+        const y = (s - h) / 2;
+        return `M ${r},${y} H ${w - r} A ${r},${r} 0 0 1 ${w - r},${y + h} H ${r} A ${r},${r} 0 0 1 ${r},${y}`;
+    },
+    shield: (s) => {
+        const cx = s / 2;
+        return `M ${cx},${s * 0.05} L ${s * 0.95},${s * 0.2} L ${s * 0.95},${s * 0.5} Q ${s * 0.95},${s * 0.8} ${cx},${s * 0.95} Q ${s * 0.05},${s * 0.8} ${s * 0.05},${s * 0.5} L ${s * 0.05},${s * 0.2} Z`;
+    },
+    pentagon: (s) => {
+        const cx = s / 2;
+        const cy = s / 2;
+        const r = s / 2;
+        const points: string[] = [];
+        for (let i = 0; i < 5; i++) {
+            const angle = (Math.PI * 2 * i) / 5 - Math.PI / 2;
+            points.push(`${cx + r * Math.cos(angle)},${cy + r * Math.sin(angle)}`);
+        }
+        return `M ${points.join(" L ")} Z`;
+    },
+    square: (s) => {
+        const r = s * 0.08;
+        return `M ${r},0 H ${s - r} Q ${s},0 ${s},${r} V ${s - r} Q ${s},${s} ${s - r},${s} H ${r} Q 0,${s} 0,${s - r} V ${r} Q 0,0 ${r},0`;
+    },
+};
+
+// Generate clip path ID based on identifier
+const clipPathId = computed(() => `glyph-clip-${props.identifier.substring(0, 8)}`);
+
+// Get the shape path for clipping
+const shapePath = computed(() => {
+    const generator = shapePaths[theme.value.shape];
+    return generator(props.size);
+});
+
+// Generate jdenticon pattern on mount
+onMounted(() => {
+    // Configure jdenticon with Galaxy blue palette - subtle and cohesive
+    jdenticon.configure({
+        hues: [210], // Galaxy blue hue
+        lightness: {
+            color: [0.35, 0.65],
+            grayscale: [0.4, 0.7],
+        },
+        saturation: {
+            color: 0.35, // Subtle saturation
+            grayscale: 0.0,
+        },
+        backColor: "transparent",
+    });
+
+    // Generate the pattern SVG
+    patternSvg.value = jdenticon.toSvg(props.identifier, props.size);
+});
+
+// Font size scales with glyph size
+const fontSize = computed(() => {
+    if (props.size <= 32) return props.size * 0.42;
+    if (props.size <= 48) return props.size * 0.4;
+    return props.size * 0.36;
+});
+
+// Colors from Galaxy palette
+const colors = {
+    background: galaxyColors.bayOfMany[100],
+    backgroundGradientEnd: galaxyColors.bayOfMany[200],
+    border: galaxyColors.bayOfMany[600],
+    text: galaxyColors.ebonyClay[900],
+    textShadow: galaxyColors.bayOfMany[50],
+};
+</script>
+
+<template>
+    <!-- Custom icon override -->
+    <img
+        v-if="customIconUrl"
+        :src="customIconUrl"
+        :alt="`${name} icon`"
+        :width="size"
+        :height="size"
+        class="workflow-glyph-custom" />
+
+    <!-- Generated glyph -->
+    <svg
+        v-else
+        :width="size"
+        :height="size"
+        :viewBox="`0 0 ${size} ${size}`"
+        class="workflow-glyph"
+        role="img"
+        :aria-label="`${name} glyph`">
+        <defs>
+            <clipPath :id="clipPathId">
+                <path :d="shapePath" />
+            </clipPath>
+            <!-- Subtle gradient for depth -->
+            <linearGradient :id="`${clipPathId}-grad`" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" :stop-color="colors.background" />
+                <stop offset="100%" :stop-color="colors.backgroundGradientEnd" />
+            </linearGradient>
+        </defs>
+
+        <!-- Background with gradient -->
+        <path :d="shapePath" :fill="`url(#${clipPathId}-grad)`" />
+
+        <!-- Jdenticon pattern (clipped to shape, subtle) -->
+        <g :clip-path="`url(#${clipPathId})`" class="pattern-layer" v-html="patternSvg" />
+
+        <!-- Shape border -->
+        <path :d="shapePath" fill="none" :stroke="colors.border" stroke-width="1.5" />
+
+        <!-- Initials -->
+        <text
+            :x="size / 2"
+            :y="size / 2"
+            text-anchor="middle"
+            dominant-baseline="central"
+            :fill="colors.text"
+            :font-size="fontSize"
+            font-weight="600"
+            font-family="'Atkinson Hyperlegible', system-ui, sans-serif"
+            class="glyph-initials">
+            {{ initials }}
+        </text>
+    </svg>
+</template>
+
+<style scoped>
+.workflow-glyph {
+    flex-shrink: 0;
+}
+
+.workflow-glyph-custom {
+    flex-shrink: 0;
+    object-fit: contain;
+}
+
+.pattern-layer {
+    opacity: 0.4;
+}
+
+.glyph-initials {
+    pointer-events: none;
+    user-select: none;
+    letter-spacing: -0.02em;
+}
+</style>

--- a/website/src/components/WorkflowListItem.vue
+++ b/website/src/components/WorkflowListItem.vue
@@ -3,6 +3,7 @@ import { computed } from "vue";
 import type { SearchIndexEntry, Workflow } from "../models/workflow";
 import { formatDate, navigateToCollection } from "../utils/";
 import Badge from "./ui/Badge.vue";
+import WorkflowGlyph from "./WorkflowGlyph.vue";
 import { Tag, Clock } from "lucide-vue-next";
 
 const props = defineProps<{
@@ -51,7 +52,15 @@ const workflowRelease = computed(() => {
         <div
             class="absolute left-0 top-0 bottom-0 w-1 bg-hokey-pokey-500 transform origin-left scale-x-0 group-hover:scale-x-100 transition-transform duration-200" />
 
-        <div class="flex items-start gap-6">
+        <div class="flex items-start gap-4">
+            <!-- Glyph -->
+            <WorkflowGlyph
+                :identifier="workflowUuid"
+                :name="workflowName"
+                :collections="workflow.collections"
+                :size="40"
+                class="mt-0.5 shrink-0" />
+
             <!-- Main content -->
             <div class="flex-1 min-w-0">
                 <a :href="`/workflow/${encodeURIComponent(workflow.iwcID)}/`" class="group/link">

--- a/website/src/utils/collectionThemes.ts
+++ b/website/src/utils/collectionThemes.ts
@@ -1,0 +1,118 @@
+/**
+ * Collection theme configuration for workflow glyphs.
+ * Uses Galaxy brand colors with shape-based differentiation per collection.
+ */
+
+export type ShapeType =
+    | "circle"
+    | "rounded-square"
+    | "hexagon"
+    | "octagon"
+    | "diamond"
+    | "pill"
+    | "shield"
+    | "pentagon"
+    | "square";
+
+export interface CollectionTheme {
+    shape: ShapeType;
+    /** Hue shift (0-360) applied to the base Galaxy blue palette */
+    hueShift: number;
+}
+
+/**
+ * Galaxy brand colors from global.css
+ */
+export const galaxyColors = {
+    // Bay of many - primary blue
+    bayOfMany: {
+        50: "#fdfdfe",
+        100: "#edf4fa",
+        200: "#cde0f0",
+        300: "#aecce7",
+        400: "#8fb9dd",
+        500: "#6fa5d4",
+        600: "#5091ca",
+        700: "#387dba",
+        800: "#2e689a",
+        900: "#25537b",
+    },
+    // Ebony clay - dark
+    ebonyClay: {
+        50: "#dfe2ea",
+        100: "#d3d6e2",
+        200: "#bbc0d2",
+        700: "#4c5574",
+        800: "#3c435c",
+        900: "#2c3143",
+    },
+    // Hokey pokey - gold accent
+    hokeyPokey: {
+        300: "#e1d36b",
+        400: "#daca49",
+        500: "#d0bd2a",
+        600: "#a19321",
+    },
+    // Chicago - grey
+    chicago: {
+        50: "#f5f5f6",
+        100: "#e6e6e7",
+        200: "#d0d0d1",
+        400: "#878789",
+        500: "#6c6c6e",
+        600: "#58585a",
+    },
+};
+
+/**
+ * Collection themes - each gets a unique shape.
+ * All use the same Galaxy color palette for consistency.
+ */
+export const collectionThemes: Record<string, CollectionTheme> = {
+    Transcriptomics: { shape: "circle", hueShift: 0 },
+    Proteomics: { shape: "rounded-square", hueShift: 0 },
+    Metabolomics: { shape: "hexagon", hueShift: 0 },
+    Metagenomics: { shape: "octagon", hueShift: 0 },
+    Microbiome: { shape: "diamond", hueShift: 0 },
+    "Genome assembly": { shape: "pill", hueShift: 0 },
+    "Genome Annotation": { shape: "shield", hueShift: 0 },
+    "Variant Calling": { shape: "pentagon", hueShift: 0 },
+    "Single Cell": { shape: "circle", hueShift: 0 },
+    Epigenetics: { shape: "rounded-square", hueShift: 0 },
+    Imaging: { shape: "square", hueShift: 0 },
+    "SARS-COV-2": { shape: "shield", hueShift: 0 },
+    Virology: { shape: "shield", hueShift: 0 },
+    "Computational Chemistry": { shape: "hexagon", hueShift: 0 },
+    Metabarcoding: { shape: "pill", hueShift: 0 },
+    Metaproteomics: { shape: "octagon", hueShift: 0 },
+    "Vertebrate Genome Project": { shape: "diamond", hueShift: 0 },
+    "Data Fetching": { shape: "square", hueShift: 0 },
+};
+
+/**
+ * Default theme for collections not in the mapping.
+ */
+export const defaultTheme: CollectionTheme = {
+    shape: "circle",
+    hueShift: 0,
+};
+
+/**
+ * Get the theme for a collection, or the default if not found.
+ */
+export function getCollectionTheme(collection: string | undefined): CollectionTheme {
+    if (!collection) {
+        return defaultTheme;
+    }
+    return collectionThemes[collection] || defaultTheme;
+}
+
+/**
+ * Get the theme for a workflow based on its primary (first) collection.
+ */
+export function getWorkflowTheme(collections: string[] | undefined): CollectionTheme {
+    if (!collections || collections.length === 0) {
+        return defaultTheme;
+    }
+    return getCollectionTheme(collections[0]);
+}

--- a/website/src/utils/initialsExtractor.ts
+++ b/website/src/utils/initialsExtractor.ts
@@ -1,0 +1,133 @@
+/**
+ * Utility for extracting initials from workflow names.
+ * Creates 2-3 letter abbreviations for visual display in glyphs.
+ */
+
+/**
+ * Words to skip when extracting initials (articles, prepositions, common fillers).
+ */
+const SKIP_WORDS = new Set([
+    "a",
+    "an",
+    "the",
+    "and",
+    "or",
+    "of",
+    "for",
+    "to",
+    "in",
+    "on",
+    "at",
+    "by",
+    "from",
+    "with",
+    "using",
+    "via",
+]);
+
+/**
+ * Common abbreviations and acronyms that should be treated as single units.
+ */
+const KNOWN_ABBREVIATIONS = new Set([
+    "rna",
+    "dna",
+    "mrna",
+    "rrna",
+    "trna",
+    "snp",
+    "vcf",
+    "bam",
+    "sam",
+    "qc",
+    "wgs",
+    "lcms",
+    "gcms",
+    "rnaseq",
+    "chipseq",
+    "atacseq",
+    "scrna",
+    "covid",
+    "sars",
+    "cov",
+    "artic",
+    "pe",
+    "se",
+]);
+
+/**
+ * Extract meaningful initials from a workflow name.
+ *
+ * Strategy:
+ * 1. Split by common delimiters (spaces, hyphens, colons, underscores)
+ * 2. Filter out skip words
+ * 3. Take first letter of significant words
+ * 4. Return 2-3 uppercase letters
+ *
+ * @param name - The workflow name
+ * @returns 2-3 uppercase letters representing the workflow
+ *
+ * @example
+ * extractInitials("RNA-Seq Differential Expression") // "RD"
+ * extractInitials("Variant Calling - Paired End") // "VC"
+ * extractInitials("COVID-19: variation analysis") // "CV"
+ * extractInitials("Mass spectrometry: LC-MS preprocessing") // "ML"
+ */
+export function extractInitials(name: string): string {
+    if (!name || typeof name !== "string") {
+        return "??";
+    }
+
+    // Split on common delimiters
+    const words = name
+        .split(/[\s\-:_/]+/)
+        .map((w) => w.trim())
+        .filter((w) => w.length > 0);
+
+    if (words.length === 0) {
+        return "??";
+    }
+
+    // Filter out skip words and very short words (unless they're abbreviations)
+    const significantWords = words.filter((word) => {
+        const lower = word.toLowerCase();
+        // Keep abbreviations even if short
+        if (KNOWN_ABBREVIATIONS.has(lower)) {
+            return true;
+        }
+        // Skip articles/prepositions
+        if (SKIP_WORDS.has(lower)) {
+            return false;
+        }
+        // Keep words with 2+ characters, or single uppercase (like "A" in "Type A")
+        return word.length >= 2 || (word.length === 1 && word === word.toUpperCase());
+    });
+
+    // If we filtered out everything, use the original words
+    const wordsToUse = significantWords.length > 0 ? significantWords : words;
+
+    // Extract first letters
+    const initials: string[] = [];
+    for (const word of wordsToUse) {
+        if (initials.length >= 3) break;
+
+        // For acronyms/abbreviations that are all caps, take the first letter
+        // For mixed case or lowercase, take the first letter
+        const firstChar = word.charAt(0).toUpperCase();
+        if (firstChar.match(/[A-Z]/)) {
+            initials.push(firstChar);
+        }
+    }
+
+    // Ensure we have at least 2 characters
+    if (initials.length < 2 && wordsToUse.length > 0) {
+        // Try to get more from the first word
+        const firstWord = wordsToUse[0];
+        if (firstWord.length >= 2) {
+            return firstWord.substring(0, 2).toUpperCase();
+        }
+    }
+
+    // Return 2-3 initials
+    const result = initials.slice(0, 3).join("");
+    return result.length >= 2 ? result : result.padEnd(2, result.charAt(0) || "W");
+}


### PR DESCRIPTION
_Not to be merged, I don't love or even like the glyphs yet, just getting a start on a possible option here._

Each workflow now displays a unique glyph combining shape-based collection theming with jdenticon-generated patterns and extracted initials. The glyphs use the Galaxy brand color palette (bay-of-many blues) for a cohesive look while providing visual distinction between workflows.

The external shape of the glyph is an indicator of what category it's in, but I don't love it as implemented.

Glyphs appear in WorkflowCard (40px/32px compact), WorkflowListItem (40px), and WorkflowContent sidebar (64px).

<img width="574" height="561" alt="image" src="https://github.com/user-attachments/assets/e1d43983-8ea2-4735-bfed-1e59c75d9411" />

This will close https://github.com/galaxyproject/iwc/issues/1057 as the last bit remaining for this cycle.

FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
