### PR TITLE
Point users to other workflow sources

### DIFF
--- a/website/src/components/WorkflowGrid.vue
+++ b/website/src/components/WorkflowGrid.vue
@@ -183,16 +183,14 @@ searchQueryStore.subscribe((value) => {
             </div>
         </Transition>
 
-        <Transition name="fade">
-            <div v-if="filteredWorkflows.length === 0" class="text-center py-12 text-chicago-500">
-                <p class="text-xl">No workflows found matching your criteria.</p>
-            </div>
-        </Transition>
-
-        <!-- Discover more workflows -->
+        <!-- External workflow sources / empty state -->
         <div
             class="mt-8 py-5 px-6 rounded-lg border border-chicago-200 bg-chicago-50 text-center text-sm text-chicago-600">
-            Find more Galaxy workflows on
+            <p v-if="filteredWorkflows.length === 0" class="text-xl text-chicago-500 mb-3">
+                No workflows found matching your criteria.
+            </p>
+            <span v-if="filteredWorkflows.length === 0">Try searching for Galaxy workflows on </span>
+            <span v-else>Find more Galaxy workflows on </span>
             <a
                 href="https://dockstore.org/search?descriptorType=Galaxy&descriptorType=gxformat2&entryType=workflows&searchMode=files"
                 target="_blank"


### PR DESCRIPTION
Adds a small banner below the workflow listing that links users to Dockstore, WorkflowHub, and the Galaxy Training Network for discovering additional Galaxy workflows

This appears at the bottom of the workflow list if you scroll all the way to the end.  Also visible if you search for something like NOSUCHWORKFLOW and there are no results, you'll see this.

<img width="993" height="205" alt="image" src="https://github.com/user-attachments/assets/beb1502b-1401-4a46-97e3-c05603b9eb34" />

<img width="946" height="223" alt="image" src="https://github.com/user-attachments/assets/34e13fcd-3313-4257-8563-358fc2675d96" />



Closes #1095

## Test plan

- [ ] Visit the homepage and verify the banner appears below the workflow grid/list
- [ ] Search for something with no results and verify the banner still appears
- [ ] Confirm all three links open correctly in new tabs