### PR TITLE
Update genes catalogue metaG WF

### DIFF
--- a/workflows/microbiome/metagenomic-genes-catalogue/CHANGELOG.md
+++ b/workflows/microbiome/metagenomic-genes-catalogue/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## [1.2] - 2025-01-13
+## [1.2.1] - 2026-02-23
+
+### Changed
+
+* Modify Quast parameter [`--max-ref-number`](https://quast.sourceforge.net/docs/manual.html#max_ref_num) from 50 to 0 because it causes error on Galaxy and the information provided with these settings is not necessarily essential.
+
+## [1.2] - 2026-01-13
 
 ### Automatic update
 

--- a/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.ga
+++ b/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.ga
@@ -4,25 +4,26 @@
     "comments": [
         {
             "child_steps": [
-                28,
-                39,
-                37,
-                34,
-                32,
-                31
+                35,
+                29,
+                26,
+                23,
+                22,
+                40,
+                25
             ],
-            "color": "green",
+            "color": "black",
             "data": {
-                "title": "Taxonomy and functional annotation"
+                "title": "MultiQC"
             },
-            "id": 3,
+            "id": 4,
             "position": [
-                3317.6,
-                1746.9
+                4596.9,
+                898.5
             ],
             "size": [
-                1281,
-                854
+                890,
+                769
             ],
             "type": "frame"
         },
@@ -75,31 +76,6 @@
         },
         {
             "child_steps": [
-                35,
-                29,
-                26,
-                23,
-                22,
-                40,
-                25
-            ],
-            "color": "black",
-            "data": {
-                "title": "MultiQC"
-            },
-            "id": 4,
-            "position": [
-                4596.9,
-                898.5
-            ],
-            "size": [
-                890,
-                769
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
                 30,
                 16,
                 38,
@@ -118,6 +94,30 @@
             "size": [
                 992.4,
                 703.9
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                28,
+                39,
+                37,
+                34,
+                32,
+                31
+            ],
+            "color": "green",
+            "data": {
+                "title": "Taxonomy and functional annotation"
+            },
+            "id": 3,
+            "position": [
+                3317.6,
+                1746.9
+            ],
+            "size": [
+                1281,
+                854
             ],
             "type": "frame"
         }
@@ -580,7 +580,7 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"advanced\": {\"contig_thresholds\": \"0,1000,5000,10000,25000,50000\", \"strict_NA\": false, \"extensive_mis_size\": \"1000\", \"scaffold_gap_max_size\": \"10000\", \"unaligned_part_size\": \"500\", \"skip_unaligned_mis_contigs\": true, \"fragmented_max_indent\": null, \"report_all_metrics\": false, \"x_for_Nx\": \"90\"}, \"alignments\": {\"use_all_alignments\": false, \"min_alignment\": \"65\", \"ambiguity_usage\": \"one\", \"ambiguity_score\": \"0.99\", \"fragmented\": false, \"upper_bound_assembly\": false, \"upper_bound_min_con\": null, \"local_mis_size\": \"200\"}, \"assembly\": {\"type\": \"metagenome\", \"__current_case__\": 1, \"ref\": {\"origin\": \"silva\", \"__current_case__\": 0, \"max_ref_num\": \"50\"}, \"reuse_combined_alignments\": false, \"min_identity\": \"95.0\"}, \"genes\": {\"gene_finding\": {\"tool\": \"none\", \"__current_case__\": 0}, \"rna_finding\": false, \"conserved_genes_finding\": false}, \"large\": false, \"min_contig\": \"1500\", \"mode\": {\"mode\": \"individual\", \"__current_case__\": 0, \"in\": {\"custom\": \"false\", \"__current_case__\": 1, \"inputs\": {\"__class__\": \"ConnectedValue\"}}, \"reads\": {\"reads_option\": \"paired_collection\", \"__current_case__\": 3, \"input_1\": {\"__class__\": \"ConnectedValue\"}}}, \"output_files\": [\"html\", \"pdf\", \"tabular\", \"log\", \"summary\"], \"split_scaffolds\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"advanced\": {\"contig_thresholds\": \"0,1000,5000,10000,25000,50000\", \"strict_NA\": false, \"extensive_mis_size\": \"1000\", \"scaffold_gap_max_size\": \"10000\", \"unaligned_part_size\": \"500\", \"skip_unaligned_mis_contigs\": true, \"fragmented_max_indent\": null, \"report_all_metrics\": false, \"x_for_Nx\": \"90\"}, \"alignments\": {\"use_all_alignments\": false, \"min_alignment\": \"65\", \"ambiguity_usage\": \"one\", \"ambiguity_score\": \"0.99\", \"fragmented\": false, \"upper_bound_assembly\": false, \"upper_bound_min_con\": null, \"local_mis_size\": \"200\"}, \"assembly\": {\"type\": \"metagenome\", \"__current_case__\": 1, \"ref\": {\"origin\": \"silva\", \"__current_case__\": 0, \"max_ref_num\": \"0\"}, \"reuse_combined_alignments\": false, \"min_identity\": \"95.0\"}, \"genes\": {\"gene_finding\": {\"tool\": \"none\", \"__current_case__\": 0}, \"rna_finding\": false, \"conserved_genes_finding\": false}, \"large\": false, \"min_contig\": \"1500\", \"mode\": {\"mode\": \"individual\", \"__current_case__\": 0, \"in\": {\"custom\": \"false\", \"__current_case__\": 1, \"inputs\": {\"__class__\": \"RuntimeValue\"}}, \"reads\": {\"reads_option\": \"paired_collection\", \"__current_case__\": 3, \"input_1\": {\"__class__\": \"RuntimeValue\"}}}, \"output_files\": [\"html\", \"pdf\", \"tabular\", \"log\", \"summary\"], \"split_scaffolds\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_version": "5.3.0+galaxy1",
             "type": "tool",
             "uuid": "bda52053-e7b0-4683-bcc1-6abaaf18d4a7",
@@ -3120,5 +3120,5 @@
     ],
     "uuid": "8f64b0be-5392-43a1-b594-d41a4dc82489",
     "version": 1,
-    "release": "1.2"
+    "release": "1.2.1"
 }


### PR DESCRIPTION
Hi, little modification changing quast --max-ref-number parameter from 50 to 0

FOR CONTRIBUTOR:
* [x] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [x] License permits unrestricted use (educational + commercial)
* [x] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
