### PR TITLE
Link GitHub URL to main IWC repo instead of mirror repos

### DIFF
--- a/scripts/workflow_manifest.py
+++ b/scripts/workflow_manifest.py
@@ -184,6 +184,7 @@ def find_and_load_compliant_workflows(directory):
                 trsID = f"#workflow/github.com/iwc-workflows/{dirname}/{workflow['name'] or 'main'}"
                 workflow["trsID"] = trsID
                 workflow["iwcID"] = create_safe_identifier(trsID)
+                workflow["repoPath"] = root
 
                 dockstore_details, categories, collections = get_dockstore_details(
                     trsID

--- a/website/src/components/WorkflowContent.vue
+++ b/website/src/components/WorkflowContent.vue
@@ -44,6 +44,11 @@ const dockstoreWorkflowPageUrl = computed(() => {
     return baseUrl + repoPath;
 });
 
+const githubWorkflowUrl = computed(() => {
+    const repoPath = props.workflow?.repoPath?.replace(/^\.\//, "");
+    return `https://github.com/galaxyproject/iwc/tree/main/${repoPath}`;
+});
+
 const doiResolverUrl = computed(() => {
     return `https://doi.org/${props.workflow?.doi}`;
 });
@@ -379,6 +384,12 @@ onMounted(() => {
                             target="_blank"
                             class="text-bay-of-many-700 hover:underline">
                             {{ workflow.trsID }} ↗
+                        </a>
+                    </li>
+                    <li>
+                        <strong class="text-ebony-clay-900">GitHub: </strong>
+                        <a :href="githubWorkflowUrl" target="_blank" class="text-bay-of-many-700 hover:underline">
+                            {{ githubWorkflowUrl }} ↗
                         </a>
                     </li>
                 </ul>

--- a/website/src/models/workflow.ts
+++ b/website/src/models/workflow.ts
@@ -49,6 +49,7 @@ export interface Workflow {
     diagram_svg?: string;
     trsID: string;
     iwcID: string;
+    repoPath: string;
     categories: string[];
     collections: string[];
     doi?: string;


### PR DESCRIPTION
## Summary

- The workflow detail sidebar previously linked to individual `iwc-workflows/*` mirror repos by parsing the TRS ID
- Now propagates the actual workflow directory path (`repoPath`) from `workflow_manifest.py` to the frontend
- GitHub link points to the workflow's folder in `galaxyproject/iwc` (e.g., `workflows/metabolomics/lcms-preprocessing`) where the README, changelog, and source files live

## Test plan

- [x] `workflow_manifest.py` regenerates with `repoPath` in each workflow JSON
- [x] All 116 E2E tests pass
- [ ] Verify GitHub link on a deployed workflow page points to correct `galaxyproject/iwc/tree/main/workflows/...` path