### PR TITLE
Fix GitHub URL overflow on mobile

### DIFF
--- a/website/src/components/WorkflowContent.vue
+++ b/website/src/components/WorkflowContent.vue
@@ -388,7 +388,7 @@ onMounted(() => {
                     </li>
                     <li>
                         <strong class="text-ebony-clay-900">GitHub: </strong>
-                        <a :href="githubWorkflowUrl" target="_blank" class="text-bay-of-many-700 hover:underline">
+                        <a :href="githubWorkflowUrl" target="_blank" class="text-bay-of-many-700 hover:underline break-all">
                             {{ githubWorkflowUrl }} ↗
                         </a>
                     </li>


### PR DESCRIPTION
## Summary

- The long GitHub URL added in #1129 doesn't wrap on mobile, forcing the sidebar container wider than the viewport and creating horizontal scroll with extra whitespace on the right
- Adds `break-all` to the GitHub link so the URL wraps within the sidebar

## Test plan

- [x] All 116 E2E tests pass
- [ ] Check workflow detail page on a narrow viewport — URL should wrap and no horizontal overflow