### PR TITLE
Fix hand-edited state in functional annotation workflow.

### DIFF
--- a/workflows/genome_annotation/functional-annotation/functional-annotation-protein-sequences/CHANGELOG.md
+++ b/workflows/genome_annotation/functional-annotation/functional-annotation-protein-sequences/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.1] - 2026-03-14
+
+### Fixed
+
+- InterProScan step: corrected inconsistent `licensed` conditional state — `__current_case__` now matches the `use: "false"` test value, removed stale `applications_licensed` data from inactive branch.
+
 ## [0.1] - 2024-12-04
 
 Initial version of the Functional annotation of protein sequence Workflow.

--- a/workflows/genome_annotation/functional-annotation/functional-annotation-protein-sequences/Functional_annotation_of_protein_sequences.ga
+++ b/workflows/genome_annotation/functional-annotation/functional-annotation-protein-sequences/Functional_annotation_of_protein_sequences.ga
@@ -39,7 +39,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.1",
+    "release": "0.1.1",
     "name": "Functional annotation of protein sequences",
     "steps": {
         "0": {


### PR DESCRIPTION
I have  hunting down ``__current_case__`` handling and figuring out how to lint workflows. This was the only case in the whole repository where ``__current_case__`` didn't match the test parameter in such a way that it couldn't be replaced outside of Galaxy so I had Claude hunt down what happened. It made me anxious in the abstract but Claude tracked down a "bug" from hand-editing. This PR seems a bit risky while providing no user or even real technical benefit other than making a future linter green - if y'all just want to close it out I'll be sure what ever linting I do implement has an exclude list and excludes this workflow - it isn't a big deal. This at least serves as documentation for why a future linting exclusion is needed.

## Summary

Fix inconsistent `licensed` conditional state in the InterProScan step of the functional-annotation-protein-sequences workflow.

Commit 088fd951d (2024-12-02) hand-edited `use` from `"true"` to `"false"` to disable licensed apps for IWC submission, but didn't update the bookkeeping fields — `__current_case__` still pointed at the `"true"` branch (index 1) and `applications_licensed` data from that branch was left behind.

### Changes
- `__current_case__`: `1` → `0` (matches `use: "false"` = When[0])
- Removed stale `applications_licensed: ["Phobius", "SignalP_EUK", "TMHMM"]` (belongs to inactive `"true"` branch)
- Bumped release to 0.1.1, updated CHANGELOG

### Impact

**Zero runtime behavior change.** Galaxy recomputes `__current_case__` from the test parameter value at load time via `get_current_case()` in `params_from_strings()`, so the stale index was already ignored during execution. This is a correctness/hygiene fix only.

---

FOR CONTRIBUTOR:
* [x] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [x] License permits unrestricted use (educational + commercial)
* [x] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [x] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [x] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [x] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [x] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [x] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [x] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [x] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [x] Changelog contains appropriate entries
* [x] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file

_Note: All reviewer items checked — this PR modifies only tool_state JSON and release metadata. No changes to inputs, outputs, labels, folder structure, README, tests, or .dockstore.yml._
