### PR TITLE
updade amr_gene_detection to 1.1.8

### DIFF
--- a/workflows/bacterial_genomics/amr_gene_detection/CHANGELOG.md
+++ b/workflows/bacterial_genomics/amr_gene_detection/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.1.8] 2026-03-15
+
+- added MultiQC to collect all tabular files and create a HTML report of them
+- added a column regex operation to remove the ignore sign of ABRicate output header to make it usable for MulitQC 
+
 ## [1.1.7] 2025-12-01
 
 ### Automatic update

--- a/workflows/bacterial_genomics/amr_gene_detection/amr_gene_detection-tests.yml
+++ b/workflows/bacterial_genomics/amr_gene_detection/amr_gene_detection-tests.yml
@@ -70,3 +70,9 @@
         text: "pointfinder_file"
       - that: "has_text"
         text: "LINCOSAMIDE"
+    multiqc_html_report:
+      asserts:
+      - that: has_text
+        text: "ABRicate virulence"
+      - that: has_text
+        text: "Staramr detailed summary"

--- a/workflows/bacterial_genomics/amr_gene_detection/amr_gene_detection.ga
+++ b/workflows/bacterial_genomics/amr_gene_detection/amr_gene_detection.ga
@@ -90,13 +90,7 @@
             "type": "parameter_input",
             "uuid": "f9a2fabf-4c0a-4ff2-8588-30ca77501dce",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "32da2b40-db44-461c-b6d8-c00ab2ac96ac"
-                }
-            ]
+            "workflow_outputs": []
         },
         "2": {
             "annotation": "Select species for point mutation analysis using PointFinder database",
@@ -123,13 +117,7 @@
             "type": "parameter_input",
             "uuid": "ef73bbee-433b-41fb-a20f-a9d6937ef94f",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "f626cf2d-76ef-4cf9-b20f-e6809e59f4ee"
-                }
-            ]
+            "workflow_outputs": []
         },
         "3": {
             "annotation": "Select the database to identify resistance-associated point mutations with AMRFinderPlus.",
@@ -156,13 +144,7 @@
             "type": "parameter_input",
             "uuid": "b2116f39-b5bb-48bb-b346-f7688a6ad908",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "9f15c1cb-3145-4c24-b2c7-08a835efc56f"
-                }
-            ]
+            "workflow_outputs": []
         },
         "4": {
             "annotation": "Select the database to identify AMR genes with AMRFinderPlus.",
@@ -189,13 +171,7 @@
             "type": "parameter_input",
             "uuid": "dc226880-eb76-4588-a823-6ed24e0947ab",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "8daa41ef-ec89-45e2-a9c5-1279a8f1e0f1"
-                }
-            ]
+            "workflow_outputs": []
         },
         "5": {
             "annotation": "Select the database to identify virulence genes with ABRicate.",
@@ -222,13 +198,7 @@
             "type": "parameter_input",
             "uuid": "5777ef56-176c-46f8-a597-9b5c3cc30666",
             "when": null,
-            "workflow_outputs": [
-                {
-                    "label": null,
-                    "output_name": "output",
-                    "uuid": "69305014-cf62-46a9-b2c9-29c5ab07a8d4"
-                }
-            ]
+            "workflow_outputs": []
         },
         "6": {
             "annotation": "staramr_amr_genes",
@@ -435,6 +405,7 @@
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"advanced\": {\"pid_threshold\": \"90.0\", \"percent_length_overlap_resfinder\": \"60.0\", \"percent_length_overlap_pointfinder\": \"95.0\", \"percent_length_overlap_plasmidfinder\": \"60.0\", \"genome_size_lower_bound\": \"4000000\", \"genome_size_upper_bound\": \"6000000\", \"minimum_N50_value\": \"10000\", \"minimum_contig_length\": \"300\", \"unacceptable_number_contigs\": \"1000\", \"report_all_blast\": false, \"exclude_negatives\": false, \"exclude_resistance_phenotypes\": false, \"mlst_scheme\": \"auto\", \"exclude_genes\": {\"exclude_genes_condition\": \"default\", \"__current_case__\": 0}, \"complex_mutations_file\": {\"__class__\": \"RuntimeValue\"}, \"plasmidfinder_type\": \"include_all\"}, \"genomes\": {\"__class__\": \"ConnectedValue\"}, \"hide_db_build\": \"\", \"output_files\": {\"output_selection\": [\"mlst_table\", \"summary_table\", \"detailed_summary_table\", \"resfinder_table\", \"plasmidfinder_table\", \"pointfinder_table\", \"settings_output\", \"excel_output\"]}, \"pointfinder_organism\": {\"__class__\": \"ConnectedValue\"}, \"staramr_db_select\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
             "tool_version": "0.11.0+galaxy3",
             "type": "tool",
             "uuid": "2064188a-099d-493e-b8f3-009bec482010",
@@ -563,6 +534,7 @@
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"input_option\": {\"amrfinder_db_select\": {\"__class__\": \"ConnectedValue\"}, \"input_mode\": {\"input_select\": \"nucleotide\", \"__current_case__\": 0, \"nucleotide_input\": {\"__class__\": \"ConnectedValue\"}, \"nucleotide_flank5_size\": \"0\"}}, \"options\": {\"ident_min\": \"-1.0\", \"coverage_min\": \"0.5\", \"translation_table\": \"11\", \"plus\": true, \"report_all_equal\": true, \"print_node\": true, \"name\": null}, \"organism_options\": {\"organism_conditionnal\": {\"organism_select\": \"add_organism\", \"__current_case__\": 0, \"organism\": {\"__class__\": \"ConnectedValue\"}, \"mutation_all\": true, \"report_common\": true}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
             "tool_version": "3.12.8+galaxy0",
             "type": "tool",
             "uuid": "3d2100c6-3604-4a81-b0fb-b9fe892d6837",
@@ -615,8 +587,8 @@
                 }
             ],
             "position": {
-                "left": 885.033177397046,
-                "top": 418.3886430778367
+                "left": 896.9776795276849,
+                "top": 435.8350732453179
             },
             "post_job_actions": {
                 "RenameDatasetActionreport": {
@@ -636,12 +608,13 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/abricate/abricate/1.0.1",
             "tool_shed_repository": {
-                "changeset_revision": "c2ef298da409",
+                "changeset_revision": "3f3e247c053d",
                 "name": "abricate",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"adv\": {\"db\": {\"__class__\": \"ConnectedValue\"}, \"no_header\": false, \"min_dna_id\": \"80.0\", \"min_cov\": \"80.0\"}, \"file_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
             "tool_version": "1.0.1",
             "type": "tool",
             "uuid": "53f1d92c-33de-4e75-aff3-e3f199256cdf",
@@ -655,10 +628,55 @@
             ]
         },
         "9": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regexColumn1/1.0.3",
+            "errors": null,
+            "id": 9,
+            "input_connections": {
+                "input": {
+                    "id": 8,
+                    "output_name": "report"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Column Regex Find And Replace",
+                    "name": "input"
+                }
+            ],
+            "label": null,
+            "name": "Column Regex Find And Replace",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1160.4702521427355,
+                "top": 501.31530292042527
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regexColumn1/1.0.3",
+            "tool_shed_repository": {
+                "changeset_revision": "503bcd6ebe4b",
+                "name": "regex_find_replace",
+                "owner": "galaxyp",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"checks\": [{\"__index__\": 0, \"pattern\": \"#FILE\", \"replacement\": \"FILE\"}], \"field\": \"1\", \"input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "1.0.3",
+            "type": "tool",
+            "uuid": "a63066ff-876e-4086-9ff2-d537fe1e3658",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "10": {
             "annotation": "ToolDistillator extracts results from tools and creates a JSON file for each tool",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator/tooldistillator/1.0.4+galaxy0",
             "errors": null,
-            "id": 9,
+            "id": 10,
             "input_connections": {
                 "tool_section|tools_0|select_tool|input": {
                     "id": 8,
@@ -715,8 +733,8 @@
                 }
             ],
             "position": {
-                "left": 1138.6692404030955,
-                "top": 661.2511784209886
+                "left": 1369.9595468127886,
+                "top": 650.8281443642051
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput_json": {
@@ -742,6 +760,7 @@
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"log\": false, \"tool_section\": {\"tools\": [{\"__index__\": 0, \"select_tool\": {\"tool_list\": \"abricate\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"select_tool\": {\"tool_list\": \"staramr\", \"__current_case__\": 37, \"input\": {\"__class__\": \"ConnectedValue\"}, \"mlst_file_path\": {\"__class__\": \"ConnectedValue\"}, \"plasmidfinder_file_path\": {\"__class__\": \"RuntimeValue\"}, \"pointfinder_file_path\": {\"__class__\": \"ConnectedValue\"}, \"setting_file_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"select_tool\": {\"tool_list\": \"amrfinderplus\", \"__current_case__\": 1, \"input\": {\"__class__\": \"ConnectedValue\"}, \"point_mutation_report_path\": {\"__class__\": \"ConnectedValue\"}, \"nucleotide_sequence_path\": {\"__class__\": \"ConnectedValue\"}, \"origin\": {\"origin\": \"false\", \"__current_case__\": 1}, \"reference_database_version\": {\"__class__\": \"ConnectedValue\"}}}]}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
             "tool_version": "1.0.4+galaxy0",
             "type": "tool",
             "uuid": "edaa1551-44b3-4714-a249-fd44f35cc370",
@@ -754,14 +773,101 @@
                 }
             ]
         },
-        "10": {
+        "11": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.33+galaxy0",
+            "errors": null,
+            "id": 11,
+            "input_connections": {
+                "results_0|software_cond|input": {
+                    "id": 6,
+                    "output_name": "detailed_summary"
+                },
+                "results_1|software_cond|input": {
+                    "id": 6,
+                    "output_name": "resfinder"
+                },
+                "results_2|software_cond|input": {
+                    "id": 6,
+                    "output_name": "plasmidfinder"
+                },
+                "results_3|software_cond|input": {
+                    "id": 6,
+                    "output_name": "pointfinder"
+                },
+                "results_4|software_cond|input": {
+                    "id": 7,
+                    "output_name": "amrfinderplus_report"
+                },
+                "results_5|software_cond|input": {
+                    "id": 7,
+                    "output_name": "mutation_all_report"
+                },
+                "results_6|software_cond|input": {
+                    "id": 9,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool MultiQC",
+                    "name": "image_content_input"
+                }
+            ],
+            "label": null,
+            "name": "MultiQC",
+            "outputs": [
+                {
+                    "name": "html_report",
+                    "type": "html"
+                },
+                {
+                    "name": "stats",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 1467.7344906405215,
+                "top": 216.01291805145792
+            },
+            "post_job_actions": {
+                "TagDatasetActionhtml_report": {
+                    "action_arguments": {
+                        "tags": "multiqc_html_report"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "html_report"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.33+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "26ee5e11ecbe",
+                "name": "multiqc",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"image_content_input\": {\"__class__\": \"RuntimeValue\"}, \"png_plots\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 48, \"plot_type\": \"table\", \"section_name\": \"Staramr detailed summary\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 48, \"plot_type\": \"table\", \"section_name\": \"Staramr resfinder\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 48, \"plot_type\": \"table\", \"section_name\": \"Staramr plasmidfinder\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 3, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 48, \"plot_type\": \"table\", \"section_name\": \"Staramr pointfinder \", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 4, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 48, \"plot_type\": \"table\", \"section_name\": \"AMRFinderPlus report\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 5, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 48, \"plot_type\": \"table\", \"section_name\": \"ARMFinderPlus mutation\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 6, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 48, \"plot_type\": \"table\", \"section_name\": \"ABRicate virulence\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}], \"title\": \"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "1.33+galaxy0",
+            "type": "tool",
+            "uuid": "fe04fa42-4566-45a5-8a3e-065425c80dfa",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "multiqc_html_report",
+                    "output_name": "multiqc_html_report",
+                    "uuid": "4ac5518b-f96f-437e-bc48-909c7d457144"
+                }
+            ]
+        },
+        "12": {
             "annotation": "ToolDistillator summarize groups all JSON file into a unique JSON file",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/tooldistillator_summarize/tooldistillator_summarize/1.0.4+galaxy0",
             "errors": null,
-            "id": 10,
+            "id": 12,
             "input_connections": {
                 "summarize_data": {
-                    "id": 9,
+                    "id": 10,
                     "output_name": "output_json"
                 }
             },
@@ -775,8 +881,8 @@
                 }
             ],
             "position": {
-                "left": 1510.406873337906,
-                "top": 911.3969486227988
+                "left": 1701.4455227163824,
+                "top": 911.3906299568054
             },
             "post_job_actions": {
                 "RenameDatasetActionsummary_json": {
@@ -802,6 +908,7 @@
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"summarize_data\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
             "tool_version": "1.0.4+galaxy0",
             "type": "tool",
             "uuid": "7b4072b0-8d8c-40ad-999b-d98eafcdccd4",
@@ -826,7 +933,7 @@
         "AMR",
         "AMR-detection"
     ],
-    "uuid": "284cc748-7532-4749-8f68-d19d41c048ef",
+    "uuid": "e3da62ad-1fb2-4a4d-bd2a-0747af49ef8d",
     "version": 1,
-    "release": "1.1.7"
+    "release": "1.1.8"
 }


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [x] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [x] License permits unrestricted use (educational + commercial)
* [x] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
