### PR TITLE
Clean ploidy-aware genotype calling workflow stale state.

### DIFF
--- a/workflows/variant-calling/ploidy-aware-genotype-calling/genotype-variant-calling-wgs-pe.ga
+++ b/workflows/variant-calling/ploidy-aware-genotype-calling/genotype-variant-calling-wgs-pe.ga
@@ -252,7 +252,88 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"duplicated_reads\": {\"handling_options\": {\"eval_dups\": \"--dont_eval_duplication\", \"__current_case__\": 0}}, \"filter_options\": {\"quality_filtering_options\": {\"disable_quality_filtering\": false, \"qualified_quality_phred\": null, \"unqualified_percent_limit\": null, \"n_base_limit\": null}, \"length_filtering_options\": {\"disable_length_filtering\": false, \"length_required\": null, \"length_limit\": null}, \"low_complexity_filter\": {\"enable_low_complexity_filter\": false, \"complexity_threshold\": null}}, \"output_options\": {\"report_html\": true, \"report_json\": true}, \"overrepresented_sequence_analysis\": {\"overrepresentation_analysis\": false, \"overrepresentation_sampling\": null}, \"read_mod_options\": {\"polyg_tail_trimming\": {\"trimming_select\": \"\", \"__current_case__\": 1, \"poly_g_min_len\": null}, \"polyx_tail_trimming\": {\"polyx_trimming_select\": \"\", \"__current_case__\": 1}, \"umi_processing\": {\"umi\": false, \"umi_loc\": null, \"umi_len\": null, \"umi_prefix\": null}, \"cutting_by_quality_options\": {\"cut_front_select\": {\"cut_front\": \"\", \"__current_case__\": 1}, \"cut_tail_select\": {\"cut_tail\": \"\", \"__current_case__\": 1}, \"cut_right_select\": {\"cut_right\": \"\", \"__current_case__\": 1}}, \"base_correction_options\": {\"correction\": false}}, \"single_paired\": {\"single_paired_selector\": \"paired_collection\", \"__current_case__\": 1, \"paired_input\": {\"__class__\": \"ConnectedValue\"}, \"merge_reads\": {\"merge\": \"\", \"__current_case__\": 1}, \"adapter_trimming_options\": {\"disable_adapter_trimming\": false, \"adapter_sequence1\": null, \"adapter_sequence2\": null, \"detect_adapter_for_pe\": false}, \"global_trimming_options\": {\"trim_front1\": null, \"trim_tail1\": null, \"trim_front2\": null, \"trim_tail2\": null}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": {
+                "duplicated_reads": {
+                    "handling_options": {
+                        "eval_dups": "--dont_eval_duplication"
+                    }
+                },
+                "filter_options": {
+                    "quality_filtering_options": {
+                        "disable_quality_filtering": false,
+                        "qualified_quality_phred": null,
+                        "unqualified_percent_limit": null,
+                        "n_base_limit": null
+                    },
+                    "length_filtering_options": {
+                        "disable_length_filtering": false,
+                        "length_required": null,
+                        "length_limit": null
+                    },
+                    "low_complexity_filter": {
+                        "enable_low_complexity_filter": false,
+                        "complexity_threshold": null
+                    }
+                },
+                "output_options": {
+                    "report_html": true,
+                    "report_json": true
+                },
+                "overrepresented_sequence_analysis": {
+                    "overrepresentation_analysis": false,
+                    "overrepresentation_sampling": null
+                },
+                "read_mod_options": {
+                    "polyg_tail_trimming": {
+                        "trimming_select": "",
+                        "poly_g_min_len": null
+                    },
+                    "polyx_tail_trimming": {
+                        "polyx_trimming_select": ""
+                    },
+                    "umi_processing": {
+                        "umi": false,
+                        "umi_loc": null,
+                        "umi_len": null,
+                        "umi_prefix": null
+                    },
+                    "cutting_by_quality_options": {
+                        "cut_front_select": {
+                            "cut_front": ""
+                        },
+                        "cut_tail_select": {
+                            "cut_tail": ""
+                        },
+                        "cut_right_select": {
+                            "cut_right": ""
+                        }
+                    },
+                    "base_correction_options": {
+                        "correction": false
+                    }
+                },
+                "single_paired": {
+                    "single_paired_selector": "paired_collection",
+                    "paired_input": {
+                        "__class__": "ConnectedValue"
+                    },
+                    "merge_reads": {
+                        "merge": ""
+                    },
+                    "adapter_trimming_options": {
+                        "disable_adapter_trimming": false,
+                        "adapter_sequence1": null,
+                        "adapter_sequence2": null,
+                        "detect_adapter_for_pe": false
+                    },
+                    "global_trimming_options": {
+                        "trim_front1": null,
+                        "trim_tail1": null,
+                        "trim_front2": null,
+                        "trim_tail2": null
+                    }
+                }
+            },
             "tool_uuid": null,
             "tool_version": "1.1.0+galaxy0",
             "type": "tool",
@@ -307,7 +388,22 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"codon_table\": \"Standard\", \"genome_version\": \"snpeff_db\", \"input_type\": {\"input_type_selector\": \"gtf\", \"__current_case__\": 2, \"input\": {\"__class__\": \"ConnectedValue\"}, \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"input_fasta\": {\"__class__\": \"ConnectedValue\"}}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": {
+                "codon_table": "Standard",
+                "genome_version": "snpeff_db",
+                "input_type": {
+                    "input_type_selector": "gtf",
+                    "input": {
+                        "__class__": "ConnectedValue"
+                    },
+                    "reference_source": {
+                        "reference_source_selector": "history",
+                        "input_fasta": {
+                            "__class__": "ConnectedValue"
+                        }
+                    }
+                }
+            },
             "tool_uuid": null,
             "tool_version": "5.2+galaxy1",
             "type": "tool",
@@ -360,7 +456,29 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"analysis_type\": {\"analysis_type_selector\": \"illumina\", \"__current_case__\": 0}, \"fastq_input\": {\"fastq_input_selector\": \"paired_collection\", \"__current_case__\": 2, \"fastq_input1\": {\"__class__\": \"ConnectedValue\"}, \"iset_stats\": null}, \"output_sort\": \"coordinate\", \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"ConnectedValue\"}, \"index_a\": \"auto\"}, \"rg\": {\"rg_selector\": \"do_not_set\", \"__current_case__\": 3}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": {
+                "analysis_type": {
+                    "analysis_type_selector": "illumina"
+                },
+                "fastq_input": {
+                    "fastq_input_selector": "paired_collection",
+                    "fastq_input1": {
+                        "__class__": "ConnectedValue"
+                    },
+                    "iset_stats": null
+                },
+                "output_sort": "coordinate",
+                "reference_source": {
+                    "reference_source_selector": "history",
+                    "ref_file": {
+                        "__class__": "ConnectedValue"
+                    },
+                    "index_a": "auto"
+                },
+                "rg": {
+                    "rg_selector": "do_not_set"
+                }
+            },
             "tool_uuid": null,
             "tool_version": "0.7.19",
             "type": "tool",
@@ -408,7 +526,59 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"mode\": {\"outtype\": \"selected_reads\", \"__current_case__\": 1, \"filter_config\": {\"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cond_rg\": {\"select_rg\": \"no\", \"__current_case__\": 0}, \"cond_expr\": {\"select_expr\": \"no\", \"__current_case__\": 0}, \"quality\": null, \"library\": null, \"cigarcons\": null, \"inclusive_filter\": [\"1\", \"2\"], \"exclusive_filter\": null, \"exclusive_filter_all\": null, \"tag\": null, \"qname_file\": {\"__class__\": \"RuntimeValue\"}}, \"subsample_config\": {\"subsampling_mode\": {\"select_subsample\": \"fraction\", \"__current_case__\": 0, \"factor\": \"1.0\", \"seed\": null}}, \"output_options\": {\"reads_report_type\": \"retained\", \"__current_case__\": 0, \"complementary_output\": false, \"adv_output\": {\"readtags\": [], \"collapsecigar\": false}, \"output_format\": {\"oformat\": \"bam\", \"__current_case__\": 2}}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": {
+                "addref_cond": {
+                    "addref_select": "no"
+                },
+                "input": {
+                    "__class__": "ConnectedValue"
+                },
+                "mode": {
+                    "outtype": "selected_reads",
+                    "filter_config": {
+                        "cond_region": {
+                            "select_region": "no"
+                        },
+                        "cond_rg": {
+                            "select_rg": "no"
+                        },
+                        "cond_expr": {
+                            "select_expr": "no"
+                        },
+                        "quality": null,
+                        "library": null,
+                        "cigarcons": null,
+                        "inclusive_filter": [
+                            "1",
+                            "2"
+                        ],
+                        "exclusive_filter": null,
+                        "exclusive_filter_all": null,
+                        "tag": null,
+                        "qname_file": {
+                            "__class__": "RuntimeValue"
+                        }
+                    },
+                    "subsample_config": {
+                        "subsampling_mode": {
+                            "select_subsample": "fraction",
+                            "factor": "1.0",
+                            "seed": null
+                        }
+                    },
+                    "output_options": {
+                        "reads_report_type": "retained",
+                        "complementary_output": false,
+                        "adv_output": {
+                            "readtags": [],
+                            "collapsecigar": false
+                        },
+                        "output_format": {
+                            "oformat": "bam"
+                        }
+                    }
+                }
+            },
             "tool_uuid": null,
             "tool_version": "1.22+galaxy1",
             "type": "tool",
@@ -448,7 +618,36 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"addref_cond\": {\"addref_select\": \"no\", \"__current_case__\": 0}, \"cond_region\": {\"select_region\": \"no\", \"__current_case__\": 0}, \"cov_threshold\": null, \"coverage_cond\": {\"coverage_select\": \"no\", \"__current_case__\": 0}, \"filter_by_flags\": {\"filter_flags\": \"nofilter\", \"__current_case__\": 1}, \"gc_depth\": null, \"input\": {\"__class__\": \"ConnectedValue\"}, \"insert_size\": null, \"most_inserts\": null, \"read_group\": null, \"read_length\": null, \"remove_dups\": false, \"remove_overlaps\": false, \"sparse\": false, \"split_output_cond\": {\"split_output_selector\": \"no\", \"__current_case__\": 0}, \"trim_quality\": null, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": {
+                "addref_cond": {
+                    "addref_select": "no"
+                },
+                "cond_region": {
+                    "select_region": "no"
+                },
+                "cov_threshold": null,
+                "coverage_cond": {
+                    "coverage_select": "no"
+                },
+                "filter_by_flags": {
+                    "filter_flags": "nofilter"
+                },
+                "gc_depth": null,
+                "input": {
+                    "__class__": "ConnectedValue"
+                },
+                "insert_size": null,
+                "most_inserts": null,
+                "read_group": null,
+                "read_length": null,
+                "remove_dups": false,
+                "remove_overlaps": false,
+                "sparse": false,
+                "split_output_cond": {
+                    "split_output_selector": "no"
+                },
+                "trim_quality": null
+            },
             "tool_uuid": null,
             "tool_version": "2.0.8",
             "type": "tool",
@@ -492,7 +691,19 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"assume_sorted\": true, \"barcode_tag\": null, \"comments\": [], \"duplicate_scoring_strategy\": \"SUM_OF_BASE_QUALITIES\", \"inputFile\": {\"__class__\": \"ConnectedValue\"}, \"optical_duplicate_pixel_distance\": \"100\", \"read_name_regex\": \"\", \"remove_duplicates\": true, \"validation_stringency\": \"LENIENT\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": {
+                "assume_sorted": true,
+                "barcode_tag": null,
+                "comments": [],
+                "duplicate_scoring_strategy": "SUM_OF_BASE_QUALITIES",
+                "inputFile": {
+                    "__class__": "ConnectedValue"
+                },
+                "optical_duplicate_pixel_distance": "100",
+                "read_name_regex": "",
+                "remove_duplicates": true,
+                "validation_stringency": "LENIENT"
+            },
             "tool_uuid": null,
             "tool_version": "3.1.1.0",
             "type": "tool",
@@ -562,7 +773,54 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"image_content_input\": {\"__class__\": \"RuntimeValue\"}, \"png_plots\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"fastp\", \"__current_case__\": 7, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"samtools\", \"__current_case__\": 24, \"output\": [{\"__index__\": 0, \"type\": {\"type\": \"stats\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}}]}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"picard\", \"__current_case__\": 17, \"output\": [{\"__index__\": 0, \"type\": \"markdups\", \"input\": {\"__class__\": \"ConnectedValue\"}}]}}], \"title\": \"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": {
+                "comment": "",
+                "export": false,
+                "flat": false,
+                "image_content_input": {
+                    "__class__": "RuntimeValue"
+                },
+                "png_plots": false,
+                "results": [
+                    {
+                        "software_cond": {
+                            "software": "fastp",
+                            "input": {
+                                "__class__": "ConnectedValue"
+                            }
+                        }
+                    },
+                    {
+                        "software_cond": {
+                            "software": "samtools",
+                            "output": [
+                                {
+                                    "type": {
+                                        "type": "stats",
+                                        "input": {
+                                            "__class__": "ConnectedValue"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "software_cond": {
+                            "software": "picard",
+                            "output": [
+                                {
+                                    "type": "markdups",
+                                    "input": {
+                                        "__class__": "ConnectedValue"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "title": ""
+            },
             "tool_uuid": null,
             "tool_version": "1.33+galaxy0",
             "type": "tool",
@@ -621,7 +879,66 @@
                 "owner": "devteam",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"coverage_options\": {\"coverage_options_selector\": \"do_not_set\", \"__current_case__\": 1}, \"options_type\": {\"options_type_selector\": \"full\", \"__current_case__\": 0, \"optional_inputs\": {\"optional_inputs_selector\": \"do_not_set\", \"__current_case__\": 1}, \"reporting\": {\"reporting_selector\": \"do_not_set\", \"__current_case__\": 1}, \"population_model\": {\"population_model_selector\": \"set\", \"__current_case__\": 0, \"T\": \"0.001\", \"P\": {\"__class__\": \"ConnectedValue\"}, \"J\": false, \"K\": false}, \"reference_allele\": {\"reference_allele_selector\": \"do_not_set\", \"__current_case__\": 1}, \"allele_scope\": {\"allele_scope_selector\": \"do_not_set\", \"__current_case__\": 1}, \"O\": false, \"input_filters\": {\"input_filters_selector\": \"do_not_set\", \"__current_case__\": 1}, \"population_mappability_priors\": {\"population_mappability_priors_selector\": \"do_not_set\", \"__current_case__\": 1}, \"genotype_likelihoods\": {\"genotype_likelihoods_selector\": \"do_not_set\", \"__current_case__\": 1}, \"algorithmic_features\": {\"algorithmic_features_selector\": \"do_not_set\", \"__current_case__\": 1}}, \"output_options\": {\"flavor\": \"vcf\", \"__current_case__\": 0}, \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"batchmode\": {\"processmode\": \"merge\", \"__current_case__\": 1, \"input_bams\": {\"__class__\": \"ConnectedValue\"}}, \"ref_file\": {\"__class__\": \"ConnectedValue\"}}, \"target_limit_type\": {\"target_limit_type_selector\": \"do_not_limit\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": {
+                "coverage_options": {
+                    "coverage_options_selector": "do_not_set"
+                },
+                "options_type": {
+                    "options_type_selector": "full",
+                    "optional_inputs": {
+                        "optional_inputs_selector": "do_not_set"
+                    },
+                    "reporting": {
+                        "reporting_selector": "do_not_set"
+                    },
+                    "population_model": {
+                        "population_model_selector": "set",
+                        "T": "0.001",
+                        "P": {
+                            "__class__": "ConnectedValue"
+                        },
+                        "J": false,
+                        "K": false
+                    },
+                    "reference_allele": {
+                        "reference_allele_selector": "do_not_set"
+                    },
+                    "allele_scope": {
+                        "allele_scope_selector": "do_not_set"
+                    },
+                    "O": false,
+                    "input_filters": {
+                        "input_filters_selector": "do_not_set"
+                    },
+                    "population_mappability_priors": {
+                        "population_mappability_priors_selector": "do_not_set"
+                    },
+                    "genotype_likelihoods": {
+                        "genotype_likelihoods_selector": "do_not_set"
+                    },
+                    "algorithmic_features": {
+                        "algorithmic_features_selector": "do_not_set"
+                    }
+                },
+                "output_options": {
+                    "flavor": "vcf"
+                },
+                "reference_source": {
+                    "reference_source_selector": "history",
+                    "batchmode": {
+                        "processmode": "merge",
+                        "input_bams": {
+                            "__class__": "ConnectedValue"
+                        }
+                    },
+                    "ref_file": {
+                        "__class__": "ConnectedValue"
+                    }
+                },
+                "target_limit_type": {
+                    "target_limit_type_selector": "do_not_limit"
+                }
+            },
             "tool_uuid": null,
             "tool_version": "1.3.10+galaxy1",
             "type": "tool",
@@ -676,7 +993,43 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"atomization\": \"\", \"check_ref\": \"w\", \"input_file\": {\"__class__\": \"ConnectedValue\"}, \"multiallelics\": {\"mode\": \"-\", \"__current_case__\": 1, \"multiallelic_types\": \"both\"}, \"normalize_indels\": true, \"old_rec_tag\": \"\", \"output_type\": \"v\", \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"fasta_ref\": {\"__class__\": \"ConnectedValue\"}}, \"rm_dup\": \"\", \"sec_default\": {\"site_win\": \"1000\", \"sort\": \"pos\"}, \"sec_filter_norm\": {\"include\": null, \"exclude\": null}, \"sec_restrict\": {\"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"targets\": {\"targets_src\": \"__none__\", \"__current_case__\": 0}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": {
+                "atomization": "",
+                "check_ref": "w",
+                "input_file": {
+                    "__class__": "ConnectedValue"
+                },
+                "multiallelics": {
+                    "mode": "-",
+                    "multiallelic_types": "both"
+                },
+                "normalize_indels": true,
+                "old_rec_tag": "",
+                "output_type": "v",
+                "reference_source": {
+                    "reference_source_selector": "history",
+                    "fasta_ref": {
+                        "__class__": "ConnectedValue"
+                    }
+                },
+                "rm_dup": "",
+                "sec_default": {
+                    "site_win": "1000",
+                    "sort": "pos"
+                },
+                "sec_filter_norm": {
+                    "include": null,
+                    "exclude": null
+                },
+                "sec_restrict": {
+                    "regions": {
+                        "regions_src": "__none__"
+                    },
+                    "targets": {
+                        "targets_src": "__none__"
+                    }
+                }
+            },
             "tool_uuid": null,
             "tool_version": "1.22+galaxy0",
             "type": "tool",
@@ -745,7 +1098,50 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"annotations\": [\"-formatEff\", \"-classic\"], \"chr\": null, \"csvStats\": false, \"filter\": {\"specificEffects\": \"no\", \"__current_case__\": 0}, \"filterOut\": [\"-no-downstream\", \"-no-intergenic\", \"-no-intron\", \"-no-utr\", \"-no-upstream\"], \"generate_gene_stats\": false, \"generate_stats\": true, \"input\": {\"__class__\": \"ConnectedValue\"}, \"inputFormat\": \"vcf\", \"intervals\": {\"__class__\": \"RuntimeValue\"}, \"noLog\": true, \"outputFormat\": \"vcf\", \"snpDb\": {\"genomeSrc\": \"custom\", \"__current_case__\": 3, \"snpeff_db\": {\"__class__\": \"ConnectedValue\"}, \"codon_table\": \"Standard\"}, \"spliceRegion\": {\"setSpliceRegions\": \"no\", \"__current_case__\": 0}, \"spliceSiteSize\": \"2\", \"transcripts\": {\"__class__\": \"RuntimeValue\"}, \"udLength\": \"0\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": {
+                "annotations": [
+                    "-formatEff",
+                    "-classic"
+                ],
+                "chr": null,
+                "csvStats": false,
+                "filter": {
+                    "specificEffects": "no"
+                },
+                "filterOut": [
+                    "-no-downstream",
+                    "-no-intergenic",
+                    "-no-intron",
+                    "-no-utr",
+                    "-no-upstream"
+                ],
+                "generate_gene_stats": false,
+                "generate_stats": true,
+                "input": {
+                    "__class__": "ConnectedValue"
+                },
+                "inputFormat": "vcf",
+                "intervals": {
+                    "__class__": "RuntimeValue"
+                },
+                "noLog": true,
+                "outputFormat": "vcf",
+                "snpDb": {
+                    "genomeSrc": "custom",
+                    "snpeff_db": {
+                        "__class__": "ConnectedValue"
+                    },
+                    "codon_table": "Standard"
+                },
+                "spliceRegion": {
+                    "setSpliceRegions": "no"
+                },
+                "spliceSiteSize": "2",
+                "transcripts": {
+                    "__class__": "RuntimeValue"
+                },
+                "udLength": "0"
+            },
             "tool_uuid": null,
             "tool_version": "5.2+galaxy1",
             "type": "tool",
@@ -801,7 +1197,15 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"empty_text\": \".\", \"extract\": \"CHROM POS FILTER REF ALT DP AF RO AO SRP SAP EFF[*].IMPACT EFF[*].FUNCLASS EFF[*].EFFECT EFF[*].GENE EFF[*].CODON EFF[*].AA EFF[*].TRID\", \"input\": {\"__class__\": \"RuntimeValue\"}, \"one_effect_per_line\": true, \"separator\": \",\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": {
+                "empty_text": ".",
+                "extract": "CHROM POS FILTER REF ALT DP AF RO AO SRP SAP EFF[*].IMPACT EFF[*].FUNCLASS EFF[*].EFFECT EFF[*].GENE EFF[*].CODON EFF[*].AA EFF[*].TRID",
+                "input": {
+                    "__class__": "RuntimeValue"
+                },
+                "one_effect_per_line": true,
+                "separator": ","
+            },
             "tool_uuid": null,
             "tool_version": "4.3+t.galaxy0",
             "type": "tool",
@@ -854,7 +1258,16 @@
                 "owner": "nml",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"filename\": {\"add_name\": true, \"__current_case__\": 0, \"place_name\": \"same_multiple\"}, \"input_list\": {\"__class__\": \"RuntimeValue\"}, \"one_header\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": {
+                "filename": {
+                    "add_name": true,
+                    "place_name": "same_multiple"
+                },
+                "input_list": {
+                    "__class__": "RuntimeValue"
+                },
+                "one_header": true
+            },
             "tool_uuid": null,
             "tool_version": "5.1.0",
             "type": "tool",


### PR DESCRIPTION
Remove 83 stale tool_state keys (bookkeeping: __page__, __rerun_remap_job_id__, __current_case__, __index__) from 12 tool steps. Tool state now written as proper JSON dicts instead of double-encoded strings for readability and diffability.

So legible 👀 - oh my god. For writing I would still want format2 but for small PR reviews this feels like a big win. 