### PR TITLE
Clean functional annotation workflow stale state

### DIFF
--- a/workflows/genome_annotation/functional-annotation/functional-annotation-protein-sequences/Functional_annotation_of_protein_sequences.ga
+++ b/workflows/genome_annotation/functional-annotation/functional-annotation-protein-sequences/Functional_annotation_of_protein_sequences.ga
@@ -105,7 +105,43 @@
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__input_ext\": \"input\", \"applications\": [\"TIGRFAM\", \"FunFam\", \"SFLD\", \"SUPERFAMILY\", \"PANTHER\", \"Gene3D\", \"Hamap\", \"PrositeProfiles\", \"Coils\", \"SMART\", \"CDD\", \"PRINTS\", \"PIRSR\", \"PrositePatterns\", \"AntiFam\", \"Pfam\", \"MobiDBLite\", \"PIRSF\"], \"chromInfo\": \"/shared/ifbstor1/galaxy/mutable-config/tool-data/shared/ucsc/chrom/?.len\", \"database\": \"5.59-91.0\", \"goterms\": true, \"input\": {\"__class__\": \"ConnectedValue\"}, \"iprlookup\": false, \"licensed\": {\"use\": \"false\", \"__current_case__\": 1, \"applications_licensed\": [\"Phobius\", \"SignalP_EUK\", \"TMHMM\"]}, \"oformat\": [\"TSV\", \"XML\"], \"pathways\": true, \"seqtype\": \"p\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": {
+                "applications": [
+                    "TIGRFAM",
+                    "FunFam",
+                    "SFLD",
+                    "SUPERFAMILY",
+                    "PANTHER",
+                    "Gene3D",
+                    "Hamap",
+                    "PrositeProfiles",
+                    "Coils",
+                    "SMART",
+                    "CDD",
+                    "PRINTS",
+                    "PIRSR",
+                    "PrositePatterns",
+                    "AntiFam",
+                    "Pfam",
+                    "MobiDBLite",
+                    "PIRSF"
+                ],
+                "database": "5.59-91.0",
+                "goterms": true,
+                "input": {
+                    "__class__": "ConnectedValue"
+                },
+                "iprlookup": false,
+                "licensed": {
+                    "use": "false"
+                },
+                "oformat": [
+                    "TSV",
+                    "XML"
+                ],
+                "pathways": true,
+                "seqtype": "p"
+            },
             "tool_version": "5.59-91.0+galaxy3",
             "type": "tool",
             "uuid": "36d72511-ef8c-42ab-8944-b7aef340a9bc",
@@ -159,7 +195,43 @@
                 "owner": "galaxyp",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__input_ext\": \"input\", \"annotation_options\": {\"no_annot\": \"\", \"__current_case__\": 0, \"seed_ortholog_evalue\": \"0.001\", \"seed_ortholog_score\": null, \"tax_scope\": null, \"target_orthologs\": \"all\", \"go_evidence\": \"non-electronic\"}, \"chromInfo\": \"/shared/ifbstor1/galaxy/mutable-config/tool-data/shared/ucsc/chrom/?.len\", \"eggnog_data\": \"5.0.2\", \"ortho_method\": {\"m\": \"diamond\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}, \"input_trans\": {\"itype\": \"proteins\", \"__current_case__\": 0}, \"matrix_gapcosts\": {\"matrix\": \"BLOSUM62\", \"__current_case__\": 2, \"gap_costs\": \"--gapopen 11 --gapextend 1\"}, \"sensmode\": \"sensitive\", \"dmnd_iterate\": false, \"dmnd_ignore_warnings\": false, \"query_cover\": null, \"subject_cover\": null, \"pident\": null, \"evalue\": null, \"score\": \"0.001\"}, \"output_options\": {\"no_file_comments\": false, \"report_orthologs\": false, \"md5\": false}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": {
+                "annotation_options": {
+                    "no_annot": "",
+                    "seed_ortholog_evalue": "0.001",
+                    "seed_ortholog_score": null,
+                    "tax_scope": null,
+                    "target_orthologs": "all",
+                    "go_evidence": "non-electronic"
+                },
+                "eggnog_data": "5.0.2",
+                "ortho_method": {
+                    "m": "diamond",
+                    "input": {
+                        "__class__": "ConnectedValue"
+                    },
+                    "input_trans": {
+                        "itype": "proteins"
+                    },
+                    "matrix_gapcosts": {
+                        "matrix": "BLOSUM62",
+                        "gap_costs": "--gapopen 11 --gapextend 1"
+                    },
+                    "sensmode": "sensitive",
+                    "dmnd_iterate": false,
+                    "dmnd_ignore_warnings": false,
+                    "query_cover": null,
+                    "subject_cover": null,
+                    "pident": null,
+                    "evalue": null,
+                    "score": "0.001"
+                },
+                "output_options": {
+                    "no_file_comments": false,
+                    "report_orthologs": false,
+                    "md5": false
+                }
+            },
             "tool_version": "2.1.8+galaxy4",
             "type": "tool",
             "uuid": "76b27114-c49f-41b8-9333-91953729dee3",


### PR DESCRIPTION
## Summary
- Remove 14 stale tool_state keys from 2 tool steps (interproscan, eggnog_mapper)
- Keys removed: `__page__`, `__rerun_remap_job_id__`, `__current_case__`, `__input_ext`, `chromInfo`, and stale conditional param `licensed|applications_licensed`
- Tool state now written as proper JSON dicts instead of double-encoded strings for readability and diffability

Supersedes #1157 — re-cleaned with updated tooling that outputs unencoded tool_state dicts.

## Test plan
- [ ] Workflow loads correctly in Galaxy editor
- [ ] Workflow executes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)