### PR TITLE
Update fasttree 2.1.10+galaxy1 to 2.1.10+galaxy3 in PathoGFAIR workflow.

### DIFF
--- a/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/CHANGELOG.md
+++ b/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.1] - 2026-03-19
+
+### Changed
+- Update fasttree from 2.1.10+galaxy1 to 2.1.10+galaxy3
+
 ## [0.1] - 2024-04-24
 
 First release.

--- a/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.ga
+++ b/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.ga
@@ -202,7 +202,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.1",
+    "release": "0.1.1",
     "name": "Pathogen Detection PathoGFAIR Samples Aggregation and Visualisation",
     "report": {
         "markdown": "# Pathogen Detection - PathoGFAIR Samples Aggregation and Visualisation Workflow Report\nBelow are the results for the PathoGFAIR Samples Aggregation and Visualisation Workflow\n\nThis workflow was run on:\n\n```galaxy\ngenerate_time()\n```\n\nWith Galaxy version:\n\n```galaxy\ngenerate_galaxy_version()\n```\n\n## Workflow Inputs\nTabular files and a FASTA file from the Gene-based Pathogen Identification workflow, four other tabular files from Nanopore Preprocessing and Nanopore - Allele-based Pathogen Identification workflow, and an optional Metadata tabular file with more sample information:\n\nFrom Gene-based Pathogenic Identification workflow: \n- contigs, FASTA file\n- VFs, Tabular file\n- vfs_of_genes_identified_by_vfdb, Tabular file\n- AMRs, Tabular file\n- amr_identified_by_ncbi, Tabular file\n\nFrom Nanopore - Allele bases Pathogen Identification workflow: \n- number_of_variants_per_sample, Tabular file\n- mapping_mean_depth_per_sample, Tabular file\n- mapping_coverage_percentage_per_sample, Tabular file\n\nFrom Nanopore Preprocessing: \n- removed_hosts_percentage_tabular, Tabular file\n\n## Some of the Workflow Outputs\n\n1- All Samples VFs Heatmap\n\n```galaxy\nhistory_dataset_as_image(output=\"heatmap_png\")\n```\n\n2- All samples phylogenetic tree VFs based\n\n```galaxy\nhistory_dataset_as_image(output=\"all_samples_phylogenetic_tree_based_vfs\")\n```\n\n3- All samples Phylogenetic tree AMR based \n\n```galaxy\nhistory_dataset_as_image(output=\"all_samples_phylogenetic_tree_based_amrs\")\n```\n\n4- Bar-plot for the Number of reads before host sequences removal and Number of found host reads per sample, performed in the Nanopore - Preprocessing workflow\n\n\n5- Barplot for the total number of removed host sequences per sample\n\n \n6- Barplot for the Mapping mean depth of coverage per sample\n\n\n6- Barplot for the Mapping breadth of coverage percentage per sample\n\n\n7- Barplot for the total number of complex variants and SNPs identified per sample\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"
@@ -2402,7 +2402,7 @@
         },
         "55": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy3",
             "errors": null,
             "id": 55,
             "input_connections": {
@@ -2438,9 +2438,9 @@
                     "output_name": "output"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "e005e659ae21",
+                "changeset_revision": "bc939965ce41",
                 "name": "fasttree",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2871,7 +2871,7 @@
         },
         "66": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy3",
             "errors": null,
             "id": 66,
             "input_connections": {
@@ -2899,9 +2899,9 @@
                 "top": 1184.9745890557185
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "e005e659ae21",
+                "changeset_revision": "bc939965ce41",
                 "name": "fasttree",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2915,7 +2915,7 @@
         },
         "67": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy3",
             "errors": null,
             "id": 67,
             "input_connections": {
@@ -2943,9 +2943,9 @@
                 "top": 1852.0079752861873
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "e005e659ae21",
+                "changeset_revision": "bc939965ce41",
                 "name": "fasttree",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"


### PR DESCRIPTION
Both intermediate releases are Galaxy-level bug fixes with no input/output changes:
- galaxy1→galaxy2: fix version_command (galaxyproject/tools-iuc#3114)
- galaxy2→galaxy3: fix tool XML declaration (galaxyproject/tools-iuc#6640)

The toolshed doesn't have the version listed in the workflow anymore - looking over galaxyproject/tools-iuc#6640 I can imagine why. My first thought was maybe we broke the tool loading in https://github.com/galaxyproject/galaxy/pull/15493. But that behavior was trying to block on a tool version. The problem isn't immediately clear but I could put more time into if want to push back and call this a tool shed bug - I could try to re-implement boolean parameters that have matching truevalues and falsevalues if they are empty. 

FOR CONTRIBUTOR:
* [x] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [x] License permits unrestricted use (educational + commercial)
* [x] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
