### PR TITLE
Fix website accessibility issues from WCAG audit

### DIFF
--- a/website/src/components/FilterSidebar.vue
+++ b/website/src/components/FilterSidebar.vue
@@ -15,7 +15,7 @@ const { selected, collectionCounts, sortedCollections, handleFilterClick } = use
 <template>
     <aside class="hidden md:block w-48 lg:w-56 shrink-0 pr-6">
         <div class="sticky top-4">
-            <h3 class="text-xs font-semibold text-chicago-400 uppercase tracking-wider mb-3">Categories</h3>
+            <h3 class="text-xs font-semibold text-chicago-500 uppercase tracking-wider mb-3">Categories</h3>
 
             <TooltipProvider :delay-duration="300">
                 <nav class="flex flex-col gap-1">
@@ -35,7 +35,7 @@ const { selected, collectionCounts, sortedCollections, handleFilterClick } = use
                                     class="text-xs tabular-nums transition-colors ml-2 shrink-0"
                                     :class="{
                                         'text-hokey-pokey-500': selected.includes(filter),
-                                        'text-chicago-400 group-hover:text-chicago-500': !selected.includes(filter),
+                                        'text-chicago-500 group-hover:text-chicago-600': !selected.includes(filter),
                                     }">
                                     {{ collectionCounts[filter] || 0 }}
                                 </span>

--- a/website/src/components/IWCFooter.astro
+++ b/website/src/components/IWCFooter.astro
@@ -10,7 +10,7 @@
             <span class="text-chicago-300">
                 Curated, peer-reviewed Galaxy workflows for reproducible scientific analysis. Part of the <a
                     href="https://galaxyproject.org"
-                    class="text-chicago-200 hover:text-hokey-pokey"
+                    class="text-chicago-200 underline hover:text-hokey-pokey"
                     target="_blank"
                     rel="noopener">Galaxy Project</a
                 >.

--- a/website/src/components/IWCHeader.astro
+++ b/website/src/components/IWCHeader.astro
@@ -12,7 +12,7 @@ import logo from "../assets/iwc_logo_white.png";
                 <span class="sm:hidden">Galaxy IWC</span>
             </span>
         </a>
-        <nav class="flex items-center space-x-4 md:space-x-8 text-sm md:text-base">
+        <nav aria-label="Main" class="flex items-center space-x-4 md:space-x-8 text-sm md:text-base">
             <a href="/about" class="hover:text-hokey-pokey">About</a>
             <a
                 href="https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows"
@@ -23,13 +23,14 @@ import logo from "../assets/iwc_logo_white.png";
                 href="https://github.com/galaxyproject/iwc/"
                 class="hover:text-hokey-pokey flex items-center gap-1"
                 target="_blank">
-                <span class="hidden sm:inline">GitHub</span>
+                <span class="sr-only sm:not-sr-only sm:inline">GitHub</span>
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
                     width="20"
                     height="20"
                     viewBox="0 0 24 24"
                     fill="currentColor"
+                    aria-hidden="true"
                     class="inline-block">
                     <path
                         d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -77,17 +77,17 @@ const {
         {
             hasHero ? (
                 <div class="header-hero-container relative">
-                    <header>
-                        <slot name="header" />
-                    </header>
                     <div>
-                        <slot name="hero" />
+                        <slot name="header" />
                     </div>
+                    <section aria-label="Featured workflows">
+                        <slot name="hero" />
+                    </section>
                 </div>
             ) : (
-                <header class="header-container relative">
+                <div class="header-container relative">
                     <slot name="header" />
-                </header>
+                </div>
             )
         }
 


### PR DESCRIPTION
## Summary

Addresses 7 accessibility issues flagged by an external WCAG audit:

- **Duplicate banner landmarks**: Layout was nesting `<header>` inside `<header>` -- changed layout wrappers to `<div>` since `IWCHeader.astro` already provides the semantic header
- **Hero content outside landmarks**: Wrapped hero slot in `<section aria-label="Featured workflows">`
- **Nav element missing label**: Added `aria-label="Main"` to the header nav
- **GitHub link inaccessible on mobile**: Changed from `display:none` to `sr-only` so screen readers always see the text; marked SVG as `aria-hidden`
- **Sidebar contrast too low**: Bumped Categories heading and count badges from `chicago-400` to `chicago-500` to clear 4.5:1 AA threshold
- **Footer link indistinguishable from text**: Added underline to the Galaxy Project link

Only visible changes are slightly darker sidebar text and the footer link underline.

## Test plan

- [x] `npm run build` passes
- [x] All 116 Playwright E2E tests pass
- [ ] Visual spot-check on homepage and collection pages