### PR TITLE
VGP 1 - update Rdeval to 0.0.9

### DIFF
--- a/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/CHANGELOG.md
+++ b/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.9] - 2026-03-31
+
+### Automatic update
+- `toolshed.g2.bx.psu.edu/repos/richard-burhans/rdeval/rdeval/0.0.8+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/richard-burhans/rdeval/rdeval/0.0.9+galaxy0`
+- `toolshed.g2.bx.psu.edu/repos/richard-burhans/rdeval/rdeval_report/0.0.8+galaxy0` was updated to `toolshed.g2.bx.psu.edu/repos/richard-burhans/rdeval/rdeval_report/0.0.9+galaxy0`
+
 ## [0.8] - 2026-01-30
 
 ### Automatic update

--- a/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1.ga
+++ b/workflows/VGP-assembly-v2/kmer-profiling-hifi-VGP1/kmer-profiling-hifi-VGP1.ga
@@ -1160,14 +1160,14 @@
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
-                    "label": "Data for Interactive HeatMap",
-                    "output_name": "Data for Interactive HeatMap",
-                    "uuid": "41039808-3e91-4ea4-b011-50e8c52bd680"
-                },
-                {
                     "label": "HeatMap",
                     "output_name": "HeatMap",
                     "uuid": "b515dc25-202e-401e-948b-e1d8066a09af"
+                },
+                {
+                    "label": "Data for Interactive HeatMap",
+                    "output_name": "Data for Interactive HeatMap",
+                    "uuid": "41039808-3e91-4ea4-b011-50e8c52bd680"
                 }
             ]
         },
@@ -1428,16 +1428,6 @@
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "GenomeScope Model",
-                    "output_name": "model",
-                    "uuid": "5732acc1-bca6-4ca6-90cc-8a320882e5f9"
-                },
-                {
-                    "label": "GenomeScope summary",
-                    "output_name": "summary",
-                    "uuid": "115ec9de-57d6-4f42-9858-a877f2201ef0"
-                },
-                {
                     "label": "GenomeScope transformed log plot",
                     "output_name": "transformed_log_plot",
                     "uuid": "ea87bd08-a6d9-4c9e-9497-8bfb1725da04"
@@ -1461,6 +1451,16 @@
                     "label": "GenomeScope transformed linear plot",
                     "output_name": "transformed_linear_plot",
                     "uuid": "48e2c4c5-8658-44e6-8981-673a2f1f719e"
+                },
+                {
+                    "label": "GenomeScope Model",
+                    "output_name": "model",
+                    "uuid": "5732acc1-bca6-4ca6-90cc-8a320882e5f9"
+                },
+                {
+                    "label": "GenomeScope summary",
+                    "output_name": "summary",
+                    "uuid": "115ec9de-57d6-4f42-9858-a877f2201ef0"
                 }
             ]
         },
@@ -2150,7 +2150,7 @@
         },
         "20": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/richard-burhans/rdeval/rdeval/0.0.8+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/richard-burhans/rdeval/rdeval/0.0.9+galaxy0",
             "errors": null,
             "id": 20,
             "input_connections": {
@@ -2206,16 +2206,16 @@
                     "output_name": "stats_outfile"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/richard-burhans/rdeval/rdeval/0.0.8+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/richard-burhans/rdeval/rdeval/0.0.9+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "f0409baac2cd",
+                "changeset_revision": "058bb29e28ba",
                 "name": "rdeval",
                 "owner": "richard-burhans",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"expected_gsize\": {\"__class__\": \"ConnectedValue\"}, \"input_compress\": {\"compress_selector\": \"no\", \"__current_case__\": 0}, \"input_filter\": {\"include_list\": {\"__class__\": \"RuntimeValue\"}, \"exclude_list\": {\"__class__\": \"RuntimeValue\"}, \"filter_expression\": {\"filter_selector\": \"no_exp\", \"__current_case__\": 0}}, \"input_reads\": {\"__class__\": \"ConnectedValue\"}, \"input_subsample\": {\"sample\": \"1.0\", \"random_seed\": {\"seed_selector\": \"no\", \"__current_case__\": 0}}, \"output_options\": {\"verbose\": false, \"stats_flavor\": {\"flavor_selector\": \"stats\", \"__current_case__\": 0, \"sequence_report\": false}, \"output_type\": {\"type_selector\": \"rd_file\", \"__current_case__\": 1, \"md5\": false}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
-            "tool_version": "0.0.8+galaxy0",
+            "tool_version": "0.0.9+galaxy0",
             "type": "tool",
             "uuid": "7b956f7d-6b8d-4fc2-91cb-cdd4d48e6be1",
             "when": null,
@@ -2297,7 +2297,7 @@
         },
         "22": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/richard-burhans/rdeval/rdeval_report/0.0.8+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/richard-burhans/rdeval/rdeval_report/0.0.9+galaxy0",
             "errors": null,
             "id": 22,
             "input_connections": {
@@ -2335,16 +2335,16 @@
                     "output_name": "outfile"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/richard-burhans/rdeval/rdeval_report/0.0.8+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/richard-burhans/rdeval/rdeval_report/0.0.9+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "f0409baac2cd",
+                "changeset_revision": "058bb29e28ba",
                 "name": "rdeval",
                 "owner": "richard-burhans",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"input_files\": {\"__class__\": \"ConnectedValue\"}, \"interactive\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
-            "tool_version": "0.0.8+galaxy0",
+            "tool_version": "0.0.9+galaxy0",
             "type": "tool",
             "uuid": "956b9d4c-2ed6-45c8-a313-ddce165bc7e2",
             "when": null,
@@ -2361,7 +2361,7 @@
         "Reviewed",
         "VGP"
     ],
-    "uuid": "97851585-7df2-4871-b481-9bc837f251d0",
-    "version": 1,
-    "release": "0.8"
+    "uuid": "9006675f-b366-411e-b39f-5b4bab389988",
+    "version": 3,
+    "release": "0.9"
 }


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
