### PR TITLE
SRA manifest to concatenated fastqs: include readme and hide intermediate steps

### DIFF
--- a/workflows/data-fetching/sra-manifest-to-concatenated-fastqs/CHANGELOG.md
+++ b/workflows/data-fetching/sra-manifest-to-concatenated-fastqs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.9] - 2026-04-09
+
+### Manual update
+
+- Add the README in the workflow
+- Hide intermediate steps
+
 ## [0.8] - 2026-01-19
 
 ### Automatic update

--- a/workflows/data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs.ga
+++ b/workflows/data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs.ga
@@ -22,6 +22,10 @@
     "format-version": "0.1",
     "license": "MIT",
     "name": "sra_manifest_to_concatenated_fastqs_parallel",
+    "readme": "# SRA manifest to concatenated fastqs\n\nThis workflow takes as input a SRA manifest from SRA Run Selector (or a tabular with a header line), downloads all sequencing run data from the SRA and arranges it into per-sample fastq or pairs of fastq datasets.\n\nIt will work out the relationship between runs and samples from the user-indicated run and sample columns in the input and will concatenate sequencing run data as needed to obtain per-sample datasets.\n\n## Input dataset\n\n- The workflow needs a single tabular input dataset, which is supposed to list SRA run identifiers in one column and sample names in another, and which needs to have a header line.\n- SRA manifests obtained via the SRA Run Selector and turned into tabular format represent valid input.\n\n## Input values\n\n- Column number with SRA run ID\n\n  For manifests obtained through the SRA Run Selector this is column 1\n\n- Column number with sample names\n\n  The number of the column that should be used to assign sequencing runs to samples\n  The names in the column will also serve as the labels of datasets in the output collection.\n  For manifests obtained through the SRA Run Selector suitable columns might be number 6 (BioSample), 16 (Experiment) or 36 (Sample Name).\n\n## Processing\n\n- The workflow downloads sequencing run data in fastq format with fasterqdump (one job per SRA run ID).\n- Run data gets concatenated if it comes from the same sample.\n\n## Outputs\n\n- There are 2 outputs, one with paired-end datasets, one with single-read datasets.\n\n## Limitations\n\n- Special characters in sample names (anything that is not an English alphabet character, digit, underscore, dash, space, dot or comma (`[a-zA-Z0-9_\\- \\.,]`) will be converted to dashes (`-`).\n",
+    "report": {
+        "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
+    },
     "steps": {
         "0": {
             "annotation": "Input tabular from SRA Run Selector or home made (First row needs to be a header)",
@@ -233,7 +237,13 @@
                 "left": 816,
                 "top": 0
             },
-            "post_job_actions": {},
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
             "tool_id": "Cut1",
             "tool_state": "{\"columnList\": {\"__class__\": \"ConnectedValue\"}, \"delimiter\": \"T\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
@@ -245,7 +255,7 @@
         },
         "6": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy3",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
             "errors": null,
             "id": 6,
             "input_connections": {
@@ -267,17 +277,23 @@
                 "left": 1096,
                 "top": 189
             },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.5+galaxy3",
+            "post_job_actions": {
+                "HideDatasetActionoutfile": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_find_and_replace/9.3+galaxy1",
             "tool_shed_repository": {
-                "changeset_revision": "ab83aa685821",
+                "changeset_revision": "fbf99087e067",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"find_and_replace\": [{\"__index__\": 0, \"find_pattern\": \"[^\\\\w\\\\- .,\\\\t](?=[^\\\\t]+$)\", \"replace_pattern\": \"-\", \"is_regex\": true, \"global\": true, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}, {\"__index__\": 1, \"find_pattern\": \"(.+)\\\\t(.+)\", \"replace_pattern\": \"$1\\\\t$1___$2\", \"is_regex\": true, \"global\": false, \"caseinsensitive\": false, \"wholewords\": false, \"skip_first_line\": false, \"searchwhere\": {\"searchwhere_select\": \"line\", \"__current_case__\": 0}}], \"infile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
-            "tool_version": "9.5+galaxy3",
+            "tool_version": "9.3+galaxy1",
             "type": "tool",
             "uuid": "7b4781ed-57b0-4962-a647-21e54375c195",
             "when": null,
@@ -376,7 +392,7 @@
         },
         "9": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/3.1.1+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/3.1.1+galaxy0",
             "errors": null,
             "id": 9,
             "input_connections": {
@@ -437,16 +453,16 @@
                     "output_name": "output_collection_other"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/3.1.1+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/sra_tools/fasterq_dump/3.1.1+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "8848455c0270",
+                "changeset_revision": "516a54ddf218",
                 "name": "sra_tools",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"adv\": {\"seq_defline\": \"@$sn/$ri\", \"minlen\": null, \"split\": \"--split-3\", \"skip_technical\": true}, \"input\": {\"input_select\": \"file_list\", \"__current_case__\": 2, \"file_list\": {\"__class__\": \"ConnectedValue\"}}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
-            "tool_version": "3.1.1+galaxy1",
+            "tool_version": "3.1.1+galaxy0",
             "type": "tool",
             "uuid": "fa409017-1eea-4426-83f6-22a10b9f762c",
             "when": null,
@@ -750,7 +766,7 @@
         }
     },
     "tags": [],
-    "uuid": "5342719f-2706-4482-89c8-83a77e51e714",
+    "uuid": "f3a15899-64ba-4df8-ac94-d1bce448dfb4",
     "version": 1,
-    "release": "0.8"
+    "release": "0.9"
 }


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
