### PR TITLE
Convert duplicate-keyed asserts blocks to list form

### DIFF
--- a/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation-tests.yml
+++ b/workflows/VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/hi-c-map-for-assembly-manual-curation-tests.yml
@@ -89,9 +89,9 @@
           delta: 5000
     P telomeres bed:
       asserts:
-        has_text:
+        - that: has_text
           text: "scaffold_10.H2"
-        has_text:
+        - that: has_text
           text: "scaffold_1.H1"
     Pretext All tracks:
       asserts:
@@ -224,9 +224,9 @@
           delta: 10000
     P telomeres bed:
       asserts:
-        has_text:
+        - that: has_text
           text: "scaffold_10.H2"
-        has_text:
+        - that: has_text
           text: "scaffold_1.H1"
     Merged Hi-C Alignments on Scaffolds:
       asserts:

--- a/workflows/VGP-assembly-v2/kmer-profiling-hifi-trio-VGP2/kmer-profiling-hifi-trio-VGP2-tests.yml
+++ b/workflows/VGP-assembly-v2/kmer-profiling-hifi-trio-VGP2/kmer-profiling-hifi-trio-VGP2-tests.yml
@@ -49,9 +49,9 @@
       delta: 15000
     GenomeScope summary (child):
       asserts:
-        has_text:
+        - that: has_text
           text: '39,419 bp'
-        has_text:
+        - that: has_text
           text: '43,763 bp'
     'Meryl database : Child':
       asserts:

--- a/workflows/bacterial_genomics/bacterial-quality-and-contamination-control-post-assembly/bacterial_quality_and_contamination_control_post_assembly-tests.yml
+++ b/workflows/bacterial_genomics/bacterial-quality-and-contamination-control-post-assembly/bacterial_quality_and_contamination_control_post_assembly-tests.yml
@@ -28,10 +28,10 @@
           n: 6
     Kraken2 sequence assignation:
       asserts:
-        has_text:
+        - that: has_text
           text: "contig00001"
-        has_text:
-          text: "contig00359"          
+        - that: has_text
+          text: "contig00359"
     Kraken2 tabular report:
       asserts:
         has_text:
@@ -56,9 +56,9 @@
       element_tests:
         E-coli3_S194.fasta:
           asserts:
-            has_text:
+            - that: has_text
               text: ">contig00001_1"
-            has_text:
+            - that: has_text
               text: ">contig00358_1"
     Tooldistillator summarize control:
       asserts:

--- a/workflows/comparative_genomics/hyphy/capheine-core-and-compare-tests.yml
+++ b/workflows/comparative_genomics/hyphy/capheine-core-and-compare-tests.yml
@@ -31,17 +31,17 @@
   outputs:
     combined_summary:
       asserts:
-        has_text:
+        - that: has_text
           text: "gene"
-        has_text:
+        - that: has_text
           text: "BUSTED"
-        has_text:
+        - that: has_text
           text: "MEME"
-        has_text:
+        - that: has_text
           text: "pval"
-        has_text:
+        - that: has_text
           text: "omega"
-        has_n_columns:
+        - that: has_n_columns
           n: 9
 
 - doc: Test CAPHEINE with reference CDS, unaligned sequences, and regex (no foreground list)
@@ -78,29 +78,29 @@
   outputs:
     combined_summary:
       asserts:
-        has_text:
+        - that: has_text
           text: "gene"
-        has_text:
+        - that: has_text
           text: "BUSTED"
-        has_text:
+        - that: has_text
           text: "MEME"
-        has_text:
+        - that: has_text
           text: "RELAX"
-        has_text:
+        - that: has_text
           text: "pval"
-        has_n_columns:
+        - that: has_n_columns
           n: 12
     combined_comparison_summary:
       asserts:
-        has_text:
+        - that: has_text
           text: "gene"
-        has_text:
+        - that: has_text
           text: "comparison_group"
-        has_text:
+        - that: has_text
           text: "Foreground"
-        has_text:
+        - that: has_text
           text: "Reference"
-        has_n_columns:
+        - that: has_n_columns
           n: 6
 
 - doc: Test CAPHEINE with reference CDS, unaligned sequences, and foreground list (no regex)
@@ -141,29 +141,29 @@
   outputs:
     combined_summary:
       asserts:
-        has_text:
+        - that: has_text
           text: "gene"
-        has_text:
+        - that: has_text
           text: "BUSTED"
-        has_text:
+        - that: has_text
           text: "MEME"
-        has_text:
+        - that: has_text
           text: "RELAX"
-        has_text:
+        - that: has_text
           text: "pval"
-        has_n_columns:
+        - that: has_n_columns
           n: 12
     combined_comparison_summary:
       asserts:
-        has_text:
+        - that: has_text
           text: "gene"
-        has_text:
+        - that: has_text
           text: "comparison_group"
-        has_text:
+        - that: has_text
           text: "Foreground"
-        has_text:
+        - that: has_text
           text: "Reference"
-        has_n_columns:
+        - that: has_n_columns
           n: 6
 
 - doc: Test CAPHEINE with all inputs (reference CDS, unaligned sequences, regex, and foreground list)
@@ -216,27 +216,27 @@
   outputs:
     combined_summary:
       asserts:
-        has_text:
+        - that: has_text
           text: "gene"
-        has_text:
+        - that: has_text
           text: "BUSTED"
-        has_text:
+        - that: has_text
           text: "MEME"
-        has_text:
+        - that: has_text
           text: "RELAX"
-        has_text:
+        - that: has_text
           text: "pval"
-        has_n_columns:
+        - that: has_n_columns
           n: 12
     combined_comparison_summary:
       asserts:
-        has_text:
+        - that: has_text
           text: "gene"
-        has_text:
+        - that: has_text
           text: "comparison_group"
-        has_text:
+        - that: has_text
           text: "Foreground"
-        has_text:
+        - that: has_text
           text: "Reference"
-        has_n_columns:
+        - that: has_n_columns
           n: 6

--- a/workflows/genome-assembly/bacterial-genome-assembly/bacterial_genome_assembly-tests.yml
+++ b/workflows/genome-assembly/bacterial-genome-assembly/bacterial_genome_assembly-tests.yml
@@ -29,7 +29,7 @@
           n: 2
     tooldistillator_summarize_assembly:
       asserts:
-        has_text:
+        - that: has_text
           text: "\"Assembly\": \"shovill_contigs_fasta\""
-        has_text:
+        - that: has_text
           text: "contig00146"

--- a/workflows/genome-assembly/quality-and-contamination-control-raw-reads/quality_and_contamination_control_raw_reads-tests.yml
+++ b/workflows/genome-assembly/quality-and-contamination-control-raw-reads/quality_and_contamination_control_raw_reads-tests.yml
@@ -12,9 +12,9 @@
   outputs:
     fastp_report_json:
       asserts:
-        has_text:
+        - that: has_text
           text: "fastp_version"
-        has_text:
+        - that: has_text
           text: "read2_before_filtering"
     kraken_report_tabular:
       asserts:

--- a/workflows/microbiome/host-contamination-removal/host-contamination-removal-long-reads/host-or-contamination-removal-on-long-reads-tests.yml
+++ b/workflows/microbiome/host-contamination-removal/host-contamination-removal-long-reads/host-or-contamination-removal-on-long-reads-tests.yml
@@ -21,9 +21,9 @@
           elements:
             genome_results:
               asserts:
-                has_text:
+                - that: has_text
                   text: "Spike3bBarcode10"
-                has_text:
+                - that: has_text
                   text: "586,300,787 bp"
             coverage_across_reference:
               asserts:
@@ -45,15 +45,15 @@
                   value: 51
             duplication_rate_histogram:
               asserts:
-                has_text:
+                - that: has_text
                   text: "#Duplication rate"
-                has_text:
+                - that: has_text
                   text: "17.0"
             homopolymer_indels:
               asserts:
-                has_text:
+                - that: has_text
                   text: "#Type of indel"
-                has_text:
+                - that: has_text
                   text: "polyN"
             insert_size_across_reference:
               asserts:
@@ -65,9 +65,9 @@
                   value: 0
             mapped_reads_clipping_profile:
               asserts:
-                has_text:
+                - that: has_text
                   text: "#Read position (bp)"
-                has_text:
+                - that: has_text
                   text: "38.123"
             mapped_reads_gc-content_distribution:
               asserts:
@@ -95,9 +95,9 @@
           elements:
             genome_results:
               asserts:
-                has_text:
+                - that: has_text
                   text: "Spike3bBarcode12"
-                has_text:
+                - that: has_text
                   text: "586,300,787 bp"
             coverage_across_reference:
               asserts:
@@ -119,15 +119,15 @@
                   value: 51
             duplication_rate_histogram:
               asserts:
-                has_text:
+                - that: has_text
                   text: "#Duplication rate"
-                has_text:
+                - that: has_text
                   text: "8.0"
             homopolymer_indels:
               asserts:
-                has_text:
+                - that: has_text
                   text: "#Type of indel"
-                has_text:
+                - that: has_text
                   text: "polyN"
             insert_size_across_reference:
               asserts:
@@ -139,9 +139,9 @@
                   value: 0
             mapped_reads_clipping_profile:
               asserts:
-                has_text:
+                - that: has_text
                   text: "#Read position (bp)"
-                has_text:
+                - that: has_text
                   text: "0.03930972"
             mapped_reads_gc-content_distribution:
               asserts:
@@ -167,9 +167,9 @@
                   value: 4
     MultiQC HTML Report:
       asserts:
-        has_text:
+        - that: has_text
           text: "Spike3bBarcode10"
-        has_text:
+        - that: has_text
           text: "Spike3bBarcode12"
     Reads without Host or Contamination:
       element_tests:

--- a/workflows/microbiome/host-contamination-removal/host-contamination-removal-short-reads/host-or-contamination-removal-on-short-reads-tests.yml
+++ b/workflows/microbiome/host-contamination-removal/host-contamination-removal-short-reads/host-or-contamination-removal-on-short-reads-tests.yml
@@ -20,9 +20,9 @@
   outputs:
     MultiQC HTML Report:
       asserts:
-        has_text:
+        - that: has_text
           text: "pair"
-        has_text:
+        - that: has_text
           text: "Bowtie"
     Bowtie2 Mapping Statistics:
       element_tests:

--- a/workflows/read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml
+++ b/workflows/read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml
@@ -24,19 +24,19 @@
   outputs:
     MultiQC HTML report:
       asserts:
-        has_text:
+        - that: has_text
           text: "Filtered Reads"
-        has_text:
+        - that: has_text
           text: "pair"
     fastp JSON report:
       element_tests:
         pair:
           asserts:
-            has_text:
+            - that: has_text
               text: "paired end (301 cycles + 301 cycles)"
-            has_text:
+            - that: has_text
               text: "300000"
-            has_text:
+            - that: has_text
               text: "295680"
-            has_text:
+            - that: has_text
               text: "59230948"

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation-tests.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation-tests.yml
@@ -32,11 +32,11 @@
       element_tests:
         SRR11578257:
           asserts:
-            has_line:
+            - that: has_line
               line: "##fileformat=VCFv4.0"
-            has_line:
+            - that: has_line
               line: "#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO"
-            has_text_matching:
+            - that: has_text_matching
               expression: "NC_045512.2\t174\t.\tG\tC\t[0-9]*\tPASS"
-            has_text_matching:
+            - that: has_text_matching
               expression: "NC_045512.2\t20209\t.\tAGTAGAAATT\tA\t[0-9]*\tPASS\tDP=[0-9]*;AF=0.9[0-9]*;SB=24;DP4=[0-9]*,[0-9]*,[0-9]*,[0-9]*;INDEL;HRUN=1;EFF=CODON_CHANGE_PLUS_CODON_DELETION\\(MODERATE||agtagaaattta/ata|SRNL6649I|7096|ORF1ab|protein_coding|CODING|GU280_gp01|2|A\\),CODON_CHANGE_PLUS_CODON_DELETION\\(MODERATE||agtagaaattta/ata|SRNL197I|345|ORF1ab|protein_coding|CODING|YP_009725310.1|1|A|WARNING_TRANSCRIPT_NO_START_CODON\\)"

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/se-wgs-variation-tests.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/se-wgs-variation-tests.yml
@@ -16,11 +16,11 @@
       element_tests:
         SRR11605118:
           asserts:
-            has_line:
+            - that: has_line
               line: "##fileformat=VCFv4.0"
-            has_line:
+            - that: has_line
               line: "#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO"
-            has_text_matching:
+            - that: has_text_matching
               expression: "NC_045512.2\t241\t.\tC\tT\t[0-9.]*\tPASS"
-            has_text_matching:
+            - that: has_text_matching
               expression: "NC_045512.2\t16111\t.\tC\tT\t[0-9.]*\tPASS\tDP=[0-9]*;AF=0.[89][0-9]*;SB=0;DP4=[0-9]*,[0-9]*,[0-9]*,[0-9]*;EFF=SYNONYMOUS_CODING\\(LOW|SILENT|Cta/Tta|L5283|7096|ORF1ab|protein_coding|CODING|GU280_gp01|2|T\\),SYNONYMOUS_CODING\\(LOW|SILENT|Cta/Tta|L891|931|ORF1ab|protein_coding|CODING|YP_009725307.1|2|T|WARNING_TRANSCRIPT_NO_START_CODON\\)"

--- a/workflows/variant-calling/ploidy-aware-genotype-calling/genotype-variant-calling-wgs-pe-test.yml
+++ b/workflows/variant-calling/ploidy-aware-genotype-calling/genotype-variant-calling-wgs-pe-test.yml
@@ -40,18 +40,18 @@
 
     SnpEff variants:
       asserts:
-        has_text:
+        - that: has_text
           text: "##fileformat=VCFv4.2"
-        has_text:
+        - that: has_text
           text: "##contig=<ID=chr1,length=2000>"
-        has_n_lines:
+        - that: has_n_lines
           n: 71
 
     SnpEff eff reports:
       asserts:
-        has_text:
+        - that: has_text
           text: "<td valign=top> <b> Number of variants processed <br> (i.e. after filter and non-variants) </b> </td>"
-        has_text:
+        - that: has_text
           text: "<td> 2 </td>"
 
     Annotated Variants:


### PR DESCRIPTION
## Summary

YAML silently collapses duplicate mapping keys, so `asserts:` blocks that repeat
an assertion type (`has_text:`, `has_line:`, `has_text_matching:`) were only
running the **last** assertion per type — every earlier assertion was silently
dropped by the YAML loader and never executed.

This converts 12 affected workflow-tests files from duplicate-keyed dict form
to list form so every assertion actually runs:

```yaml
# Before — second has_text: overwrites first, "gene" assertion never ran
asserts:
  has_text:
    text: "gene"
  has_text:
    text: "BUSTED"

# After — both assertions run
asserts:
  - that: has_text
    text: "gene"
  - that: has_text
    text: "BUSTED"
```

## ⚠ Heads-up for maintainers: semantic change

Because the first N−1 assertions per type were previously dead code, some of
these tests may have been silently passing on assertion text that doesn't
actually match current tool output. Running them for real may surface
legitimate assertion failures. That's not a regression in this PR — it's the
first time those assertions have run. If CI fails on one of these, the fix is
to update the expected text (the author's intent was clearly to assert both),
not to revert this PR.

## Files changed (12)

- `VGP-assembly-v2/hi-c-contact-map-for-assembly-manual-curation/…-tests.yml`
- `VGP-assembly-v2/kmer-profiling-hifi-trio-VGP2/…-tests.yml`
- `bacterial_genomics/bacterial-quality-and-contamination-control-post-assembly/…-tests.yml`
- `comparative_genomics/hyphy/capheine-core-and-compare-tests.yml`
- `genome-assembly/bacterial-genome-assembly/…-tests.yml`
- `genome-assembly/quality-and-contamination-control-raw-reads/…-tests.yml`
- `microbiome/host-contamination-removal/host-contamination-removal-long-reads/…-tests.yml`
- `microbiome/host-contamination-removal/host-contamination-removal-short-reads/…-tests.yml`
- `read-preprocessing/short-read-qc-trimming/…-tests.yml`
- `sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/…-tests.yml`
- `sars-cov-2-variant-calling/sars-cov-2-se-illumina-wgs-variant-calling/…-tests.yml`
- `variant-calling/ploidy-aware-genotype-calling/…-test.yml`

## How this was found

Galaxy's new `gxwf validate-tests` workflow-test validator (in-progress work on
the Galaxy side) swept all IWC workflow-tests files against the Pydantic
`Tests` model. `ordered_load` in Galaxy's YAML helper raises on duplicate
mapping keys (per YAML 1.2), which surfaced these authoring bugs.

A follow-up PR will handle the remaining cases (duplicate `text:` / `expression:`
*inside* a single assertion item, plus a few misc structural dupes like
duplicate output names and `assert:` vs `asserts:` typos).


FOR CONTRIBUTOR:
* [x] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [x] License permits unrestricted use (educational + commercial)
* [x] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
