### PR TITLE
Split duplicate-keyed assertion content into separate assertions

### DIFF
--- a/workflows/genome_annotation/annotation-braker3/Genome_annotation_with_braker3-tests.yml
+++ b/workflows/genome_annotation/annotation-braker3/Genome_annotation_with_braker3-tests.yml
@@ -39,7 +39,8 @@
       asserts:
         - has_text:
             text: "AUGUSTUS"
-            text: "scaffold_100"   
+        - has_text:
+            text: "scaffold_100"
     
     Predicted Proteins:
       asserts:

--- a/workflows/genome_annotation/annotation-helixer/Galaxy-Workflow-annotation_helixer-tests.yml
+++ b/workflows/genome_annotation/annotation-helixer/Galaxy-Workflow-annotation_helixer-tests.yml
@@ -12,27 +12,32 @@
       asserts:
         - has_text:
             text: "##gff-version 3.2.1"
-            text: "Helixer"   
+        - has_text:
+            text: "Helixer"
     
     busco sum genome:
       asserts:
         - has_text:
             text: "BUSCO version is: 5.8.0"
-            text: "mucorales_odb10" 
+        - has_text:
+            text: "mucorales_odb10"
     busco gff genome:
       asserts:
         - has_text:
             text: "BUSCO version is: 5.8.0"
-            text: "miniprot"   
+        - has_text:
+            text: "miniprot"
     busco missing genome:
       asserts:
         - has_text:
             text: "Missing"
+        - has_text:
             text: "10at4827"
     busco table genome:
       asserts:
         - has_text:
             text: "Missing"
+        - has_text:
             text: "10at4827"
     
     gffread peptides:

--- a/workflows/genome_annotation/lncRNAs-annotation/Galaxy-Workflow-lncRNAs_annotation_workflow-tests.yml
+++ b/workflows/genome_annotation/lncRNAs-annotation/Galaxy-Workflow-lncRNAs_annotation_workflow-tests.yml
@@ -22,7 +22,8 @@
             n: 137448
         - has_text:
             text: "funannotate"
-            text: "transcript"   
+        - has_text:
+            text: "transcript"
     
     stringtie gtf:
       asserts:
@@ -30,7 +31,8 @@
             n: 77365
         - has_text:
             text: "StringTie version 2.2.3"
-            text: "transcript" 
+        - has_text:
+            text: "transcript"
     
     
     candidate lncRNA:
@@ -39,14 +41,16 @@
             n: 233
         - has_text:
             text: "StringTie"
-            text: "scaffold_21"   
+        - has_text:
+            text: "scaffold_21"
     classification:
       asserts:
         - has_n_lines:
             n: 696
         - has_text:
             text: "STRG.6410"
-            text: "antisense"   
+        - has_text:
+            text: "antisense"
     
     
     annotation final:
@@ -55,5 +59,6 @@
             n: 137681
         - has_text:
             text: "funannotate"
-            text: "StringTie"   
+        - has_text:
+            text: "StringTie"
     

--- a/workflows/scRNAseq/pseudobulk-worflow-decoupler-edger/pseudo-bulk_edgeR-tests.yml
+++ b/workflows/scRNAseq/pseudobulk-worflow-decoupler-edger/pseudo-bulk_edgeR-tests.yml
@@ -13,8 +13,10 @@
     Formula: '~ 0 + disease'
   outputs:
     'Pseudobulk count matrix':
-        has_text_matching:
+      asserts:
+        - that: has_text_matching
           expression: "ACAP2\t9.0\t18.0\t20.0\t68.0\t106.0\t122.0\t14.0\t259.0\t279.0\t184.0\t612.0\t293.0\t297.0\t46.0\t1.0\t0.0\t1.0\t12.0\t229.0\t151.0\t141.0\t309.0\t299.0\t181.0\t2.0\t2.0\t28.0\t15.0\t54.0\t210.0\t1.0\t1.0\t1.0\t11.0"
+        - that: has_text_matching
           expression: "ACER3\t4.0\t25.0\t21.0\t110.0\t82.0\t91.0\t22.0\t326.0\t297.0\t211.0\t1004.0\t574.0\t370.0\t108.0\t0.0\t0.0\t2.0\t2.0\t188.0\t113.0\t135.0\t322.0\t324.0\t159.0\t7.0\t7.0\t32.0\t5.0\t33.0\t89.0\t2.0\t2.0\t8.0\t48.0"
     'Pseudobulk Plot':
       element_test:
@@ -31,18 +33,22 @@
     'Tables: DEG':
       element_tests:
         edgeR_normal-COVID_19:
-          has_text_matching:
-            expression: "RALBP1\tENSG00000017797\tFalse\t0.518[0-9]*\t1.609[0-9]*\t0.402[0-9]*\t2\tFalse\t0.286[0-9]*\t0.552[0-9]*\t-1.967[0-9]*\t7.483[0-9]*\t12.0213[0-9]*\t0.001[0-9]*\t0.436[0-9]*"
-            expression: "NAPA\tENSG00000105402\tTrue\t0.342[0-9]\t1.686[0-9]\t0.846[0-9]\t4\tFalse\t0.180[0-9]\t0.440[0-9]\t-1.059[0-9]\t6.833[0-9]\t3.291[0-9]\t0.076[0-9]\t0.619[0-9]"
-          has_n_lines:
-            n: 1430
-            delta: 1
+          asserts:
+            - that: has_text_matching
+              expression: "RALBP1\tENSG00000017797\tFalse\t0.518[0-9]*\t1.609[0-9]*\t0.402[0-9]*\t2\tFalse\t0.286[0-9]*\t0.552[0-9]*\t-1.967[0-9]*\t7.483[0-9]*\t12.0213[0-9]*\t0.001[0-9]*\t0.436[0-9]*"
+            - that: has_text_matching
+              expression: "NAPA\tENSG00000105402\tTrue\t0.342[0-9]\t1.686[0-9]\t0.846[0-9]\t4\tFalse\t0.180[0-9]\t0.440[0-9]\t-1.059[0-9]\t6.833[0-9]\t3.291[0-9]\t0.076[0-9]\t0.619[0-9]"
+            - that: has_n_lines
+              n: 1430
+              delta: 1
     'Tables for volcano plot':
       element_tests:
         edgeR_normal-COVID_19:
-          has_text_matching:
-            expression: "CPEB4\t-2.402[0-9]\t0.001[0-9]\t0.436[0-9]"
-            expression: "FGFR1OP2\t-2.367[0-9]\t0.004[0-9]\t0.458[0-9]"
+          asserts:
+            - that: has_text_matching
+              expression: "CPEB4\t-2.402[0-9]\t0.001[0-9]\t0.436[0-9]"
+            - that: has_text_matching
+              expression: "FGFR1OP2\t-2.367[0-9]\t0.004[0-9]\t0.458[0-9]"
     'Volcano Plot on input dataset(s): PDF':
       element_tests:
         edgeR_normal-COVID_19:

--- a/workflows/transcriptomics/rnaseq-de/rnaseq-de-filtering-plotting-tests.yml
+++ b/workflows/transcriptomics/rnaseq-de/rnaseq-de-filtering-plotting-tests.yml
@@ -29,17 +29,21 @@
     log2 fold change threshold: 0.5
   outputs:
     Annotated DESeq2 results table:
-        has_text_matching:
-            expression: "YML123C\t122.984408142053\t-1.67[0-9]*\t0.21[0-9]*\t-7.66[0-9]*\t1.81[0-9]*e-14\t5.04[0-9]*e-[0-9]*\tchrXIII\t24036\t25800\t-\tprotein_coding\tPHO84"
-            expression: "YKL081W\t264.71[0-9]*\t-0.54[0-9]*\t0.15[0-9]*\t-3.46[0-9]*\t0.00[0-9]*\t0.09[0-9]*\tchrXI\t282890\t284455\t+\tprotein_coding\tTEF4"
+      asserts:
+        - that: has_text_matching
+          expression: "YML123C\t122.984408142053\t-1.67[0-9]*\t0.21[0-9]*\t-7.66[0-9]*\t1.81[0-9]*e-14\t5.04[0-9]*e-[0-9]*\tchrXIII\t24036\t25800\t-\tprotein_coding\tPHO84"
+        - that: has_text_matching
+          expression: "YKL081W\t264.71[0-9]*\t-0.54[0-9]*\t0.15[0-9]*\t-3.46[0-9]*\t0.00[0-9]*\t0.09[0-9]*\tchrXI\t282890\t284455\t+\tprotein_coding\tTEF4"
     Heatmap of Z-scores:
       has_size:
         value: 19510
         delta: 1000
     DESeq2 Normalized Counts:
-        has_text_matching:
-            expression: "YML123C\t210.50[0-9]*\t180.36[0-9]*\t48.64[0-9]*\t52.43[0-9]*"
-            expression: "YKL081W\t313.76[0-9]*\t322.37[0-9]*\t223.48[0-9]*\t199.24[0-9]*"
+      asserts:
+        - that: has_text_matching
+          expression: "YML123C\t210.50[0-9]*\t180.36[0-9]*\t48.64[0-9]*\t52.43[0-9]*"
+        - that: has_text_matching
+          expression: "YKL081W\t313.76[0-9]*\t322.37[0-9]*\t223.48[0-9]*\t199.24[0-9]*"
     DESeq2 Plots:
       has_size:
         value: 1193021

--- a/workflows/virology/generic-non-segmented-viral-variant-calling/pe-illumina-simple-virus-calling-and-consensus-test.yml
+++ b/workflows/virology/generic-non-segmented-viral-variant-calling/pe-illumina-simple-virus-calling-and-consensus-test.yml
@@ -59,6 +59,7 @@
         - that: "has_text"
           text: "SRR30155677_region_filtered\tAB016162.1\t"
           n: 43
+        - that: "has_text"
           text: "SRR30155702_subsampled\tAB016162.1\t"
           n: 599
 - doc: Test outline for pe-illumina-simple-virus-calling-and-consensus.ga with primer scheme (ampliconic mode)
@@ -129,5 +130,6 @@
         - that: "has_text"
           text: "SRR30155677_region_filtered\tAB016162.1\t"
           n: 39
+        - that: "has_text"
           text: "SRR30155702_subsampled\tAB016162.1\t"
           n: 498

--- a/workflows/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping-test.yml
+++ b/workflows/virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping-test.yml
@@ -43,12 +43,13 @@
   outputs:
     Subtyping results:
       asserts:
-        has_n_lines:
+        - that: has_n_lines
           n: 2
-        has_n_columns:
+        - that: has_n_columns
           n: 2
-        has_text:
+        - that: has_text
           text: "SRR6674560\tH3N2"
+        - that: has_text
           text: "SRR24839074\tH5N1"
     fastp reports:
       element_tests:
@@ -84,13 +85,15 @@
       element_tests:
         HA:
           asserts:
-            has_text:
+            - that: has_text
               text: ">SRR6674560|HA"
+            - that: has_text
               text: ">SRR24839074|HA"
         NA:
           asserts:
-            has_text:
+            - that: has_text
               text: ">SRR6674560|NA"
+            - that: has_text
               text: ">SRR24839074|NA"
     Snipit plots per segment:
       element_tests:


### PR DESCRIPTION
## Summary

Second pass after #1217. That PR fixed dup keys at the
`asserts:` level (two `has_text:` siblings). This one fixes the dup-key bug
one level deeper — the same assertion *content* key (`text:`, `expression:`,
`n:`) was repeated inside a single assertion block, so only the last value
survived the YAML load and everything before it was dead code.

```yaml
# Before — second "text:" overwrites first, "AUGUSTUS" assertion never ran
asserts:
  - has_text:
      text: "AUGUSTUS"
      text: "scaffold_100"

# After — both assertions run
asserts:
  - has_text:
      text: "AUGUSTUS"
  - has_text:
      text: "scaffold_100"
```

## Structural cleanup piggy-backed in

Three files were also missing the `asserts:` wrapper entirely — assertion
keys (`has_text_matching:`, `has_n_lines:`, etc.) were attached directly to
the output/element name. The current validator would reject those regardless,
so I added the `asserts:` wrapper while restructuring to list form:

- `scRNAseq/pseudobulk-worflow-decoupler-edger/pseudo-bulk_edgeR-tests.yml`
- `transcriptomics/rnaseq-de/rnaseq-de-filtering-plotting-tests.yml`
- `virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping-test.yml`

These files still have other schema drift (e.g. `element_test:` singular vs
`element_tests:` plural, `has_size:` outside `asserts:`) that's out of scope
for this PR and will be handled in a later cleanup.

## ⚠ Semantic change — same caveat as #<previous-PR-number>

Previously-dropped assertions now run for real. If CI surfaces an assertion
failure on one of these, the expected text needs updating — the author's
intent was clearly to assert both, and the dropped one just hadn't been
caught for however long.

## Files changed (7)

- `genome_annotation/annotation-braker3/Genome_annotation_with_braker3-tests.yml`
- `genome_annotation/annotation-helixer/Galaxy-Workflow-annotation_helixer-tests.yml`
- `genome_annotation/lncRNAs-annotation/Galaxy-Workflow-lncRNAs_annotation_workflow-tests.yml`
- `scRNAseq/pseudobulk-worflow-decoupler-edger/pseudo-bulk_edgeR-tests.yml`
- `transcriptomics/rnaseq-de/rnaseq-de-filtering-plotting-tests.yml`
- `virology/generic-non-segmented-viral-variant-calling/pe-illumina-simple-virus-calling-and-consensus-test.yml`
- `virology/influenza-isolates-consensus-and-subtyping/influenza-consensus-and-subtyping-test.yml`


FOR CONTRIBUTOR:
* [x] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [x] License permits unrestricted use (educational + commercial)
* [x] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
