### PR TITLE
VGP Precuration - Creation of the workflow to generate jbrowse2 instances with related  species

### DIFF
--- a/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/.dockstore.yml
+++ b/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/.dockstore.yml
@@ -1,0 +1,13 @@
+version: 1.2
+workflows:
+- name: main
+  subclass: Galaxy
+  publish: true
+  primaryDescriptorPath: /Precuration-Jbrowse-tracks-alignments.ga
+  testParameterFiles:
+  - /Precuration-Jbrowse-tracks-alignments-tests.yml
+  authors:
+  - name: Patrik Smeds
+    orcid: 0000-0001-6228-2785
+  - name: Delphine Lariviere
+    orcid: 0000-0001-6421-3484

--- a/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/CHANGELOG.md
+++ b/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [0.1] - 2026-05-07
+
+- Initial release: workflow generates JBrowse2 instances with assembly tracks (telomeres, gaps, coverage, optional gene annotation) and related-species alignments to assist manual curation of genome assemblies. Supports single- or dual-haplotype inputs.

--- a/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/Precuration-Jbrowse-tracks-alignments-tests.yml
+++ b/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/Precuration-Jbrowse-tracks-alignments-tests.yml
@@ -17,7 +17,6 @@
       hashes:
       - hash_function: SHA-1
         hash_value: a0ee25fd9f7cf223ca40ff530e1201589fade212
-    Will you use a second haplotype?: false
     Related Species:
       class: Collection
       collection_type: list
@@ -36,7 +35,6 @@
         hashes:
         - hash_function: SHA-1
           hash_value: bd70fbde965e16ee88b54223d6dfe67989d3865f
-    Do you want to provide gene annotation for your assembly?: false
     Telomere P:
       class: File
       location: https://zenodo.org/records/20074725/files/P_telomeres.bed
@@ -86,7 +84,6 @@
       hashes:
       - hash_function: SHA-1
         hash_value: a0ee25fd9f7cf223ca40ff530e1201589fade212
-    Will you use a second haplotype?: true
     Haplotype 2:
       class: File
       location: https://zenodo.org/records/20074725/files/Haplotype_2.fasta
@@ -112,7 +109,6 @@
         hashes:
         - hash_function: SHA-1
           hash_value: bd70fbde965e16ee88b54223d6dfe67989d3865f
-    Do you want to provide gene annotation for your assembly?: true
     Genes:
       class: File
       location: https://zenodo.org/records/20074725/files/Compleasm_genes_track.gff

--- a/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/Precuration-Jbrowse-tracks-alignments-tests.yml
+++ b/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/Precuration-Jbrowse-tracks-alignments-tests.yml
@@ -1,0 +1,151 @@
+# Planemo test configuration for Jbrowse2 Precuration tracks workflow
+# Test 1: Single haplotype with related species, no gene annotation
+# Test 2: Two haplotypes with related species and gene annotation
+#
+# All test files are hosted on Zenodo record 20074725. The Q_telomeres input
+# in the test reuses the P_telomeres file because the actual Q_telomeres test
+# file is empty and cannot be uploaded to Zenodo.
+
+- doc: Test 1 - Single haplotype, related species, no gene annotation
+  job:
+    Species Name: Test_species
+    Assembly Name: toLID
+    Haplotype 1:
+      class: File
+      location: https://zenodo.org/records/20074725/files/Haplotype_1.fasta
+      filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: a0ee25fd9f7cf223ca40ff530e1201589fade212
+    Will you use a second haplotype?: false
+    Related Species:
+      class: Collection
+      collection_type: list
+      elements:
+      - class: File
+        identifier: Related_species_1
+        location: https://zenodo.org/records/20074725/files/Related_species_1.fasta.gz
+        filetype: fasta.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 5121b574218ce9295fa6de1dd3fbdb1cfb9c68b1
+      - class: File
+        identifier: Related_species_2
+        location: https://zenodo.org/records/20074725/files/Related_species_2.fasta.gz
+        filetype: fasta.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: bd70fbde965e16ee88b54223d6dfe67989d3865f
+    Do you want to provide gene annotation for your assembly?: false
+    Telomere P:
+      class: File
+      location: https://zenodo.org/records/20074725/files/P_telomeres.bed
+      filetype: bed
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 54f67ca7cb77c89ce8b887ab0fa2205a69eec96d
+    Telomere Q:
+      class: File
+      location: https://zenodo.org/records/20074725/files/P_telomeres.bed
+      filetype: bed
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 54f67ca7cb77c89ce8b887ab0fa2205a69eec96d
+    Gaps:
+      class: File
+      location: https://zenodo.org/records/20074725/files/Gaps.bed
+      filetype: bed
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 5a14e6a11d9dc0ac41c3466f0693823a3f2c10be
+    Coverage:
+      class: File
+      location: https://zenodo.org/records/20074725/files/Coverage.bigwig
+      filetype: bigwig
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 63dfd14dbc162633ed123fc256dfc8ef756c5ad4
+  outputs:
+    JBrowse2 Single Haplotype with related species:
+      element_tests: {}
+    JBrowse2 Single Haplotype with related species and Gene Tracks:
+      element_tests: {}
+
+- doc: Test 2 - Two haplotypes, related species, with gene annotation
+  job:
+    Species Name: Test_species
+    Assembly Name: toLID
+    Haplotype 1:
+      class: File
+      location: https://zenodo.org/records/20074725/files/Haplotype_1.fasta
+      filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: a0ee25fd9f7cf223ca40ff530e1201589fade212
+    Will you use a second haplotype?: true
+    Haplotype 2:
+      class: File
+      location: https://zenodo.org/records/20074725/files/Haplotype_2.fasta
+      filetype: fasta
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 166cb118625113e39593bedb10aaea028c20f77d
+    Related Species:
+      class: Collection
+      collection_type: list
+      elements:
+      - class: File
+        identifier: Related_species_1
+        location: https://zenodo.org/records/20074725/files/Related_species_1.fasta.gz
+        filetype: fasta.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: 5121b574218ce9295fa6de1dd3fbdb1cfb9c68b1
+      - class: File
+        identifier: Related_species_2
+        location: https://zenodo.org/records/20074725/files/Related_species_2.fasta.gz
+        filetype: fasta.gz
+        hashes:
+        - hash_function: SHA-1
+          hash_value: bd70fbde965e16ee88b54223d6dfe67989d3865f
+    Do you want to provide gene annotation for your assembly?: true
+    Genes:
+      class: File
+      location: https://zenodo.org/records/20074725/files/Compleasm_genes_track.gff
+      filetype: gff3
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 526abf443cc04c3904c2b2b140b19bb4f17622d0
+    Telomere P:
+      class: File
+      location: https://zenodo.org/records/20074725/files/P_telomeres.bed
+      filetype: bed
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 54f67ca7cb77c89ce8b887ab0fa2205a69eec96d
+    Telomere Q:
+      class: File
+      location: https://zenodo.org/records/20074725/files/P_telomeres.bed
+      filetype: bed
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 54f67ca7cb77c89ce8b887ab0fa2205a69eec96d
+    Gaps:
+      class: File
+      location: https://zenodo.org/records/20074725/files/Gaps.bed
+      filetype: bed
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 5a14e6a11d9dc0ac41c3466f0693823a3f2c10be
+    Coverage:
+      class: File
+      location: https://zenodo.org/records/20074725/files/Coverage.bigwig
+      filetype: bigwig
+      hashes:
+      - hash_function: SHA-1
+        hash_value: 63dfd14dbc162633ed123fc256dfc8ef756c5ad4
+  outputs:
+    JBrowse2 Hap1 and hap2 with related species:
+      element_tests: {}
+    JBrowse2 Hap1 and hap2 with related species and gene tracks:
+      element_tests: {}

--- a/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/Precuration-Jbrowse-tracks-alignments-tests.yml
+++ b/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/Precuration-Jbrowse-tracks-alignments-tests.yml
@@ -66,6 +66,10 @@
       - hash_function: SHA-1
         hash_value: 63dfd14dbc162633ed123fc256dfc8ef756c5ad4
   outputs:
+    JBrowse2 Single Haplotype:
+      asserts:
+        has_text:
+          text: "JBrowse"
     JBrowse2 Single Haplotype with related species:
       element_tests: {}
     JBrowse2 Single Haplotype with related species and Gene Tracks:
@@ -145,6 +149,10 @@
       - hash_function: SHA-1
         hash_value: 63dfd14dbc162633ed123fc256dfc8ef756c5ad4
   outputs:
+    JBrowse2 Hap1 vs Hap2 with gene tracks:
+      asserts:
+        has_text:
+          text: "JBrowse"
     JBrowse2 Hap1 and hap2 with related species:
       element_tests: {}
     JBrowse2 Hap1 and hap2 with related species and gene tracks:

--- a/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/Precuration-Jbrowse-tracks-alignments.ga
+++ b/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/Precuration-Jbrowse-tracks-alignments.ga
@@ -1,6 +1,6 @@
 {
     "a_galaxy_workflow": "true",
-    "annotation": "This Workflow generates Jbrowse2 Instances with genome assembly tracks and alignements agains related species to assist the manual curation of genome assemblies. ",
+    "annotation": "This workflow generates JBrowse2 instances with genome assembly tracks and alignments against related species to assist the manual curation of genome assemblies. ",
     "comments": [],
     "creator": [
         {
@@ -16,8 +16,8 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
+    "release": "0.1",
     "name": "Jbrowse2 for Precuration with Related Species",
-    "readme": "",
     "report": {
         "markdown": "# Precuration  workflow on:\n\n```galaxy\nhistory_dataset_embedded(output=\"Assembly Info\")\n```\n\n## Duplication Stats\n\nSamtools markdup deduplication stats (if applicable)\n\n\n```galaxy\nhistory_dataset_as_table(output=\"Hi-C duplication stats\")\n```\n\n\n\nPairtools stats\n```galaxy\nhistory_dataset_as_table(output=\"Hi-C duplication stats: MultiQC\")\n```\n\n## Telomere report\n\n```galaxy\nhistory_dataset_embedded(output=\"Telomere Report\")\n```\n\n## Pretext Snapshots\n\nWith Multimapping\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Pretext Snapshot With tracks - Multimapping\")\n```\n\n\nWith MAPQ filtering\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Pretext Snapshot With tracks\")\n```\n\n\n"
     },
@@ -45,7 +45,7 @@
             "tool_state": "{\"multiple\": false, \"validators\": [], \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "fbb656ec-5dc2-4a7b-bb67-06642e707885",
+            "uuid": "61d68c28-9135-4fb7-af7f-6cf04e88cc9a",
             "when": null,
             "workflow_outputs": []
         },
@@ -72,7 +72,7 @@
             "tool_state": "{\"multiple\": false, \"validators\": [], \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "dd9e5260-8f5e-42a9-8708-fe657736d107",
+            "uuid": "8cc23e0a-d9bb-429c-a08e-ca357b3c3ad9",
             "when": null,
             "workflow_outputs": []
         },
@@ -99,7 +99,7 @@
             "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "fa895dbf-8f06-4728-ac6c-d526fcff2578",
+            "uuid": "672ebc11-5a2e-427c-9b64-c811821b5768",
             "when": null,
             "workflow_outputs": []
         },
@@ -126,7 +126,7 @@
             "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "697b66dc-1c0f-40d7-9d03-51318db580f1",
+            "uuid": "1f933849-8bc5-47ff-83da-7f53006c39cf",
             "when": null,
             "workflow_outputs": []
         },
@@ -146,49 +146,22 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 379.76112945636174,
-                "top": 508.0890158498388
+                "left": 415.3930839522133,
+                "top": 539.8438023368923
             },
             "tool_id": null,
             "tool_state": "{\"optional\": true, \"format\": [\"fasta\"], \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "b6516e91-ade5-457d-9b65-d54448413a13",
+            "uuid": "12c55b92-9015-4d4d-97ee-b675971486e4",
             "when": null,
             "workflow_outputs": []
         },
         "5": {
-            "annotation": "Note: Duplicated sequence names between the species in the collection will cause inaccurate alignment visualization in JBrowse2.  ",
-            "content_id": null,
-            "errors": null,
-            "id": 5,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "Note: Duplicated sequence names between the species in the collection will cause inaccurate alignment visualization in JBrowse2.  ",
-                    "name": "Related Species"
-                }
-            ],
-            "label": "Related Species",
-            "name": "Input dataset collection",
-            "outputs": [],
-            "position": {
-                "left": 454.5392171033154,
-                "top": 590.680154112835
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false, \"format\": [\"fasta.gz\"], \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
-            "tool_version": null,
-            "type": "data_collection_input",
-            "uuid": "ccac50f2-56b3-41ff-9670-4ef7e59dcd1d",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "6": {
             "annotation": "",
             "content_id": null,
             "errors": null,
-            "id": 6,
+            "id": 5,
             "input_connections": {},
             "inputs": [
                 {
@@ -200,22 +173,22 @@
             "name": "Input parameter",
             "outputs": [],
             "position": {
-                "left": 542.4198438191992,
-                "top": 698.2369037827142
+                "left": 532.8506745873698,
+                "top": 662.309181460891
             },
             "tool_id": null,
             "tool_state": "{\"default\": false, \"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "7b8f0c07-dc65-47c4-99c1-bf5d75d28ab2",
+            "uuid": "ae28b111-3e2f-4506-b653-97b4cebcee72",
             "when": null,
             "workflow_outputs": []
         },
-        "7": {
+        "6": {
             "annotation": "",
             "content_id": null,
             "errors": null,
-            "id": 7,
+            "id": 6,
             "input_connections": {},
             "inputs": [
                 {
@@ -234,15 +207,15 @@
             "tool_state": "{\"optional\": true, \"format\": [\"gff3\"], \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "fac0888a-e1fc-41df-b134-deb4b45d9a10",
+            "uuid": "5983756f-c13c-4a41-b323-f52db5e172a4",
             "when": null,
             "workflow_outputs": []
         },
-        "8": {
+        "7": {
             "annotation": "",
             "content_id": null,
             "errors": null,
-            "id": 8,
+            "id": 7,
             "input_connections": {},
             "inputs": [
                 {
@@ -261,15 +234,15 @@
             "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "d535900a-9ab8-4860-9b0d-880b072c1aa6",
+            "uuid": "1b1bf84f-e625-4b7d-8f9e-471cd5a18b4c",
             "when": null,
             "workflow_outputs": []
         },
-        "9": {
+        "8": {
             "annotation": "",
             "content_id": null,
             "errors": null,
-            "id": 9,
+            "id": 8,
             "input_connections": {},
             "inputs": [
                 {
@@ -288,15 +261,15 @@
             "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "aa5b2cfd-6a81-4e01-b721-2ff78cb1c8f9",
+            "uuid": "6e214300-bac1-46e2-9dba-b305b10dbe28",
             "when": null,
             "workflow_outputs": []
         },
-        "10": {
+        "9": {
             "annotation": "",
             "content_id": null,
             "errors": null,
-            "id": 10,
+            "id": 9,
             "input_connections": {},
             "inputs": [
                 {
@@ -315,15 +288,15 @@
             "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "47b84649-e4a6-4e49-874b-b7194cd62167",
+            "uuid": "04f38367-909b-4c7b-a452-261dcc1b77da",
             "when": null,
             "workflow_outputs": []
         },
-        "11": {
+        "10": {
             "annotation": "",
             "content_id": null,
             "errors": null,
-            "id": 11,
+            "id": 10,
             "input_connections": {},
             "inputs": [
                 {
@@ -342,7 +315,34 @@
             "tool_state": "{\"optional\": false, \"format\": [\"bigwig\"], \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "832bc0af-4341-470c-8da2-1ddbf94f83f0",
+            "uuid": "67d4f124-7ba7-4ca8-9980-77efb986ad53",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "11": {
+            "annotation": "Note: Duplicated sequence names between the species in the collection will cause inaccurate alignment visualization in JBrowse2.  ",
+            "content_id": null,
+            "errors": null,
+            "id": 11,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Note: Duplicated sequence names between the species in the collection will cause inaccurate alignment visualization in JBrowse2.  ",
+                    "name": "Related Species"
+                }
+            ],
+            "label": "Related Species",
+            "name": "Input dataset collection",
+            "outputs": [],
+            "position": {
+                "left": 1016.2648364611407,
+                "top": 1255.890937169875
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"format\": [\"fasta.gz\"], \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
+            "tool_version": null,
+            "type": "data_collection_input",
+            "uuid": "b1d57707-483c-43cd-8256-0a2888af1246",
             "when": null,
             "workflow_outputs": []
         },
@@ -399,13 +399,13 @@
             "tool_uuid": null,
             "tool_version": "0.1.1",
             "type": "tool",
-            "uuid": "b8f3cf11-2e38-4ad8-adaf-f73b48e4b2bf",
+            "uuid": "e8e6b489-fa33-4563-ba7a-9978b88c22e2",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Assembly Info",
                     "output_name": "out1",
-                    "uuid": "0c1bc167-f66b-4d07-9729-9c10669f6e02"
+                    "uuid": "9bc7a768-762d-4578-b675-7656de8d8a65"
                 }
             ]
         },
@@ -420,12 +420,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Map parameter value",
-                    "name": "input_param_type"
-                }
-            ],
+            "inputs": [],
             "label": "Only one Haplotype",
             "name": "Map parameter value",
             "outputs": [
@@ -435,8 +430,8 @@
                 }
             ],
             "position": {
-                "left": 1696.2229666494914,
-                "top": 489.1299185816589
+                "left": 1736.3581103638398,
+                "top": 455.0639514218991
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_param_boolean": {
@@ -456,7 +451,7 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "66395547-21e9-4e70-bbe0-a8e14f361e65",
+            "uuid": "df19ed91-a001-4caa-91f8-8d9051fde5c9",
             "when": null,
             "workflow_outputs": []
         },
@@ -485,8 +480,8 @@
                 }
             ],
             "position": {
-                "left": 1849.3268007633433,
-                "top": 762.524547165319
+                "left": 1706.8744833487017,
+                "top": 654.7944887566696
             },
             "post_job_actions": {
                 "HideDatasetActiondata_param": {
@@ -506,18 +501,68 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "d1e92b9f-8bed-41b3-bbe8-f6e8c6f94fce",
+            "uuid": "e6631462-b13d-46f1-8fdd-a3e760c3f76a",
             "when": null,
             "workflow_outputs": []
         },
         "15": {
             "annotation": "",
-            "content_id": "CONVERTER_gz_to_uncompressed",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
             "errors": null,
             "id": 15,
             "input_connections": {
+                "style_cond|type_cond|pick_from_0|value": {
+                    "id": 6,
+                    "output_name": "output"
+                },
+                "style_cond|type_cond|pick_from_1|value": {
+                    "id": 9,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Pick parameter value",
+            "outputs": [
+                {
+                    "name": "data_param",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2050.977397800029,
+                "top": 1042.9931586846508
+            },
+            "post_job_actions": {
+                "HideDatasetActiondata_param": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "data_param"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+            "tool_shed_repository": {
+                "changeset_revision": "b19e21af9c52",
+                "name": "pick_value",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"style_cond\": {\"pick_style\": \"first\", \"__current_case__\": 0, \"type_cond\": {\"param_type\": \"data\", \"__current_case__\": 4, \"pick_from\": [{\"__index__\": 0, \"value\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"value\": {\"__class__\": \"ConnectedValue\"}}]}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "0.2.0",
+            "type": "tool",
+            "uuid": "87a497ce-176b-4e85-adf2-0f3e58b24670",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "16": {
+            "annotation": "",
+            "content_id": "CONVERTER_gz_to_uncompressed",
+            "errors": null,
+            "id": 16,
+            "input_connections": {
                 "input1": {
-                    "id": 5,
+                    "id": 11,
                     "output_name": "output"
                 }
             },
@@ -531,8 +576,8 @@
                 }
             ],
             "position": {
-                "left": 1782.0781695209464,
-                "top": 959.6837944877021
+                "left": 1685.3438207068607,
+                "top": 928.4985122876616
             },
             "post_job_actions": {
                 "ChangeDatatypeActionoutput1": {
@@ -553,57 +598,7 @@
             "tool_uuid": null,
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "3573f560-1fd1-4748-94f5-530c89717387",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "16": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
-            "errors": null,
-            "id": 16,
-            "input_connections": {
-                "style_cond|type_cond|pick_from_0|value": {
-                    "id": 7,
-                    "output_name": "output"
-                },
-                "style_cond|type_cond|pick_from_1|value": {
-                    "id": 10,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Pick parameter value",
-            "outputs": [
-                {
-                    "name": "data_param",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 1889.2481070836782,
-                "top": 1357.6627147156235
-            },
-            "post_job_actions": {
-                "HideDatasetActiondata_param": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "data_param"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
-            "tool_shed_repository": {
-                "changeset_revision": "b19e21af9c52",
-                "name": "pick_value",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"style_cond\": {\"pick_style\": \"first\", \"__current_case__\": 0, \"type_cond\": {\"param_type\": \"data\", \"__current_case__\": 4, \"pick_from\": [{\"__index__\": 0, \"value\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"value\": {\"__class__\": \"ConnectedValue\"}}]}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_uuid": null,
-            "tool_version": "0.2.0",
-            "type": "tool",
-            "uuid": "15318e0e-6320-4637-a28b-29521d1c8d43",
+            "uuid": "6f868700-ff9c-4415-98d7-81befe9dde9e",
             "when": null,
             "workflow_outputs": []
         },
@@ -614,7 +609,7 @@
             "id": 17,
             "input_connections": {
                 "infile": {
-                    "id": 15,
+                    "id": 16,
                     "output_name": "output1"
                 }
             },
@@ -656,7 +651,7 @@
             "tool_uuid": null,
             "tool_version": "9.5+galaxy3",
             "type": "tool",
-            "uuid": "4e84f6c9-53ca-4119-bfba-960c183e46b5",
+            "uuid": "24671126-d835-4ecf-94c6-f22fa01d6abd",
             "when": null,
             "workflow_outputs": []
         },
@@ -665,22 +660,22 @@
             "id": 18,
             "input_connections": {
                 "Coverage": {
-                    "id": 11,
+                    "id": 10,
                     "input_subworkflow_step_id": 5,
                     "output_name": "output"
                 },
                 "Gaps": {
-                    "id": 10,
+                    "id": 9,
                     "input_subworkflow_step_id": 4,
                     "output_name": "output"
                 },
                 "Genes": {
-                    "id": 16,
+                    "id": 15,
                     "input_subworkflow_step_id": 6,
                     "output_name": "data_param"
                 },
                 "Genes?": {
-                    "id": 6,
+                    "id": 5,
                     "input_subworkflow_step_id": 7,
                     "output_name": "output"
                 },
@@ -690,17 +685,17 @@
                     "output_name": "output"
                 },
                 "Related Species": {
-                    "id": 15,
+                    "id": 16,
                     "input_subworkflow_step_id": 1,
                     "output_name": "output1"
                 },
                 "Telomeres P": {
-                    "id": 9,
+                    "id": 8,
                     "input_subworkflow_step_id": 3,
                     "output_name": "output"
                 },
                 "Telomeres Q": {
-                    "id": 8,
+                    "id": 7,
                     "input_subworkflow_step_id": 2,
                     "output_name": "output"
                 },
@@ -714,8 +709,8 @@
             "name": "Jbrowse for pre-curation single haplotype - 1 related Species ",
             "outputs": [],
             "position": {
-                "left": 2854.7399278462617,
-                "top": 1020.4253695653766
+                "left": 2934.6624331027892,
+                "top": 744.4198856816727
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -743,8 +738,8 @@
                         "name": "Input dataset",
                         "outputs": [],
                         "position": {
-                            "left": 0.0,
-                            "top": 229.96277645916257
+                            "left": 0,
+                            "top": 699.2443289019618
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
@@ -771,7 +766,7 @@
                         "outputs": [],
                         "position": {
                             "left": 77.86825459522053,
-                            "top": 325.6336833365997
+                            "top": 794.9152357793989
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
@@ -798,7 +793,7 @@
                         "outputs": [],
                         "position": {
                             "left": 162.91806250869854,
-                            "top": 456.26384063400747
+                            "top": 925.5453930768067
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
@@ -825,7 +820,7 @@
                         "outputs": [],
                         "position": {
                             "left": 235.76054218223504,
-                            "top": 579.8993537085871
+                            "top": 1049.1809061513864
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
@@ -852,7 +847,7 @@
                         "outputs": [],
                         "position": {
                             "left": 325.8334374647798,
-                            "top": 674.1406057066439
+                            "top": 1143.422158149443
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
@@ -879,7 +874,7 @@
                         "outputs": [],
                         "position": {
                             "left": 426.80614784345863,
-                            "top": 777.2141288680696
+                            "top": 1246.4956813108688
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"format\": [\"bigwig\"], \"tag\": \"\"}",
@@ -906,7 +901,7 @@
                         "outputs": [],
                         "position": {
                             "left": 481.54024694955143,
-                            "top": 876.2540908741984
+                            "top": 1345.5356433169977
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"tag\": \"\"}",
@@ -933,7 +928,7 @@
                         "outputs": [],
                         "position": {
                             "left": 535.8872921148474,
-                            "top": 982.3539279850593
+                            "top": 1451.6354804278585
                         },
                         "tool_id": null,
                         "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
@@ -968,8 +963,8 @@
                             }
                         ],
                         "position": {
-                            "left": 865.3187502811058,
-                            "top": 0
+                            "left": 1026.595772250997,
+                            "top": 858.7635819182626
                         },
                         "post_job_actions": {
                             "HideDatasetActionmashout": {
@@ -1002,7 +997,131 @@
                     },
                     "9": {
                         "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                        "errors": null,
                         "id": 9,
+                        "input_connections": {
+                            "input_param_type|input_param": {
+                                "id": 7,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Map parameter value",
+                        "outputs": [
+                            {
+                                "name": "output_param_boolean",
+                                "type": "expression.json"
+                            }
+                        ],
+                        "position": {
+                            "left": 909.3164880438957,
+                            "top": 1632.3549251437048
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionoutput_param_boolean": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output_param_boolean"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "5ac8a4bf7a8d",
+                            "name": "map_param_value",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": false, \"to\": \"True\"}, {\"__index__\": 1, \"from\": true, \"to\": \"False\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "0.2.0",
+                        "type": "tool",
+                        "uuid": "a8eddf6e-6019-46b9-bda4-3cae4f66baf1",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "10": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                        "errors": null,
+                        "id": 10,
+                        "input_connections": {
+                            "assemblies_0|reference_genome|genome": {
+                                "id": 0,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 2,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_0|data_tracks_1|data_format|annotation_cond|annotation": {
+                                "id": 3,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 4,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 5,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 6,
+                                "output_name": "output"
+                            },
+                            "when": {
+                                "id": 7,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "JBrowse2 Hap1 with gene track",
+                        "name": "JBrowse2",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "html"
+                            }
+                        ],
+                        "position": {
+                            "left": 1896.9114798587966,
+                            "top": 990.3320527378663
+                        },
+                        "post_job_actions": {
+                            "RenameDatasetActionoutput": {
+                                "action_arguments": {
+                                    "newname": "JBrowse2 Single Haplotype with Gene Track"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "output"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "bd903fbbc26e",
+                            "name": "jbrowse2",
+                            "owner": "fubar",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"RuntimeValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Telomeres\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_off\"}}]}, {\"__index__\": 1, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"Annotations\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "3.7.0+galaxy0",
+                        "type": "tool",
+                        "uuid": "8244bcfd-113f-4a5f-8b7a-4ebf39a2fd0d",
+                        "when": "$(inputs.when)",
+                        "workflow_outputs": [
+                            {
+                                "label": "JBrowse2 Single Haplotype with Gene Track",
+                                "output_name": "output",
+                                "uuid": "b4b0f191-314c-4519-8ea9-6885a3c3a1e5"
+                            }
+                        ]
+                    },
+                    "11": {
+                        "annotation": "",
+                        "id": 11,
                         "input_connections": {
                             "Coverage": {
                                 "id": 5,
@@ -1055,8 +1174,8 @@
                         "name": "Jbrowse2 for 1 related species - single haplotype",
                         "outputs": [],
                         "position": {
-                            "left": 1523.302721783011,
-                            "top": 447.47521325816376
+                            "left": 1504.531864079652,
+                            "top": 1218.259001224898
                         },
                         "subworkflow": {
                             "a_galaxy_workflow": "true",
@@ -1322,12 +1441,7 @@
                                             "output_name": "output"
                                         }
                                     },
-                                    "inputs": [
-                                        {
-                                            "description": "runtime parameter for tool Map parameter value",
-                                            "name": "input_param_type"
-                                        }
-                                    ],
+                                    "inputs": [],
                                     "label": null,
                                     "name": "Map parameter value",
                                     "outputs": [
@@ -1540,35 +1654,119 @@
                         "when": null,
                         "workflow_outputs": [
                             {
-                                "label": "JBrowse2 Single Haplotype with related species",
-                                "output_name": "JBrowse2 Single Haplotype with related species",
-                                "uuid": "3c519fbb-453d-418c-8af3-e4532cf23c28"
-                            },
-                            {
                                 "label": "JBrowse2 Single Haplotype with related species and Gene Tracks",
                                 "output_name": "JBrowse2 Single Haplotype with related species and Gene Tracks",
                                 "uuid": "2dc05ed1-2c39-45a0-b07c-2ec4b8a6b0df"
+                            },
+                            {
+                                "label": "JBrowse2 Single Haplotype with related species",
+                                "output_name": "JBrowse2 Single Haplotype with related species",
+                                "uuid": "3c519fbb-453d-418c-8af3-e4532cf23c28"
+                            }
+                        ]
+                    },
+                    "12": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                        "errors": null,
+                        "id": 12,
+                        "input_connections": {
+                            "assemblies_0|reference_genome|genome": {
+                                "id": 0,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 2,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_0|data_tracks_1|data_format|annotation_cond|annotation": {
+                                "id": 3,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 4,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 5,
+                                "output_name": "output"
+                            },
+                            "when": {
+                                "id": 9,
+                                "output_name": "output_param_boolean"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "JBrowse2 Hap1",
+                        "name": "JBrowse2",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "html"
+                            }
+                        ],
+                        "position": {
+                            "left": 1896.5312607039984,
+                            "top": 0.0
+                        },
+                        "post_job_actions": {
+                            "RenameDatasetActionoutput": {
+                                "action_arguments": {
+                                    "newname": "JBrowse2 Single Haplotype"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "output"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "bd903fbbc26e",
+                            "name": "jbrowse2",
+                            "owner": "fubar",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Telomeres\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_off\"}}]}, {\"__index__\": 1, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "3.7.0+galaxy0",
+                        "type": "tool",
+                        "uuid": "bda6d01b-ed4d-44b5-9307-4113d25d704c",
+                        "when": "$(inputs.when)",
+                        "workflow_outputs": [
+                            {
+                                "label": "JBrowse2 Single Haplotype",
+                                "output_name": "output",
+                                "uuid": "20eb67af-6a5e-44f1-a9eb-4cd7c7cf627a"
                             }
                         ]
                     }
                 },
                 "tags": [],
-                "uuid": "0569b4db-b204-41dc-b5c9-f5ad1b42265a"
+                "uuid": "aa94bcea-e6b3-4677-9709-176f6f732c75"
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "7fa40e11-ee9e-4492-852e-fa55278c26fe",
+            "uuid": "b0c9d1b4-2cfe-46b6-8a59-e2bbf8418997",
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
+                    "label": "JBrowse2 Single Haplotype",
+                    "output_name": "JBrowse2 Single Haplotype",
+                    "uuid": "6a22e395-9c90-4c39-8649-a02200a5f9d3"
+                },
+                {
                     "label": "JBrowse2 Single Haplotype with related species",
                     "output_name": "JBrowse2 Single Haplotype with related species",
-                    "uuid": "3a5bf4bd-0e11-4289-b09a-3126d1da9594"
+                    "uuid": "0651be6a-3ad9-4302-a501-702a7d435ea4"
                 },
                 {
                     "label": "JBrowse2 Single Haplotype with related species and Gene Tracks",
                     "output_name": "JBrowse2 Single Haplotype with related species and Gene Tracks",
-                    "uuid": "77c9e164-d85b-454e-b996-29fe74100c03"
+                    "uuid": "010b5194-1e89-4f30-9b20-1e3d7eac7aeb"
+                },
+                {
+                    "label": "JBrowse2 Single Haplotype with Gene Track",
+                    "output_name": "JBrowse2 Single Haplotype with Gene Track",
+                    "uuid": "4eacbf80-e972-46c8-afe6-e90d72faa758"
                 }
             ]
         },
@@ -1577,22 +1775,22 @@
             "id": 19,
             "input_connections": {
                 "Coverage": {
-                    "id": 11,
+                    "id": 10,
                     "input_subworkflow_step_id": 6,
                     "output_name": "output"
                 },
                 "Gaps": {
-                    "id": 10,
+                    "id": 9,
                     "input_subworkflow_step_id": 5,
                     "output_name": "output"
                 },
                 "Genes": {
-                    "id": 16,
+                    "id": 15,
                     "input_subworkflow_step_id": 8,
                     "output_name": "data_param"
                 },
                 "Genes?": {
-                    "id": 6,
+                    "id": 5,
                     "input_subworkflow_step_id": 7,
                     "output_name": "output"
                 },
@@ -1607,17 +1805,17 @@
                     "output_name": "data_param"
                 },
                 "Related Species": {
-                    "id": 15,
+                    "id": 16,
                     "input_subworkflow_step_id": 2,
                     "output_name": "output1"
                 },
                 "Telomeres P": {
-                    "id": 9,
+                    "id": 8,
                     "input_subworkflow_step_id": 4,
                     "output_name": "output"
                 },
                 "Telomeres Q": {
-                    "id": 8,
+                    "id": 7,
                     "input_subworkflow_step_id": 3,
                     "output_name": "output"
                 },
@@ -1898,6 +2096,63 @@
                                 "output_name": "output"
                             },
                             "reflist": {
+                                "id": 1,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "Align Haplotypes Hap1 is query",
+                        "name": "mashmap",
+                        "outputs": [
+                            {
+                                "name": "mashout",
+                                "type": "paf"
+                            }
+                        ],
+                        "position": {
+                            "left": 1507.3273804321968,
+                            "top": 793.8614046625582
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionmashout": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "mashout"
+                            },
+                            "RenameDatasetActionmashout": {
+                                "action_arguments": {
+                                    "newname": "Alignment Hap1 vs Hap2"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "mashout"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "a3a6b0b31f2d",
+                            "name": "mashmap",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"dense\": false, \"filter_mode\": \"map\", \"kmerComplexity\": null, \"kmerThreshold\": null, \"noHgFilter\": false, \"noMerge\": false, \"perc_identity\": \"90.0\", \"query\": {\"__class__\": \"ConnectedValue\"}, \"reflist\": {\"__class__\": \"ConnectedValue\"}, \"reportPercentage\": false, \"seqLength\": \"5000\", \"sketchSize\": \"0\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "3.1.3+galaxy0",
+                        "type": "tool",
+                        "uuid": "c7740c1c-5674-43d4-aa00-aeca2dcc7fa6",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "10": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
+                        "errors": null,
+                        "id": 10,
+                        "input_connections": {
+                            "query": {
+                                "id": 0,
+                                "output_name": "output"
+                            },
+                            "reflist": {
                                 "id": 2,
                                 "output_name": "output"
                             }
@@ -1944,11 +2199,11 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "10": {
+                    "11": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
                         "errors": null,
-                        "id": 10,
+                        "id": 11,
                         "input_connections": {
                             "query": {
                                 "id": 2,
@@ -2001,9 +2256,161 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "11": {
+                    "12": {
                         "annotation": "",
-                        "id": 11,
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                        "errors": null,
+                        "id": 12,
+                        "input_connections": {
+                            "input_param_type|input_param": {
+                                "id": 7,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Map parameter value",
+                        "outputs": [
+                            {
+                                "name": "output_param_boolean",
+                                "type": "expression.json"
+                            }
+                        ],
+                        "position": {
+                            "left": 1107.9772160860653,
+                            "top": 1163.288147730554
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionoutput_param_boolean": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output_param_boolean"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "5ac8a4bf7a8d",
+                            "name": "map_param_value",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": true, \"to\": \"False\"}, {\"__index__\": 1, \"from\": false, \"to\": \"True\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "0.2.0",
+                        "type": "tool",
+                        "uuid": "03bd04b4-815e-471e-8bf2-b51054b8390e",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "13": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                        "errors": null,
+                        "id": 13,
+                        "input_connections": {
+                            "assemblies_0|reference_genome|genome": {
+                                "id": 0,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 9,
+                                "output_name": "mashout"
+                            },
+                            "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 3,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_1|data_tracks_1|data_format|annotation_cond|annotation": {
+                                "id": 4,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 5,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 6,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_4|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 8,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|reference_genome|genome": {
+                                "id": 0,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 3,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_0|data_tracks_1|data_format|annotation_cond|annotation": {
+                                "id": 4,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 5,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 6,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 8,
+                                "output_name": "output"
+                            },
+                            "when": {
+                                "id": 7,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "JBrowse2 Hap1 vs Hap2 with gene tracks",
+                        "name": "JBrowse2",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "html"
+                            }
+                        ],
+                        "position": {
+                            "left": 2146.8088643141236,
+                            "top": 602.2449366027035
+                        },
+                        "post_job_actions": {
+                            "RenameDatasetActionoutput": {
+                                "action_arguments": {
+                                    "newname": "JBrowse2 Hap1 vs Hap2 with gene tracks"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "output"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "bd903fbbc26e",
+                            "name": "jbrowse2",
+                            "owner": "fubar",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"RuntimeValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Alignments\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Telomeres Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_off\"}}]}, {\"__index__\": 2, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 4, \"category\": \"Annotation\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 1, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"RuntimeValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Telomeres\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"Annotation\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "3.7.0+galaxy0",
+                        "type": "tool",
+                        "uuid": "8579f589-f836-4f8e-ad72-aa14a8b6c450",
+                        "when": "$(inputs.when)",
+                        "workflow_outputs": [
+                            {
+                                "label": "JBrowse2 Hap1 vs Hap2 with gene tracks",
+                                "output_name": "output",
+                                "uuid": "4db7f57b-58ba-4932-9d15-8a0e3cde1f9b"
+                            }
+                        ]
+                    },
+                    "14": {
+                        "annotation": "",
+                        "id": 14,
                         "input_connections": {
                             "Coverage": {
                                 "id": 6,
@@ -2031,7 +2438,7 @@
                                 "output_name": "output"
                             },
                             "Hap1 vs Species": {
-                                "id": 9,
+                                "id": 10,
                                 "input_subworkflow_step_id": 4,
                                 "output_name": "mashout"
                             },
@@ -2046,7 +2453,7 @@
                                 "output_name": "output"
                             },
                             "Species vs Hap2": {
-                                "id": 10,
+                                "id": 11,
                                 "input_subworkflow_step_id": 3,
                                 "output_name": "mashout"
                             },
@@ -2066,8 +2473,8 @@
                         "name": "Jbrowse2 for 1 related species",
                         "outputs": [],
                         "position": {
-                            "left": 2292.870790775461,
-                            "top": 343.7939440488241
+                            "left": 1887.4863910257557,
+                            "top": 102.53355703483975
                         },
                         "subworkflow": {
                             "a_galaxy_workflow": "true",
@@ -2387,12 +2794,7 @@
                                             "output_name": "output"
                                         }
                                     },
-                                    "inputs": [
-                                        {
-                                            "description": "runtime parameter for tool Map parameter value",
-                                            "name": "input_param_type"
-                                        }
-                                    ],
+                                    "inputs": [],
                                     "label": "No Gene track",
                                     "name": "Map parameter value",
                                     "outputs": [
@@ -2657,35 +3059,143 @@
                         "when": null,
                         "workflow_outputs": [
                             {
-                                "label": "JBrowse2 Hap1 and hap2 with related species",
-                                "output_name": "JBrowse2 Hap1 and hap2 with related species",
-                                "uuid": "7562c81f-4b86-4932-8056-52f4dc17d2a9"
-                            },
-                            {
                                 "label": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
                                 "output_name": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
                                 "uuid": "ca3249af-b46a-450d-8dbe-696490325d42"
+                            },
+                            {
+                                "label": "JBrowse2 Hap1 and hap2 with related species",
+                                "output_name": "JBrowse2 Hap1 and hap2 with related species",
+                                "uuid": "7562c81f-4b86-4932-8056-52f4dc17d2a9"
+                            }
+                        ]
+                    },
+                    "15": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                        "errors": null,
+                        "id": 15,
+                        "input_connections": {
+                            "assemblies_0|reference_genome|genome": {
+                                "id": 0,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 9,
+                                "output_name": "mashout"
+                            },
+                            "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 3,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_1|data_tracks_1|data_format|annotation_cond|annotation": {
+                                "id": 4,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 5,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 6,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|reference_genome|genome": {
+                                "id": 0,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 3,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_0|data_tracks_1|data_format|annotation_cond|annotation": {
+                                "id": 4,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 5,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 6,
+                                "output_name": "output"
+                            },
+                            "when": {
+                                "id": 12,
+                                "output_name": "output_param_boolean"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "JBrowse2 Hap1 vs Hap2",
+                        "name": "JBrowse2",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "html"
+                            }
+                        ],
+                        "position": {
+                            "left": 2427.3955083914084,
+                            "top": 101.59146846369417
+                        },
+                        "post_job_actions": {
+                            "RenameDatasetActionoutput": {
+                                "action_arguments": {
+                                    "newname": "JBrowse2 Hap1 vs Hap2"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "output"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "bd903fbbc26e",
+                            "name": "jbrowse2",
+                            "owner": "fubar",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Alignments\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Telomeres Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_off\"}}]}, {\"__index__\": 2, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 1, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Telomeres\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "3.7.0+galaxy0",
+                        "type": "tool",
+                        "uuid": "1838736c-68a4-41fd-b6c8-cd4de0aad595",
+                        "when": "$(inputs.when)",
+                        "workflow_outputs": [
+                            {
+                                "label": "JBrowse2 Hap1 vs Hap2",
+                                "output_name": "output",
+                                "uuid": "a3d1e37d-ea4d-44e6-ac96-c456fef1395f"
                             }
                         ]
                     }
                 },
                 "tags": [],
-                "uuid": "ef9af3c8-a765-4077-9cb2-9ad16d1a570e"
+                "uuid": "feda97a2-4c3f-4211-80f4-3c4cd83555a0"
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "af188630-081d-489b-b46f-eae324b3df01",
+            "uuid": "c65e39fb-f036-47f7-9bd1-c63d161b736f",
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
-                    "label": "JBrowse2 Hap1 and hap2 with related species",
-                    "output_name": "JBrowse2 Hap1 and hap2 with related species",
-                    "uuid": "6861e850-7a02-47cf-aab2-4093019878e9"
-                },
-                {
                     "label": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
                     "output_name": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
-                    "uuid": "edb52be2-a128-49cb-9c82-e693d7b7656c"
+                    "uuid": "4a390dc0-8929-4bf5-aea4-2ca8352a8987"
+                },
+                {
+                    "label": "JBrowse2 Hap1 and hap2 with related species",
+                    "output_name": "JBrowse2 Hap1 and hap2 with related species",
+                    "uuid": "1d0f2614-f167-446d-b874-f2435995ca7a"
+                },
+                {
+                    "label": "JBrowse2 Hap1 vs Hap2",
+                    "output_name": "JBrowse2 Hap1 vs Hap2",
+                    "uuid": "a0cefb53-5c71-4e7a-8415-760c5f49d254"
+                },
+                {
+                    "label": "JBrowse2 Hap1 vs Hap2 with gene tracks",
+                    "output_name": "JBrowse2 Hap1 vs Hap2 with gene tracks",
+                    "uuid": "42a88cd2-d2d5-4cfe-a00c-145d647cb12b"
                 }
             ]
         },
@@ -2731,7 +3241,7 @@
             "tool_uuid": null,
             "tool_version": "5.1.0",
             "type": "tool",
-            "uuid": "c70c2d41-43fe-4601-a3aa-8ca8a5433c0a",
+            "uuid": "6e2e1a5d-5849-4852-898d-6646c379ee0d",
             "when": null,
             "workflow_outputs": []
         },
@@ -2757,7 +3267,7 @@
             ],
             "position": {
                 "left": 2853.562857058991,
-                "top": 0.0
+                "top": 0
             },
             "post_job_actions": {
                 "ChangeDatatypeActionoutfile": {
@@ -2784,7 +3294,7 @@
             "tool_uuid": null,
             "tool_version": "9.5+galaxy3",
             "type": "tool",
-            "uuid": "19ffba37-86b9-4fe3-aae8-f8fbfa2d4ff0",
+            "uuid": "4e7c4704-4734-49f8-b51e-53c500853bbc",
             "when": null,
             "workflow_outputs": []
         },
@@ -2824,7 +3334,7 @@
             "tool_uuid": null,
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "b00153cb-f706-4e4a-bda6-4b3e859858f6",
+            "uuid": "71d76ee3-7dac-450a-98e9-bb57111df8c5",
             "when": null,
             "workflow_outputs": []
         },
@@ -2864,7 +3374,7 @@
             "tool_uuid": null,
             "tool_version": "1.0.0",
             "type": "tool",
-            "uuid": "b1b48543-f5a6-410b-aeb6-86c058dee9e3",
+            "uuid": "2da84228-d818-493b-bafd-a95959ee2de3",
             "when": null,
             "workflow_outputs": []
         },
@@ -2904,7 +3414,7 @@
             "tool_uuid": null,
             "tool_version": "0.1.0",
             "type": "tool",
-            "uuid": "0d89e2e9-fec0-4bc8-a3fc-513dc91f2f1b",
+            "uuid": "c03bb38c-3383-4d3f-843f-9f74c70b1c47",
             "when": null,
             "workflow_outputs": []
         },
@@ -2944,7 +3454,7 @@
             "tool_uuid": null,
             "tool_version": "0.1.0",
             "type": "tool",
-            "uuid": "9f9a8b3d-6d0a-424f-aae0-4db2e0c16940",
+            "uuid": "5ad8559e-e863-45e9-bae2-ede8be8314c7",
             "when": null,
             "workflow_outputs": []
         },
@@ -2994,7 +3504,7 @@
             "tool_uuid": null,
             "tool_version": "0.1.0",
             "type": "tool",
-            "uuid": "34cce52f-7548-4454-94ad-ee1547b25636",
+            "uuid": "bdc1a0bf-1614-47f8-90f8-89cc139edf9a",
             "when": null,
             "workflow_outputs": []
         },
@@ -3009,12 +3519,7 @@
                     "output_name": "integer_param"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Map parameter value",
-                    "name": "input_param_type"
-                }
-            ],
+            "inputs": [],
             "label": "Fail if there are duplicated sequence names between the fasta files",
             "name": "Map parameter value",
             "outputs": [
@@ -3047,19 +3552,19 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "84eeffe0-4578-4857-8555-841769a58073",
+            "uuid": "4af8e08f-5777-40db-b483-89d68084369b",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Fail if there are duplicated sequence names between the fasta files",
                     "output_name": "output_param_boolean",
-                    "uuid": "b4ebfb36-d369-4ced-964c-450c62e01b7d"
+                    "uuid": "3928e6f8-3d1b-46dc-b5dc-8d5bae43deb7"
                 }
             ]
         }
     },
     "tags": [],
-    "uuid": "2e394d56-6c89-4588-956e-5c1a9abd33c2",
-    "version": 1,
-    "release": "0.1"
+    "uuid": "62ed4482-aaa8-4942-b327-e16cae8f537f",
+    "version": 18,
+    "readme": "# JBrowse2 Precuration Tracks with Related Species Alignments\n\nThis workflow generates JBrowse2 instances with genome assembly tracks and alignments against related species, to assist the manual curation of genome assemblies. It complements the Hi-C contact map workflow by providing a complementary genome browser view of the same precuration tracks alongside synteny with related species.\n\nThe workflow takes the assembly haplotype(s) and the precuration tracks (telomeres, gaps, coverage, optional gene annotations), aligns the assembly against a list of related species, and packages everything into a JBrowse2 instance that curators can open directly in their browser.\n\n## Inputs\n\n### Required Inputs\n\n1. **Species Name** [text] - Species identifier used in the assembly info report\n2. **Assembly Name** [text] - Assembly identifier (e.g., toLID)\n3. **Haplotype 1** [fasta] - Primary haplotype assembly (recommended: with H1 suffix added to scaffold names)\n4. **Will you use a second haplotype?** [boolean] - Set to true for diploid assemblies\n5. **Haplotype 2** [fasta, optional] - Secondary haplotype assembly (required if using two haplotypes)\n6. **Related Species** [collection of fasta.gz] - Simple list of gzipped FASTA files of related species genomes for synteny alignment. **Sequence names must be unique across the entire collection** - the workflow performs a duplicate-name check on the merged related-species fastas and will fail early if any sequence name appears in more than one file. A common pattern is to prefix each species' scaffolds with the species name (e.g. `Species_1_scaffold_1`).\n7. **Telomere P** [BED] - P-arm telomere coordinates\n8. **Telomere Q** [BED] - Q-arm telomere coordinates (can be empty)\n9. **Gaps** [BED] - Assembly gap coordinates\n10. **Coverage** [BigWig] - PacBio HiFi read coverage track\n\n### Gene Annotation Options\n\n11. **Do you want to provide gene annotation for your assembly?** [boolean] - Enable to include a gene annotation track in the JBrowse2 instance\n12. **Genes** [GFF, optional] - Gene annotation track (required if gene annotations enabled)\n\n## Outputs\n\n1. **Assembly Info** - Summary of species and assembly name\n2. **JBrowse2 Single Haplotype with related species** [collection] - JBrowse2 instance for a single haplotype with related species alignments (when only one haplotype is used)\n3. **JBrowse2 Single Haplotype with related species and Gene Tracks** [collection] - As above, with gene annotation tracks included\n4. **JBrowse2 Hap1 and hap2 with related species** [collection] - JBrowse2 instance for two haplotypes with related species alignments (when two haplotypes are used)\n5. **JBrowse2 Hap1 and hap2 with related species and gene tracks** [collection] - As above, with gene annotation tracks included\n\n### Additional outputs\n\nThese JBrowse2 instances are produced without the related-species alignment tracks and can be useful for curators who only need the assembly-internal view.\n\n6. **JBrowse2 Single Haplotype** [collection] - JBrowse2 instance for a single haplotype with assembly tracks only (telomeres, gaps, coverage), no related-species alignments\n7. **JBrowse2 Single Haplotype with Gene Track** [collection] - As above, with gene annotation tracks included\n8. **JBrowse2 Hap1 vs Hap2** [collection] - JBrowse2 instance for two haplotypes with the hap1-vs-hap2 alignment, no related-species alignments\n9. **JBrowse2 Hap1 vs Hap2 with gene tracks** [collection] - As above, with gene annotation tracks included\n\n### Validation output\n\n10. **Fail if there are duplicated sequence names between the fasta files** [boolean] - Internal validation flag. The workflow fails fast if any sequence name appears in more than one of the related-species fastas.\n\n## Usage Notes\n\n### Pairing with the Hi-C contact map workflow\n\nThis workflow is designed to consume the precuration track outputs of the [Hi-C contact map for assembly manual curation](../hi-c-contact-map-for-assembly-manual-curation) workflow:\n\n| Hi-C workflow output | Use here as input |\n|---|---|\n| `Decontaminated Hap1 with Suffix` | `Haplotype 1` |\n| `Decontaminated Hap2 with Suffix` | `Haplotype 2` |\n| `P telomeres bed` | `Telomere P` |\n| `Q telomeres Bed` | `Telomere Q` |\n| `Gaps Bed` | `Gaps` |\n| `BigWig Coverage` | `Coverage` |\n| `Compleasm Genes track` | `Genes` |\n\n### Related species selection\n\nChoose related species whose genomes are evolutionarily close to the assembly under curation, so synteny is informative for spotting misassemblies. Provide them as gzipped FASTA files in a simple list collection.\n\n**Sequence names must be unique across the collection.** The workflow validates this and fails fast if duplicates are detected (e.g. two species both contain `>scaffold_1`). Prefix per-species scaffold names before uploading, for example:\n\n```bash\nzcat Species_1.fasta.gz | sed 's/^>/>Species_1_/' | gzip > Species_1_renamed.fasta.gz\n```\n\n### Scaffold name suffixes\n\nIf using two haplotypes, the recommended workflow is to apply per-haplotype suffixes (e.g. `H1`/`H2`) to scaffold names *before* running this workflow, so that scaffolds from each haplotype are unambiguously identified in the JBrowse view and in synteny tracks.\n\n## Citation\n\nIf you use this workflow, please cite:\n- JBrowse2 ([Diesh et al., 2023](https://doi.org/10.1186/s13059-023-02914-z))\n- minimap2 (used for related-species alignment)\n- Other tools as listed in the workflow\n"
 }

--- a/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/Precuration-Jbrowse-tracks-alignments.ga
+++ b/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/Precuration-Jbrowse-tracks-alignments.ga
@@ -1,0 +1,3065 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "This Workflow generates Jbrowse2 Instances with genome assembly tracks and alignements agains related species to assist the manual curation of genome assemblies. ",
+    "comments": [],
+    "creator": [
+        {
+            "class": "Person",
+            "identifier": "https://orcid.org/0000-0001-6228-2785",
+            "name": "Patrik Smeds"
+        },
+        {
+            "class": "Person",
+            "identifier": "https://orcid.org/0000-0001-6421-3484",
+            "name": "Delphine Lariviere"
+        }
+    ],
+    "format-version": "0.1",
+    "license": "MIT",
+    "name": "Jbrowse2 for Precuration with Related Species",
+    "readme": "",
+    "report": {
+        "markdown": "# Precuration  workflow on:\n\n```galaxy\nhistory_dataset_embedded(output=\"Assembly Info\")\n```\n\n## Duplication Stats\n\nSamtools markdup deduplication stats (if applicable)\n\n\n```galaxy\nhistory_dataset_as_table(output=\"Hi-C duplication stats\")\n```\n\n\n\nPairtools stats\n```galaxy\nhistory_dataset_as_table(output=\"Hi-C duplication stats: MultiQC\")\n```\n\n## Telomere report\n\n```galaxy\nhistory_dataset_embedded(output=\"Telomere Report\")\n```\n\n## Pretext Snapshots\n\nWith Multimapping\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Pretext Snapshot With tracks - Multimapping\")\n```\n\n\nWith MAPQ filtering\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Pretext Snapshot With tracks\")\n```\n\n\n"
+    },
+    "steps": {
+        "0": {
+            "annotation": "For Workflow report.",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "For Workflow report.",
+                    "name": "Species Name"
+                }
+            ],
+            "label": "Species Name",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 0,
+                "top": 113.32852983289965
+            },
+            "tool_id": null,
+            "tool_state": "{\"multiple\": false, \"validators\": [], \"parameter_type\": \"text\", \"optional\": false}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "fbb656ec-5dc2-4a7b-bb67-06642e707885",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "1": {
+            "annotation": "For Workflow report.",
+            "content_id": null,
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "For Workflow report.",
+                    "name": "Assembly Name"
+                }
+            ],
+            "label": "Assembly Name",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 95.65671993217956,
+                "top": 204.52575895443343
+            },
+            "tool_id": null,
+            "tool_state": "{\"multiple\": false, \"validators\": [], \"parameter_type\": \"text\", \"optional\": false}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "dd9e5260-8f5e-42a9-8708-fe657736d107",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "2": {
+            "annotation": "Assembly for Haplotype 1.",
+            "content_id": null,
+            "errors": null,
+            "id": 2,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Assembly for Haplotype 1.",
+                    "name": "Haplotype 1"
+                }
+            ],
+            "label": "Haplotype 1",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 198.28766556712145,
+                "top": 333.06630818129815
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "fa895dbf-8f06-4728-ac6c-d526fcff2578",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "3": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 3,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Will you use a second haplotype?"
+                }
+            ],
+            "label": "Will you use a second haplotype?",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 301.8902333217979,
+                "top": 405.0410156580133
+            },
+            "tool_id": null,
+            "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "697b66dc-1c0f-40d7-9d03-51318db580f1",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "4": {
+            "annotation": "Assembly for Haplotype 2. If \"Will you use a second haplotype?\" is set to \"no\", use haplotype 1 here. ",
+            "content_id": null,
+            "errors": null,
+            "id": 4,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Assembly for Haplotype 2. If \"Will you use a second haplotype?\" is set to \"no\", use haplotype 1 here. ",
+                    "name": "Haplotype 2"
+                }
+            ],
+            "label": "Haplotype 2",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 379.76112945636174,
+                "top": 508.0890158498388
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": true, \"format\": [\"fasta\"], \"tag\": null}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "b6516e91-ade5-457d-9b65-d54448413a13",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "5": {
+            "annotation": "Note: Duplicated sequence names between the species in the collection will cause inaccurate alignment visualization in JBrowse2.  ",
+            "content_id": null,
+            "errors": null,
+            "id": 5,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Note: Duplicated sequence names between the species in the collection will cause inaccurate alignment visualization in JBrowse2.  ",
+                    "name": "Related Species"
+                }
+            ],
+            "label": "Related Species",
+            "name": "Input dataset collection",
+            "outputs": [],
+            "position": {
+                "left": 454.5392171033154,
+                "top": 590.680154112835
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"format\": [\"fasta.gz\"], \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
+            "tool_version": null,
+            "type": "data_collection_input",
+            "uuid": "ccac50f2-56b3-41ff-9670-4ef7e59dcd1d",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "6": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 6,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Do you want to provide gene annotation for your assembly?"
+                }
+            ],
+            "label": "Do you want to provide gene annotation for your assembly?",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 542.4198438191992,
+                "top": 698.2369037827142
+            },
+            "tool_id": null,
+            "tool_state": "{\"default\": false, \"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "7b8f0c07-dc65-47c4-99c1-bf5d75d28ab2",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "7": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 7,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Genes"
+                }
+            ],
+            "label": "Genes",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 614.6440902431865,
+                "top": 818.8033806207972
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": true, \"format\": [\"gff3\"], \"tag\": null}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "fac0888a-e1fc-41df-b134-deb4b45d9a10",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "8": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 8,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Telomere Q"
+                }
+            ],
+            "label": "Telomere Q",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 680.5676592646699,
+                "top": 901.3563409388138
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "d535900a-9ab8-4860-9b0d-880b072c1aa6",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "9": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 9,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Telomere P"
+                }
+            ],
+            "label": "Telomere P",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 761.1770988870501,
+                "top": 998.8551768278469
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "aa5b2cfd-6a81-4e01-b721-2ff78cb1c8f9",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "10": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 10,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Gaps"
+                }
+            ],
+            "label": "Gaps",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 816.7956506700089,
+                "top": 1085.617189755827
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "47b84649-e4a6-4e49-874b-b7194cd62167",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "11": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 11,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Coverage"
+                }
+            ],
+            "label": "Coverage",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 889.9015443268538,
+                "top": 1165.3201006570696
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"format\": [\"bigwig\"], \"tag\": null}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "832bc0af-4341-470c-8da2-1ddbf94f83f0",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "12": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
+            "errors": null,
+            "id": 12,
+            "input_connections": {
+                "components_0|param_type|component_value": {
+                    "id": 0,
+                    "output_name": "output"
+                },
+                "components_2|param_type|component_value": {
+                    "id": 1,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Compose text parameter value",
+            "outputs": [
+                {
+                    "name": "out1",
+                    "type": "expression.json"
+                }
+            ],
+            "position": {
+                "left": 1513.3687877339703,
+                "top": 196.67349674870826
+            },
+            "post_job_actions": {
+                "HideDatasetActionout1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out1"
+                },
+                "RenameDatasetActionout1": {
+                    "action_arguments": {
+                        "newname": "Assembly Info"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out1"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
+            "tool_shed_repository": {
+                "changeset_revision": "e188c9826e0f",
+                "name": "compose_text_param",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": \": \"}}, {\"__index__\": 2, \"param_type\": {\"select_param_type\": \"text\", \"__current_case__\": 0, \"component_value\": {\"__class__\": \"ConnectedValue\"}}}], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "0.1.1",
+            "type": "tool",
+            "uuid": "b8f3cf11-2e38-4ad8-adaf-f73b48e4b2bf",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Assembly Info",
+                    "output_name": "out1",
+                    "uuid": "0c1bc167-f66b-4d07-9729-9c10669f6e02"
+                }
+            ]
+        },
+        "13": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+            "errors": null,
+            "id": 13,
+            "input_connections": {
+                "input_param_type|input_param": {
+                    "id": 3,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Map parameter value",
+                    "name": "input_param_type"
+                }
+            ],
+            "label": "Only one Haplotype",
+            "name": "Map parameter value",
+            "outputs": [
+                {
+                    "name": "output_param_boolean",
+                    "type": "expression.json"
+                }
+            ],
+            "position": {
+                "left": 1696.2229666494914,
+                "top": 489.1299185816589
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput_param_boolean": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_param_boolean"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+            "tool_shed_repository": {
+                "changeset_revision": "5ac8a4bf7a8d",
+                "name": "map_param_value",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": true, \"to\": \"False\"}, {\"__index__\": 1, \"from\": false, \"to\": \"True\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "0.2.0",
+            "type": "tool",
+            "uuid": "66395547-21e9-4e70-bbe0-a8e14f361e65",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "14": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+            "errors": null,
+            "id": 14,
+            "input_connections": {
+                "style_cond|type_cond|pick_from_0|value": {
+                    "id": 4,
+                    "output_name": "output"
+                },
+                "style_cond|type_cond|pick_from_1|value": {
+                    "id": 2,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Pick parameter value",
+            "outputs": [
+                {
+                    "name": "data_param",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1849.3268007633433,
+                "top": 762.524547165319
+            },
+            "post_job_actions": {
+                "HideDatasetActiondata_param": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "data_param"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+            "tool_shed_repository": {
+                "changeset_revision": "b19e21af9c52",
+                "name": "pick_value",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"style_cond\": {\"pick_style\": \"first\", \"__current_case__\": 0, \"type_cond\": {\"param_type\": \"data\", \"__current_case__\": 4, \"pick_from\": [{\"__index__\": 0, \"value\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"value\": {\"__class__\": \"ConnectedValue\"}}]}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "0.2.0",
+            "type": "tool",
+            "uuid": "d1e92b9f-8bed-41b3-bbe8-f6e8c6f94fce",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "15": {
+            "annotation": "",
+            "content_id": "CONVERTER_gz_to_uncompressed",
+            "errors": null,
+            "id": 15,
+            "input_connections": {
+                "input1": {
+                    "id": 5,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Convert gz compressed file to uncompressed.",
+            "outputs": [
+                {
+                    "name": "output1",
+                    "type": "auto"
+                }
+            ],
+            "position": {
+                "left": 1782.0781695209464,
+                "top": 959.6837944877021
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionoutput1": {
+                    "action_arguments": {
+                        "newtype": "fasta"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "output1"
+                },
+                "HideDatasetActionoutput1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output1"
+                }
+            },
+            "tool_id": "CONVERTER_gz_to_uncompressed",
+            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "3573f560-1fd1-4748-94f5-530c89717387",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "16": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+            "errors": null,
+            "id": 16,
+            "input_connections": {
+                "style_cond|type_cond|pick_from_0|value": {
+                    "id": 7,
+                    "output_name": "output"
+                },
+                "style_cond|type_cond|pick_from_1|value": {
+                    "id": 10,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Pick parameter value",
+            "outputs": [
+                {
+                    "name": "data_param",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1889.2481070836782,
+                "top": 1357.6627147156235
+            },
+            "post_job_actions": {
+                "HideDatasetActiondata_param": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "data_param"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+            "tool_shed_repository": {
+                "changeset_revision": "b19e21af9c52",
+                "name": "pick_value",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"style_cond\": {\"pick_style\": \"first\", \"__current_case__\": 0, \"type_cond\": {\"param_type\": \"data\", \"__current_case__\": 4, \"pick_from\": [{\"__index__\": 0, \"value\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"value\": {\"__class__\": \"ConnectedValue\"}}]}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "0.2.0",
+            "type": "tool",
+            "uuid": "15318e0e-6320-4637-a28b-29521d1c8d43",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "17": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.5+galaxy3",
+            "errors": null,
+            "id": 17,
+            "input_connections": {
+                "infile": {
+                    "id": 15,
+                    "output_name": "output1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Search in textfiles",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2193.787159776598,
+                "top": 516.9501479775356
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionoutput": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "output"
+                },
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.5+galaxy3",
+            "tool_shed_repository": {
+                "changeset_revision": "ab83aa685821",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"case_sensitive\": \"-i\", \"color\": \"NOCOLOR\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"invert\": \"\", \"lines_after\": \"0\", \"lines_before\": \"0\", \"regex_type\": \"-P\", \"url_paste\": \">\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "9.5+galaxy3",
+            "type": "tool",
+            "uuid": "4e84f6c9-53ca-4119-bfba-960c183e46b5",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "18": {
+            "annotation": "",
+            "id": 18,
+            "input_connections": {
+                "Coverage": {
+                    "id": 11,
+                    "input_subworkflow_step_id": 5,
+                    "output_name": "output"
+                },
+                "Gaps": {
+                    "id": 10,
+                    "input_subworkflow_step_id": 4,
+                    "output_name": "output"
+                },
+                "Genes": {
+                    "id": 16,
+                    "input_subworkflow_step_id": 6,
+                    "output_name": "data_param"
+                },
+                "Genes?": {
+                    "id": 6,
+                    "input_subworkflow_step_id": 7,
+                    "output_name": "output"
+                },
+                "Hap1 fasta": {
+                    "id": 2,
+                    "input_subworkflow_step_id": 0,
+                    "output_name": "output"
+                },
+                "Related Species": {
+                    "id": 15,
+                    "input_subworkflow_step_id": 1,
+                    "output_name": "output1"
+                },
+                "Telomeres P": {
+                    "id": 9,
+                    "input_subworkflow_step_id": 3,
+                    "output_name": "output"
+                },
+                "Telomeres Q": {
+                    "id": 8,
+                    "input_subworkflow_step_id": 2,
+                    "output_name": "output"
+                },
+                "when": {
+                    "id": 13,
+                    "output_name": "output_param_boolean"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Jbrowse for pre-curation single haplotype - 1 related Species ",
+            "outputs": [],
+            "position": {
+                "left": 2854.7399278462617,
+                "top": 1020.4253695653766
+            },
+            "subworkflow": {
+                "a_galaxy_workflow": "true",
+                "annotation": "",
+                "comments": [],
+                "format-version": "0.1",
+                "name": "Jbrowse for pre-curation single haplotype - 1 related Species ",
+                "report": {
+                    "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
+                },
+                "steps": {
+                    "0": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 0,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Hap1 fasta"
+                            }
+                        ],
+                        "label": "Hap1 fasta",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 0.0,
+                            "top": 229.96277645916257
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "4a20362f-2551-4a60-9118-e4c3e7c4f264",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "1": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 1,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Related Species"
+                            }
+                        ],
+                        "label": "Related Species",
+                        "name": "Input dataset collection",
+                        "outputs": [],
+                        "position": {
+                            "left": 77.86825459522053,
+                            "top": 325.6336833365997
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
+                        "tool_version": null,
+                        "type": "data_collection_input",
+                        "uuid": "771229b7-cdcc-462a-a1e5-314204a3fca1",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "2": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 2,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Telomeres Q"
+                            }
+                        ],
+                        "label": "Telomeres Q",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 162.91806250869854,
+                            "top": 456.26384063400747
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "ce01ac46-a3c2-4013-ba5b-ea8a0e46be64",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "3": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 3,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Telomeres P"
+                            }
+                        ],
+                        "label": "Telomeres P",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 235.76054218223504,
+                            "top": 579.8993537085871
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "8044ff06-8a3b-4ac1-b6ee-521cc28e585d",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "4": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 4,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Gaps"
+                            }
+                        ],
+                        "label": "Gaps",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 325.8334374647798,
+                            "top": 674.1406057066439
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "37e56713-8aa6-474e-9a87-6c702d7d6b49",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "5": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 5,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Coverage"
+                            }
+                        ],
+                        "label": "Coverage",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 426.80614784345863,
+                            "top": 777.2141288680696
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"bigwig\"], \"tag\": \"\"}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "738f43fc-5f88-4117-bcc3-4a9c1b01c0a1",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "6": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 6,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Genes"
+                            }
+                        ],
+                        "label": "Genes",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 481.54024694955143,
+                            "top": 876.2540908741984
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"tag\": \"\"}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "3831fc6f-0526-46ab-869b-5a07c6cded67",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "7": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 7,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Genes?"
+                            }
+                        ],
+                        "label": "Genes?",
+                        "name": "Input parameter",
+                        "outputs": [],
+                        "position": {
+                            "left": 535.8872921148474,
+                            "top": 982.3539279850593
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
+                        "tool_version": null,
+                        "type": "parameter_input",
+                        "uuid": "bc1b0c8a-64af-4cac-a825-6eb7a70cbbeb",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "8": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
+                        "errors": null,
+                        "id": 8,
+                        "input_connections": {
+                            "query": {
+                                "id": 0,
+                                "output_name": "output"
+                            },
+                            "reflist": {
+                                "id": 1,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "hap1 vs species",
+                        "name": "mashmap",
+                        "outputs": [
+                            {
+                                "name": "mashout",
+                                "type": "paf"
+                            }
+                        ],
+                        "position": {
+                            "left": 865.3187502811058,
+                            "top": 0
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionmashout": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "mashout"
+                            },
+                            "RenameDatasetActionmashout": {
+                                "action_arguments": {
+                                    "newname": "hap1 vs species"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "mashout"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "a3a6b0b31f2d",
+                            "name": "mashmap",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"dense\": false, \"filter_mode\": \"one-to-one\", \"kmerComplexity\": null, \"kmerThreshold\": null, \"noHgFilter\": false, \"noMerge\": false, \"perc_identity\": \"85.0\", \"query\": {\"__class__\": \"ConnectedValue\"}, \"reflist\": {\"__class__\": \"ConnectedValue\"}, \"reportPercentage\": false, \"seqLength\": \"5000\", \"sketchSize\": \"0\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "3.1.3+galaxy0",
+                        "type": "tool",
+                        "uuid": "b1a857dd-1140-4641-943b-cb141b6a6f81",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "9": {
+                        "annotation": "",
+                        "id": 9,
+                        "input_connections": {
+                            "Coverage": {
+                                "id": 5,
+                                "input_subworkflow_step_id": 6,
+                                "output_name": "output"
+                            },
+                            "Gaps": {
+                                "id": 4,
+                                "input_subworkflow_step_id": 5,
+                                "output_name": "output"
+                            },
+                            "Gene Tracks": {
+                                "id": 6,
+                                "input_subworkflow_step_id": 7,
+                                "output_name": "output"
+                            },
+                            "Genes?": {
+                                "id": 7,
+                                "input_subworkflow_step_id": 8,
+                                "output_name": "output"
+                            },
+                            "Hap1 fasta": {
+                                "id": 0,
+                                "input_subworkflow_step_id": 0,
+                                "output_name": "output"
+                            },
+                            "Hap1 vs Species": {
+                                "id": 8,
+                                "input_subworkflow_step_id": 2,
+                                "output_name": "mashout"
+                            },
+                            "Related Fasta": {
+                                "id": 1,
+                                "input_subworkflow_step_id": 1,
+                                "output_name": "output"
+                            },
+                            "Telomeres P": {
+                                "id": 3,
+                                "input_subworkflow_step_id": 4,
+                                "output_name": "output"
+                            },
+                            "Telomeres Q": {
+                                "id": 2,
+                                "input_subworkflow_step_id": 3,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Jbrowse2 for 1 related species - single haplotype",
+                        "outputs": [],
+                        "position": {
+                            "left": 1523.302721783011,
+                            "top": 447.47521325816376
+                        },
+                        "subworkflow": {
+                            "a_galaxy_workflow": "true",
+                            "annotation": "",
+                            "comments": [],
+                            "format-version": "0.1",
+                            "name": "Jbrowse2 for 1 related species - single haplotype",
+                            "report": {
+                                "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
+                            },
+                            "steps": {
+                                "0": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 0,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Hap1 fasta"
+                                        }
+                                    ],
+                                    "label": "Hap1 fasta",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 0,
+                                        "top": 209.22223652047438
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "4a20362f-2551-4a60-9118-e4c3e7c4f264",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "1": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 1,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Related Fasta"
+                                        }
+                                    ],
+                                    "label": "Related Fasta",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 64.19044612855507,
+                                        "top": 339.63559170456904
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "385825a9-198e-425f-9fb3-55af892d20dc",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "2": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 2,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Hap1 vs Species"
+                                        }
+                                    ],
+                                    "label": "Hap1 vs Species",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 113.31939864522589,
+                                        "top": 479.1639618101156
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"paf\"], \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "c18b3a25-89e8-4853-81fe-affb519a9ae0",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "3": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 3,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Telomeres Q"
+                                        }
+                                    ],
+                                    "label": "Telomeres Q",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 173.91872965677103,
+                                        "top": 640.6573469993632
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "ce01ac46-a3c2-4013-ba5b-ea8a0e46be64",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "4": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 4,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Telomeres P"
+                                        }
+                                    ],
+                                    "label": "Telomeres P",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 262.08020244071406,
+                                        "top": 799.4536221643712
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "8044ff06-8a3b-4ac1-b6ee-521cc28e585d",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "5": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 5,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Gaps"
+                                        }
+                                    ],
+                                    "label": "Gaps",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 334.3294215467986,
+                                        "top": 926.268574398666
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "37e56713-8aa6-474e-9a87-6c702d7d6b49",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "6": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 6,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Coverage"
+                                        }
+                                    ],
+                                    "label": "Coverage",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 431.83941564925703,
+                                        "top": 1078.7178133506623
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"bigwig\"], \"tag\": \"\"}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "2131fd1e-4f34-4662-be5c-382101fcbc76",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "7": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 7,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Gene Tracks"
+                                        }
+                                    ],
+                                    "label": "Gene Tracks",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 564.2214660523151,
+                                        "top": 1297.0956580243692
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "f6db855c-e1de-49f7-836c-87a510e955aa",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "8": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 8,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Genes?"
+                                        }
+                                    ],
+                                    "label": "Genes?",
+                                    "name": "Input parameter",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 676.3375507125828,
+                                        "top": 1426.4770174033545
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
+                                    "tool_version": null,
+                                    "type": "parameter_input",
+                                    "uuid": "a7391d09-c347-4520-91c2-8b07fd147efa",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "9": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "errors": null,
+                                    "id": 9,
+                                    "input_connections": {
+                                        "input_param_type|input_param": {
+                                            "id": 8,
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "inputs": [
+                                        {
+                                            "description": "runtime parameter for tool Map parameter value",
+                                            "name": "input_param_type"
+                                        }
+                                    ],
+                                    "label": null,
+                                    "name": "Map parameter value",
+                                    "outputs": [
+                                        {
+                                            "name": "output_param_boolean",
+                                            "type": "expression.json"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 1443.6518169393487,
+                                        "top": 980.4294207784309
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActionoutput_param_boolean": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "output_param_boolean"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "5ac8a4bf7a8d",
+                                        "name": "map_param_value",
+                                        "owner": "iuc",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": false, \"to\": \"True\"}, {\"__index__\": 1, \"from\": true, \"to\": \"False\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "0.2.0",
+                                    "type": "tool",
+                                    "uuid": "216d68c5-1d97-4dc5-961a-ea915c97a92d",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "10": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                                    "errors": null,
+                                    "id": 10,
+                                    "input_connections": {
+                                        "assemblies_0|reference_genome|genome": {
+                                            "id": 0,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 2,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 3,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_1|data_tracks_1|data_format|annotation_cond|annotation": {
+                                            "id": 4,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 5,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 6,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_4|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 7,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_1|reference_genome|genome": {
+                                            "id": 1,
+                                            "output_name": "output"
+                                        },
+                                        "when": {
+                                            "id": 8,
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": "JBrowse2 Hap1 and hap2 with 1st related species 2",
+                                    "name": "JBrowse2",
+                                    "outputs": [
+                                        {
+                                            "name": "output",
+                                            "type": "html"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 2561.3898434899743,
+                                        "top": 900.6399388618673
+                                    },
+                                    "post_job_actions": {
+                                        "RenameDatasetActionoutput": {
+                                            "action_arguments": {
+                                                "newname": "JBrowse2 Single Haplotype with related species and Gene Tracks"
+                                            },
+                                            "action_type": "RenameDatasetAction",
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "bd903fbbc26e",
+                                        "name": "jbrowse2",
+                                        "owner": "fubar",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Synteny Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Telomeres Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 4, \"category\": \"Annotation\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 1, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": []}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "3.7.0+galaxy0",
+                                    "type": "tool",
+                                    "uuid": "ffb776d2-dcb0-458c-9f2d-ffcd2de39ba2",
+                                    "when": "$(inputs.when)",
+                                    "workflow_outputs": [
+                                        {
+                                            "label": "JBrowse2 Single Haplotype with related species and Gene Tracks",
+                                            "output_name": "output",
+                                            "uuid": "a71b266a-4d49-4dbd-b4d1-410849b941bb"
+                                        }
+                                    ]
+                                },
+                                "11": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                                    "errors": null,
+                                    "id": 11,
+                                    "input_connections": {
+                                        "assemblies_0|reference_genome|genome": {
+                                            "id": 0,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 2,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 3,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_1|data_tracks_1|data_format|annotation_cond|annotation": {
+                                            "id": 4,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 5,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 6,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_1|reference_genome|genome": {
+                                            "id": 1,
+                                            "output_name": "output"
+                                        },
+                                        "when": {
+                                            "id": 9,
+                                            "output_name": "output_param_boolean"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": "JBrowse2 Hap1 and hap2 with 1st related species",
+                                    "name": "JBrowse2",
+                                    "outputs": [
+                                        {
+                                            "name": "output",
+                                            "type": "html"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 1931.9531666252099,
+                                        "top": 0
+                                    },
+                                    "post_job_actions": {
+                                        "RenameDatasetActionoutput": {
+                                            "action_arguments": {
+                                                "newname": "JBrowse2 Single Haplotype with related species"
+                                            },
+                                            "action_type": "RenameDatasetAction",
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "bd903fbbc26e",
+                                        "name": "jbrowse2",
+                                        "owner": "fubar",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Synteny Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Telomeres Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 1, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": []}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "3.7.0+galaxy0",
+                                    "type": "tool",
+                                    "uuid": "0dba1c5e-903c-46f3-a58c-2b9341b92a15",
+                                    "when": "$(inputs.when)",
+                                    "workflow_outputs": [
+                                        {
+                                            "label": "JBrowse2 Single Haplotype with related species",
+                                            "output_name": "output",
+                                            "uuid": "448fe2be-896a-49d7-b5c3-dfc4ceae0352"
+                                        }
+                                    ]
+                                }
+                            },
+                            "tags": [],
+                            "uuid": "236c7163-dde8-4597-a9b5-a7d55314997e"
+                        },
+                        "tool_id": null,
+                        "type": "subworkflow",
+                        "uuid": "6ad9fa44-c0d3-49e8-af09-e1a93e66eb8a",
+                        "when": null,
+                        "workflow_outputs": [
+                            {
+                                "label": "JBrowse2 Single Haplotype with related species",
+                                "output_name": "JBrowse2 Single Haplotype with related species",
+                                "uuid": "3c519fbb-453d-418c-8af3-e4532cf23c28"
+                            },
+                            {
+                                "label": "JBrowse2 Single Haplotype with related species and Gene Tracks",
+                                "output_name": "JBrowse2 Single Haplotype with related species and Gene Tracks",
+                                "uuid": "2dc05ed1-2c39-45a0-b07c-2ec4b8a6b0df"
+                            }
+                        ]
+                    }
+                },
+                "tags": [],
+                "uuid": "0569b4db-b204-41dc-b5c9-f5ad1b42265a"
+            },
+            "tool_id": null,
+            "type": "subworkflow",
+            "uuid": "7fa40e11-ee9e-4492-852e-fa55278c26fe",
+            "when": "$(inputs.when)",
+            "workflow_outputs": [
+                {
+                    "label": "JBrowse2 Single Haplotype with related species",
+                    "output_name": "JBrowse2 Single Haplotype with related species",
+                    "uuid": "3a5bf4bd-0e11-4289-b09a-3126d1da9594"
+                },
+                {
+                    "label": "JBrowse2 Single Haplotype with related species and Gene Tracks",
+                    "output_name": "JBrowse2 Single Haplotype with related species and Gene Tracks",
+                    "uuid": "77c9e164-d85b-454e-b996-29fe74100c03"
+                }
+            ]
+        },
+        "19": {
+            "annotation": "",
+            "id": 19,
+            "input_connections": {
+                "Coverage": {
+                    "id": 11,
+                    "input_subworkflow_step_id": 6,
+                    "output_name": "output"
+                },
+                "Gaps": {
+                    "id": 10,
+                    "input_subworkflow_step_id": 5,
+                    "output_name": "output"
+                },
+                "Genes": {
+                    "id": 16,
+                    "input_subworkflow_step_id": 8,
+                    "output_name": "data_param"
+                },
+                "Genes?": {
+                    "id": 6,
+                    "input_subworkflow_step_id": 7,
+                    "output_name": "output"
+                },
+                "Hap1 fasta": {
+                    "id": 2,
+                    "input_subworkflow_step_id": 0,
+                    "output_name": "output"
+                },
+                "Hap2 fasta": {
+                    "id": 14,
+                    "input_subworkflow_step_id": 1,
+                    "output_name": "data_param"
+                },
+                "Related Species": {
+                    "id": 15,
+                    "input_subworkflow_step_id": 2,
+                    "output_name": "output1"
+                },
+                "Telomeres P": {
+                    "id": 9,
+                    "input_subworkflow_step_id": 4,
+                    "output_name": "output"
+                },
+                "Telomeres Q": {
+                    "id": 8,
+                    "input_subworkflow_step_id": 3,
+                    "output_name": "output"
+                },
+                "when": {
+                    "id": 3,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Jbrowse for pre-curation",
+            "outputs": [],
+            "position": {
+                "left": 3359.99060088773,
+                "top": 782.0624564807059
+            },
+            "subworkflow": {
+                "a_galaxy_workflow": "true",
+                "annotation": "",
+                "comments": [],
+                "format-version": "0.1",
+                "name": "Jbrowse for pre-curation",
+                "report": {
+                    "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
+                },
+                "steps": {
+                    "0": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 0,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Hap1 fasta"
+                            }
+                        ],
+                        "label": "Hap1 fasta",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 0,
+                            "top": 85.5397415161874
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "4a20362f-2551-4a60-9118-e4c3e7c4f264",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "1": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 1,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Hap2 fasta"
+                            }
+                        ],
+                        "label": "Hap2 fasta",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 51.81545453466647,
+                            "top": 205.03846714316876
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "177f6825-e58e-45e9-a3fc-8c7623187e02",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "2": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 2,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Related Species"
+                            }
+                        ],
+                        "label": "Related Species",
+                        "name": "Input dataset collection",
+                        "outputs": [],
+                        "position": {
+                            "left": 297.860981218189,
+                            "top": 609.7270107228887
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
+                        "tool_version": null,
+                        "type": "data_collection_input",
+                        "uuid": "20f7abfb-20b8-49bb-b522-cd911fd1ec4c",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "3": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 3,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Telomeres Q"
+                            }
+                        ],
+                        "label": "Telomeres Q",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 347.4491076529599,
+                            "top": 765.9971383218501
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "ce01ac46-a3c2-4013-ba5b-ea8a0e46be64",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "4": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 4,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Telomeres P"
+                            }
+                        ],
+                        "label": "Telomeres P",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 455.5329585464028,
+                            "top": 870.0948319299273
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "8044ff06-8a3b-4ac1-b6ee-521cc28e585d",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "5": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 5,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Gaps"
+                            }
+                        ],
+                        "label": "Gaps",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 524.1536909971493,
+                            "top": 963.4615908089734
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "37e56713-8aa6-474e-9a87-6c702d7d6b49",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "6": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 6,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Coverage"
+                            }
+                        ],
+                        "label": "Coverage",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 581.1909253334677,
+                            "top": 1050.5810577223672
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"bigwig\"], \"tag\": \"\"}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "738f43fc-5f88-4117-bcc3-4a9c1b01c0a1",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "7": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 7,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Genes?"
+                            }
+                        ],
+                        "label": "Genes?",
+                        "name": "Input parameter",
+                        "outputs": [],
+                        "position": {
+                            "left": 632.8136499329014,
+                            "top": 1153.233851898539
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
+                        "tool_version": null,
+                        "type": "parameter_input",
+                        "uuid": "7c8dc365-9ea0-4f5a-af57-0983008b7ade",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "8": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 8,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Genes"
+                            }
+                        ],
+                        "label": "Genes",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 683.9939626471161,
+                            "top": 1243.3922887919446
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"tag\": null}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "dabdef6f-cb85-410c-a5ef-229d9ae21a3b",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "9": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
+                        "errors": null,
+                        "id": 9,
+                        "input_connections": {
+                            "query": {
+                                "id": 0,
+                                "output_name": "output"
+                            },
+                            "reflist": {
+                                "id": 2,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "Hap1 vs Species",
+                        "name": "mashmap",
+                        "outputs": [
+                            {
+                                "name": "mashout",
+                                "type": "paf"
+                            }
+                        ],
+                        "position": {
+                            "left": 1211.2240968936799,
+                            "top": 0
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionmashout": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "mashout"
+                            },
+                            "RenameDatasetActionmashout": {
+                                "action_arguments": {
+                                    "newname": "Species to Hap2"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "mashout"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "a3a6b0b31f2d",
+                            "name": "mashmap",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"dense\": false, \"filter_mode\": \"one-to-one\", \"kmerComplexity\": null, \"kmerThreshold\": null, \"noHgFilter\": false, \"noMerge\": false, \"perc_identity\": \"85.0\", \"query\": {\"__class__\": \"ConnectedValue\"}, \"reflist\": {\"__class__\": \"ConnectedValue\"}, \"reportPercentage\": false, \"seqLength\": \"5000\", \"sketchSize\": \"0\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "3.1.3+galaxy0",
+                        "type": "tool",
+                        "uuid": "ba8fe065-a989-4cff-bcda-2e6883b1f6cd",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "10": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
+                        "errors": null,
+                        "id": 10,
+                        "input_connections": {
+                            "query": {
+                                "id": 2,
+                                "output_name": "output"
+                            },
+                            "reflist": {
+                                "id": 1,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "Species vs Hap2",
+                        "name": "mashmap",
+                        "outputs": [
+                            {
+                                "name": "mashout",
+                                "type": "paf"
+                            }
+                        ],
+                        "position": {
+                            "left": 1225.3530086334274,
+                            "top": 365.8375864791642
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionmashout": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "mashout"
+                            },
+                            "RenameDatasetActionmashout": {
+                                "action_arguments": {
+                                    "newname": "Species to Hap2"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "mashout"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "a3a6b0b31f2d",
+                            "name": "mashmap",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"dense\": false, \"filter_mode\": \"one-to-one\", \"kmerComplexity\": null, \"kmerThreshold\": null, \"noHgFilter\": false, \"noMerge\": false, \"perc_identity\": \"85.0\", \"query\": {\"__class__\": \"ConnectedValue\"}, \"reflist\": {\"__class__\": \"ConnectedValue\"}, \"reportPercentage\": false, \"seqLength\": \"5000\", \"sketchSize\": \"0\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "3.1.3+galaxy0",
+                        "type": "tool",
+                        "uuid": "cf1e95b5-3bd6-41c1-a2d4-93ac6c1b1b1a",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "11": {
+                        "annotation": "",
+                        "id": 11,
+                        "input_connections": {
+                            "Coverage": {
+                                "id": 6,
+                                "input_subworkflow_step_id": 8,
+                                "output_name": "output"
+                            },
+                            "Gaps": {
+                                "id": 5,
+                                "input_subworkflow_step_id": 7,
+                                "output_name": "output"
+                            },
+                            "Genes": {
+                                "id": 8,
+                                "input_subworkflow_step_id": 10,
+                                "output_name": "output"
+                            },
+                            "Genes?": {
+                                "id": 7,
+                                "input_subworkflow_step_id": 9,
+                                "output_name": "output"
+                            },
+                            "Hap1 fasta": {
+                                "id": 0,
+                                "input_subworkflow_step_id": 0,
+                                "output_name": "output"
+                            },
+                            "Hap1 vs Species": {
+                                "id": 9,
+                                "input_subworkflow_step_id": 4,
+                                "output_name": "mashout"
+                            },
+                            "Hap2 fasta": {
+                                "id": 1,
+                                "input_subworkflow_step_id": 1,
+                                "output_name": "output"
+                            },
+                            "Related Species": {
+                                "id": 2,
+                                "input_subworkflow_step_id": 2,
+                                "output_name": "output"
+                            },
+                            "Species vs Hap2": {
+                                "id": 10,
+                                "input_subworkflow_step_id": 3,
+                                "output_name": "mashout"
+                            },
+                            "Telomeres P": {
+                                "id": 4,
+                                "input_subworkflow_step_id": 6,
+                                "output_name": "output"
+                            },
+                            "Telomeres Q": {
+                                "id": 3,
+                                "input_subworkflow_step_id": 5,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Jbrowse2 for 1 related species",
+                        "outputs": [],
+                        "position": {
+                            "left": 2292.870790775461,
+                            "top": 343.7939440488241
+                        },
+                        "subworkflow": {
+                            "a_galaxy_workflow": "true",
+                            "annotation": "",
+                            "comments": [],
+                            "format-version": "0.1",
+                            "name": "Jbrowse2 for 1 related species",
+                            "report": {
+                                "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
+                            },
+                            "steps": {
+                                "0": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 0,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Hap1 fasta"
+                                        }
+                                    ],
+                                    "label": "Hap1 fasta",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 0,
+                                        "top": 271.13908772215916
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "4a20362f-2551-4a60-9118-e4c3e7c4f264",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "1": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 1,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Hap2 fasta"
+                                        }
+                                    ],
+                                    "label": "Hap2 fasta",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 53.14881800970572,
+                                        "top": 420.7641795440555
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "177f6825-e58e-45e9-a3fc-8c7623187e02",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "2": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 2,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Related Species"
+                                        }
+                                    ],
+                                    "label": "Related Species",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 98.91709918730632,
+                                        "top": 553.1054764799819
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "604a6bec-8c1f-47e3-8884-c32f63246589",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "3": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 3,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Species vs Hap2"
+                                        }
+                                    ],
+                                    "label": "Species vs Hap2",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 147.9198303415696,
+                                        "top": 670.2931389328182
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"paf\"], \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "ebdc47b3-16f5-48e9-a101-c82b2370181a",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "4": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 4,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Hap1 vs Species"
+                                        }
+                                    ],
+                                    "label": "Hap1 vs Species",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 175.64670268098203,
+                                        "top": 777.2105888619357
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"paf\"], \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "385825a9-198e-425f-9fb3-55af892d20dc",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "5": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 5,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Telomeres Q"
+                                        }
+                                    ],
+                                    "label": "Telomeres Q",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 206.21568172170709,
+                                        "top": 895.0983900914266
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "ce01ac46-a3c2-4013-ba5b-ea8a0e46be64",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "6": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 6,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Telomeres P"
+                                        }
+                                    ],
+                                    "label": "Telomeres P",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 274.77222990165984,
+                                        "top": 1069.4502766623036
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "8044ff06-8a3b-4ac1-b6ee-521cc28e585d",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "7": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 7,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Gaps"
+                                        }
+                                    ],
+                                    "label": "Gaps",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 353.8919295731858,
+                                        "top": 1244.9653893778952
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "37e56713-8aa6-474e-9a87-6c702d7d6b49",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "8": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 8,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Coverage"
+                                        }
+                                    ],
+                                    "label": "Coverage",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 391.49614814580605,
+                                        "top": 1410.3962329181184
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"bigwig\"], \"tag\": \"\"}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "2131fd1e-4f34-4662-be5c-382101fcbc76",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "9": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 9,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Genes?"
+                                        }
+                                    ],
+                                    "label": "Genes?",
+                                    "name": "Input parameter",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 419.6781495431659,
+                                        "top": 1559.6965461441787
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
+                                    "tool_version": null,
+                                    "type": "parameter_input",
+                                    "uuid": "ccb4de54-c370-4f56-a5d4-42708ee6c835",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "10": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 10,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Genes"
+                                        }
+                                    ],
+                                    "label": "Genes",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 450.73254127706855,
+                                        "top": 1696.059196784704
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "496c7358-def1-4256-b4e8-6698cac34f97",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "11": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "errors": null,
+                                    "id": 11,
+                                    "input_connections": {
+                                        "input_param_type|input_param": {
+                                            "id": 9,
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "inputs": [
+                                        {
+                                            "description": "runtime parameter for tool Map parameter value",
+                                            "name": "input_param_type"
+                                        }
+                                    ],
+                                    "label": "No Gene track",
+                                    "name": "Map parameter value",
+                                    "outputs": [
+                                        {
+                                            "name": "output_param_boolean",
+                                            "type": "expression.json"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 1030.3127513910322,
+                                        "top": 1346.1174612746302
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActionoutput_param_boolean": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "output_param_boolean"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "5ac8a4bf7a8d",
+                                        "name": "map_param_value",
+                                        "owner": "iuc",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": false, \"to\": \"True\"}, {\"__index__\": 1, \"from\": false, \"to\": \"False\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "0.2.0",
+                                    "type": "tool",
+                                    "uuid": "d8f71bf4-51a3-4af7-8cf2-fd16730469b4",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "12": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                                    "errors": null,
+                                    "id": 12,
+                                    "input_connections": {
+                                        "assemblies_0|reference_genome|genome": {
+                                            "id": 0,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 4,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 5,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_1|data_tracks_1|data_format|annotation_cond|annotation": {
+                                            "id": 6,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 7,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 8,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_4|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 10,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_1|reference_genome|genome": {
+                                            "id": 2,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_1|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 3,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|reference_genome|genome": {
+                                            "id": 1,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 5,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_0|data_tracks_1|data_format|annotation_cond|annotation": {
+                                            "id": 6,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 7,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 8,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 10,
+                                            "output_name": "output"
+                                        },
+                                        "when": {
+                                            "id": 9,
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
+                                    "name": "JBrowse2",
+                                    "outputs": [
+                                        {
+                                            "name": "output",
+                                            "type": "html"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 2604.560544371787,
+                                        "top": 306.40203071991476
+                                    },
+                                    "post_job_actions": {
+                                        "RenameDatasetActionoutput": {
+                                            "action_arguments": {
+                                                "newname": "JBrowse2 Hap1 and hap2 with related species and gene tracks"
+                                            },
+                                            "action_type": "RenameDatasetAction",
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "bd903fbbc26e",
+                                        "name": "jbrowse2",
+                                        "owner": "fubar",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"RuntimeValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Synteny Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Telomeres Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 4, \"category\": \"Annotations\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 1, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"RuntimeValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Synteny Hap2\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 2, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"RuntimeValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Telomeres Haplotype 2\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"Annotations\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "3.7.0+galaxy0",
+                                    "type": "tool",
+                                    "uuid": "c4b25ca4-bdd4-4260-ac8b-80ae381da1ab",
+                                    "when": "$(inputs.when)",
+                                    "workflow_outputs": [
+                                        {
+                                            "label": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
+                                            "output_name": "output",
+                                            "uuid": "78b83679-2eea-4812-9936-54e27a2c404d"
+                                        }
+                                    ]
+                                },
+                                "13": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                                    "errors": null,
+                                    "id": 13,
+                                    "input_connections": {
+                                        "assemblies_0|reference_genome|genome": {
+                                            "id": 0,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 4,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 5,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_1|data_tracks_1|data_format|annotation_cond|annotation": {
+                                            "id": 6,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 7,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 8,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_1|reference_genome|genome": {
+                                            "id": 2,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_1|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 3,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|reference_genome|genome": {
+                                            "id": 1,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 5,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_0|data_tracks_1|data_format|annotation_cond|annotation": {
+                                            "id": 6,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 7,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 8,
+                                            "output_name": "output"
+                                        },
+                                        "when": {
+                                            "id": 11,
+                                            "output_name": "output_param_boolean"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": "JBrowse2 Hap1 and hap2 with 1st related species",
+                                    "name": "JBrowse2",
+                                    "outputs": [
+                                        {
+                                            "name": "output",
+                                            "type": "html"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 1960.7191746063156,
+                                        "top": 0
+                                    },
+                                    "post_job_actions": {
+                                        "RenameDatasetActionoutput": {
+                                            "action_arguments": {
+                                                "newname": "JBrowse2 Hap1 and hap2 with related species"
+                                            },
+                                            "action_type": "RenameDatasetAction",
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "bd903fbbc26e",
+                                        "name": "jbrowse2",
+                                        "owner": "fubar",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Synteny Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Telomeres Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 1, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Synteny Hap2\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 2, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Telomeres Haplotype 2\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "3.7.0+galaxy0",
+                                    "type": "tool",
+                                    "uuid": "0dba1c5e-903c-46f3-a58c-2b9341b92a15",
+                                    "when": "$(inputs.when)",
+                                    "workflow_outputs": [
+                                        {
+                                            "label": "JBrowse2 Hap1 and hap2 with related species",
+                                            "output_name": "output",
+                                            "uuid": "ce6026de-ad8b-4dec-8926-fccc97f25df6"
+                                        }
+                                    ]
+                                }
+                            },
+                            "tags": [],
+                            "uuid": "fb028d13-e1d0-4d81-b413-b2c662d5213a"
+                        },
+                        "tool_id": null,
+                        "type": "subworkflow",
+                        "uuid": "e134915a-f5b7-4b32-a511-921e0b363bff",
+                        "when": null,
+                        "workflow_outputs": [
+                            {
+                                "label": "JBrowse2 Hap1 and hap2 with related species",
+                                "output_name": "JBrowse2 Hap1 and hap2 with related species",
+                                "uuid": "7562c81f-4b86-4932-8056-52f4dc17d2a9"
+                            },
+                            {
+                                "label": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
+                                "output_name": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
+                                "uuid": "ca3249af-b46a-450d-8dbe-696490325d42"
+                            }
+                        ]
+                    }
+                },
+                "tags": [],
+                "uuid": "ef9af3c8-a765-4077-9cb2-9ad16d1a570e"
+            },
+            "tool_id": null,
+            "type": "subworkflow",
+            "uuid": "af188630-081d-489b-b46f-eae324b3df01",
+            "when": "$(inputs.when)",
+            "workflow_outputs": [
+                {
+                    "label": "JBrowse2 Hap1 and hap2 with related species",
+                    "output_name": "JBrowse2 Hap1 and hap2 with related species",
+                    "uuid": "6861e850-7a02-47cf-aab2-4093019878e9"
+                },
+                {
+                    "label": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
+                    "output_name": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
+                    "uuid": "edb52be2-a128-49cb-9c82-e693d7b7656c"
+                }
+            ]
+        },
+        "20": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+            "errors": null,
+            "id": 20,
+            "input_connections": {
+                "input_list": {
+                    "id": 17,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Collapse Collection",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2499.556473225303,
+                "top": 293.47025968475924
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+            "tool_shed_repository": {
+                "changeset_revision": "90981f86000f",
+                "name": "collapse_collections",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"filename\": {\"add_name\": false, \"__current_case__\": 1}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "5.1.0",
+            "type": "tool",
+            "uuid": "c70c2d41-43fe-4601-a3aa-8ca8a5433c0a",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "21": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/9.5+galaxy3",
+            "errors": null,
+            "id": 21,
+            "input_connections": {
+                "infile": {
+                    "id": 20,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Unique",
+            "outputs": [
+                {
+                    "name": "outfile",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2853.562857058991,
+                "top": 0.0
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionoutfile": {
+                    "action_arguments": {
+                        "newtype": "tabular"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "outfile"
+                },
+                "HideDatasetActionoutfile": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "outfile"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/9.5+galaxy3",
+            "tool_shed_repository": {
+                "changeset_revision": "ab83aa685821",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"adv_opts\": {\"adv_opts_selector\": \"basic\", \"__current_case__\": 0}, \"header\": \"0\", \"ignore_case\": false, \"infile\": {\"__class__\": \"ConnectedValue\"}, \"is_numeric\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "9.5+galaxy3",
+            "type": "tool",
+            "uuid": "19ffba37-86b9-4fe3-aae8-f8fbfa2d4ff0",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "22": {
+            "annotation": "",
+            "content_id": "wc_gnu",
+            "errors": null,
+            "id": 22,
+            "input_connections": {
+                "input1": {
+                    "id": 20,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Line/Word/Character count",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 2812.55061813865,
+                "top": 510.6734558790175
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "wc_gnu",
+            "tool_state": "{\"include_header\": false, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"options\": [\"lines\"], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "b00153cb-f706-4e4a-bda6-4b3e859858f6",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "23": {
+            "annotation": "",
+            "content_id": "wc_gnu",
+            "errors": null,
+            "id": 23,
+            "input_connections": {
+                "input1": {
+                    "id": 21,
+                    "output_name": "outfile"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Line/Word/Character count",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 3066.1573769206448,
+                "top": 268.5825615907663
+            },
+            "post_job_actions": {
+                "HideDatasetActionout_file1": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "wc_gnu",
+            "tool_state": "{\"include_header\": false, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"options\": [\"lines\"], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "b1b48543-f5a6-410b-aeb6-86c058dee9e3",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "24": {
+            "annotation": "",
+            "content_id": "param_value_from_file",
+            "errors": null,
+            "id": 24,
+            "input_connections": {
+                "input1": {
+                    "id": 22,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Parse parameter value",
+            "outputs": [
+                {
+                    "name": "integer_param",
+                    "type": "expression.json"
+                }
+            ],
+            "position": {
+                "left": 3236.7131866213954,
+                "top": 502.9407403932288
+            },
+            "post_job_actions": {
+                "HideDatasetActioninteger_param": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "integer_param"
+                }
+            },
+            "tool_id": "param_value_from_file",
+            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"integer\", \"remove_newlines\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "0.1.0",
+            "type": "tool",
+            "uuid": "0d89e2e9-fec0-4bc8-a3fc-513dc91f2f1b",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "25": {
+            "annotation": "",
+            "content_id": "param_value_from_file",
+            "errors": null,
+            "id": 25,
+            "input_connections": {
+                "input1": {
+                    "id": 23,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Parse parameter value",
+            "outputs": [
+                {
+                    "name": "integer_param",
+                    "type": "expression.json"
+                }
+            ],
+            "position": {
+                "left": 3349.6578232069623,
+                "top": 103.77316093552422
+            },
+            "post_job_actions": {
+                "HideDatasetActioninteger_param": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "integer_param"
+                }
+            },
+            "tool_id": "param_value_from_file",
+            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"integer\", \"remove_newlines\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "0.1.0",
+            "type": "tool",
+            "uuid": "9f9a8b3d-6d0a-424f-aae0-4db2e0c16940",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "26": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/calculate_numeric_param/calculate_numeric_param/0.1.0",
+            "errors": null,
+            "id": 26,
+            "input_connections": {
+                "components_0|param_type|component_value": {
+                    "id": 24,
+                    "output_name": "integer_param"
+                },
+                "components_1|param_type|component_value": {
+                    "id": 25,
+                    "output_name": "integer_param"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Calculate numeric parameter value",
+            "outputs": [
+                {
+                    "name": "integer_param",
+                    "type": "expression.json"
+                }
+            ],
+            "position": {
+                "left": 3600.8912340886463,
+                "top": 332.9150842713157
+            },
+            "post_job_actions": {
+                "HideDatasetActioninteger_param": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "integer_param"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/calculate_numeric_param/calculate_numeric_param/0.1.0",
+            "tool_shed_repository": {
+                "changeset_revision": "0e586762f97b",
+                "name": "calculate_numeric_param",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 0, \"component_value\": {\"__class__\": \"ConnectedValue\"}}, \"arith\": \"-\"}, {\"__index__\": 1, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 0, \"component_value\": {\"__class__\": \"ConnectedValue\"}}, \"arith\": \"\"}], \"output_type\": \"integer\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "0.1.0",
+            "type": "tool",
+            "uuid": "34cce52f-7548-4454-94ad-ee1547b25636",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "27": {
+            "annotation": "This step is meant to warn the user that there are duplicated sequence names, which would cause inaccurate alignments results with MashMap. ",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+            "errors": null,
+            "id": 27,
+            "input_connections": {
+                "input_param_type|input_param": {
+                    "id": 26,
+                    "output_name": "integer_param"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Map parameter value",
+                    "name": "input_param_type"
+                }
+            ],
+            "label": "Fail if there are duplicated sequence names between the fasta files",
+            "name": "Map parameter value",
+            "outputs": [
+                {
+                    "name": "output_param_boolean",
+                    "type": "expression.json"
+                }
+            ],
+            "position": {
+                "left": 3822.4432951091107,
+                "top": 766.5545148192659
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutput_param_boolean": {
+                    "action_arguments": {
+                        "newname": "Fail if there are duplicated sequence names between the fasta files"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output_param_boolean"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+            "tool_shed_repository": {
+                "changeset_revision": "5ac8a4bf7a8d",
+                "name": "map_param_value",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_param_type\": {\"type\": \"integer\", \"__current_case__\": 1, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": \"0\", \"to\": \"True\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"fail\", \"__current_case__\": 1}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "0.2.0",
+            "type": "tool",
+            "uuid": "84eeffe0-4578-4857-8555-841769a58073",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Fail if there are duplicated sequence names between the fasta files",
+                    "output_name": "output_param_boolean",
+                    "uuid": "b4ebfb36-d369-4ced-964c-450c62e01b7d"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "2e394d56-6c89-4588-956e-5c1a9abd33c2",
+    "version": 1,
+    "release": "0.1"
+}

--- a/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/Precuration-Jbrowse-tracks-alignments.ga
+++ b/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/Precuration-Jbrowse-tracks-alignments.ga
@@ -39,7 +39,7 @@
             "outputs": [],
             "position": {
                 "left": 0,
-                "top": 113.32852983289965
+                "top": 64.56706309674621
             },
             "tool_id": null,
             "tool_state": "{\"multiple\": false, \"validators\": [], \"parameter_type\": \"text\", \"optional\": false}",
@@ -66,7 +66,7 @@
             "outputs": [],
             "position": {
                 "left": 95.65671993217956,
-                "top": 204.52575895443343
+                "top": 155.76429221828
             },
             "tool_id": null,
             "tool_state": "{\"multiple\": false, \"validators\": [], \"parameter_type\": \"text\", \"optional\": false}",
@@ -93,7 +93,7 @@
             "outputs": [],
             "position": {
                 "left": 198.28766556712145,
-                "top": 333.06630818129815
+                "top": 284.3048414451447
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
@@ -104,37 +104,10 @@
             "workflow_outputs": []
         },
         "3": {
-            "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 3,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
-                    "name": "Will you use a second haplotype?"
-                }
-            ],
-            "label": "Will you use a second haplotype?",
-            "name": "Input parameter",
-            "outputs": [],
-            "position": {
-                "left": 301.8902333217979,
-                "top": 405.0410156580133
-            },
-            "tool_id": null,
-            "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
-            "tool_version": null,
-            "type": "parameter_input",
-            "uuid": "1f933849-8bc5-47ff-83da-7f53006c39cf",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "4": {
             "annotation": "Assembly for Haplotype 2. If \"Will you use a second haplotype?\" is set to \"no\", use haplotype 1 here. ",
             "content_id": null,
             "errors": null,
-            "id": 4,
+            "id": 3,
             "input_connections": {},
             "inputs": [
                 {
@@ -146,14 +119,41 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 415.3930839522133,
-                "top": 539.8438023368923
+                "left": 321.8732762998182,
+                "top": 399.83130302028997
             },
             "tool_id": null,
             "tool_state": "{\"optional\": true, \"format\": [\"fasta\"], \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
             "uuid": "12c55b92-9015-4d4d-97ee-b675971486e4",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "4": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 4,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Genes"
+                }
+            ],
+            "label": "Genes",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 460.3563529960522,
+                "top": 529.5975044587185
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": true, \"format\": [\"gff3\"], \"tag\": null}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "5983756f-c13c-4a41-b323-f52db5e172a4",
             "when": null,
             "workflow_outputs": []
         },
@@ -166,21 +166,21 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "Do you want to provide gene annotation for your assembly?"
+                    "name": "Telomere Q"
                 }
             ],
-            "label": "Do you want to provide gene annotation for your assembly?",
-            "name": "Input parameter",
+            "label": "Telomere Q",
+            "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 532.8506745873698,
-                "top": 662.309181460891
+                "left": 579.1058347276563,
+                "top": 646.1816269398256
             },
             "tool_id": null,
-            "tool_state": "{\"default\": false, \"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
+            "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
             "tool_version": null,
-            "type": "parameter_input",
-            "uuid": "ae28b111-3e2f-4506-b653-97b4cebcee72",
+            "type": "data_input",
+            "uuid": "1b1bf84f-e625-4b7d-8f9e-471cd5a18b4c",
             "when": null,
             "workflow_outputs": []
         },
@@ -193,21 +193,21 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "Genes"
+                    "name": "Telomere P"
                 }
             ],
-            "label": "Genes",
+            "label": "Telomere P",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 614.6440902431865,
-                "top": 818.8033806207972
+                "left": 671.0474417062338,
+                "top": 757.1049343640235
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": true, \"format\": [\"gff3\"], \"tag\": null}",
+            "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "5983756f-c13c-4a41-b323-f52db5e172a4",
+            "uuid": "6e214300-bac1-46e2-9dba-b305b10dbe28",
             "when": null,
             "workflow_outputs": []
         },
@@ -220,21 +220,21 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "Telomere Q"
+                    "name": "Gaps"
                 }
             ],
-            "label": "Telomere Q",
+            "label": "Gaps",
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 680.5676592646699,
-                "top": 901.3563409388138
+                "left": 774.9938551754473,
+                "top": 870.9665747424492
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
             "tool_version": null,
             "type": "data_input",
-            "uuid": "1b1bf84f-e625-4b7d-8f9e-471cd5a18b4c",
+            "uuid": "04f38367-909b-4c7b-a452-261dcc1b77da",
             "when": null,
             "workflow_outputs": []
         },
@@ -247,60 +247,6 @@
             "inputs": [
                 {
                     "description": "",
-                    "name": "Telomere P"
-                }
-            ],
-            "label": "Telomere P",
-            "name": "Input dataset",
-            "outputs": [],
-            "position": {
-                "left": 761.1770988870501,
-                "top": 998.8551768278469
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
-            "tool_version": null,
-            "type": "data_input",
-            "uuid": "6e214300-bac1-46e2-9dba-b305b10dbe28",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "9": {
-            "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 9,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
-                    "name": "Gaps"
-                }
-            ],
-            "label": "Gaps",
-            "name": "Input dataset",
-            "outputs": [],
-            "position": {
-                "left": 816.7956506700089,
-                "top": 1085.617189755827
-            },
-            "tool_id": null,
-            "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
-            "tool_version": null,
-            "type": "data_input",
-            "uuid": "04f38367-909b-4c7b-a452-261dcc1b77da",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "10": {
-            "annotation": "",
-            "content_id": null,
-            "errors": null,
-            "id": 10,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "",
                     "name": "Coverage"
                 }
             ],
@@ -308,8 +254,8 @@
             "name": "Input dataset",
             "outputs": [],
             "position": {
-                "left": 889.9015443268538,
-                "top": 1165.3201006570696
+                "left": 849.5535664328285,
+                "top": 975.6679392124566
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"format\": [\"bigwig\"], \"tag\": null}",
@@ -319,11 +265,11 @@
             "when": null,
             "workflow_outputs": []
         },
-        "11": {
+        "9": {
             "annotation": "Note: Duplicated sequence names between the species in the collection will cause inaccurate alignment visualization in JBrowse2.  ",
             "content_id": null,
             "errors": null,
-            "id": 11,
+            "id": 9,
             "input_connections": {},
             "inputs": [
                 {
@@ -335,22 +281,22 @@
             "name": "Input dataset collection",
             "outputs": [],
             "position": {
-                "left": 1016.2648364611407,
-                "top": 1255.890937169875
+                "left": 951.676946611419,
+                "top": 1071.3522608342273
             },
             "tool_id": null,
-            "tool_state": "{\"optional\": false, \"format\": [\"fasta.gz\"], \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
+            "tool_state": "{\"optional\": true, \"format\": [\"fasta.gz\"], \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
             "tool_version": null,
             "type": "data_collection_input",
             "uuid": "b1d57707-483c-43cd-8256-0a2888af1246",
             "when": null,
             "workflow_outputs": []
         },
-        "12": {
+        "10": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/compose_text_param/compose_text_param/0.1.1",
             "errors": null,
-            "id": 12,
+            "id": 10,
             "input_connections": {
                 "components_0|param_type|component_value": {
                     "id": 0,
@@ -371,8 +317,8 @@
                 }
             ],
             "position": {
-                "left": 1513.3687877339703,
-                "top": 196.67349674870826
+                "left": 1494.2245235926566,
+                "top": 0
             },
             "post_job_actions": {
                 "HideDatasetActionout1": {
@@ -409,11 +355,11 @@
                 }
             ]
         },
-        "13": {
+        "11": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
             "errors": null,
-            "id": 13,
+            "id": 11,
             "input_connections": {
                 "input_param_type|input_param": {
                     "id": 3,
@@ -421,7 +367,7 @@
                 }
             },
             "inputs": [],
-            "label": "Only one Haplotype",
+            "label": "Two Haplotypes",
             "name": "Map parameter value",
             "outputs": [
                 {
@@ -430,8 +376,8 @@
                 }
             ],
             "position": {
-                "left": 1736.3581103638398,
-                "top": 455.0639514218991
+                "left": 1253.1907400797504,
+                "top": 628.6659493845017
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_param_boolean": {
@@ -447,22 +393,22 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": true, \"to\": \"False\"}, {\"__index__\": 1, \"from\": false, \"to\": \"True\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input_param_type\": {\"type\": \"data\", \"__current_case__\": 4, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": []}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "df19ed91-a001-4caa-91f8-8d9051fde5c9",
+            "uuid": "4b9805d1-c6d8-4b9d-85a4-d80c93925869",
             "when": null,
             "workflow_outputs": []
         },
-        "14": {
+        "12": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
             "errors": null,
-            "id": 14,
+            "id": 12,
             "input_connections": {
                 "style_cond|type_cond|pick_from_0|value": {
-                    "id": 4,
+                    "id": 3,
                     "output_name": "output"
                 },
                 "style_cond|type_cond|pick_from_1|value": {
@@ -481,7 +427,7 @@
             ],
             "position": {
                 "left": 1706.8744833487017,
-                "top": 654.7944887566696
+                "top": 606.0330220205161
             },
             "post_job_actions": {
                 "HideDatasetActiondata_param": {
@@ -505,177 +451,416 @@
             "when": null,
             "workflow_outputs": []
         },
-        "15": {
+        "13": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
-            "errors": null,
-            "id": 15,
+            "id": 13,
             "input_connections": {
-                "style_cond|type_cond|pick_from_0|value": {
-                    "id": 6,
-                    "output_name": "output"
-                },
-                "style_cond|type_cond|pick_from_1|value": {
+                "Related Species": {
                     "id": 9,
+                    "input_subworkflow_step_id": 0,
                     "output_name": "output"
                 }
             },
             "inputs": [],
             "label": null,
-            "name": "Pick parameter value",
+            "name": "Map Collection to boolean",
+            "outputs": [],
+            "position": {
+                "left": 2657.8767092560806,
+                "top": 53.28010686264924
+            },
+            "subworkflow": {
+                "a_galaxy_workflow": "true",
+                "annotation": "",
+                "comments": [],
+                "creator": [
+                    {
+                        "class": "Person",
+                        "identifier": "https://orcid.org/0000-0001-6228-2785",
+                        "name": "Patrik Smeds"
+                    },
+                    {
+                        "class": "Person",
+                        "identifier": "https://orcid.org/0000-0001-6421-3484",
+                        "name": "Delphine Lariviere"
+                    }
+                ],
+                "format-version": "0.1",
+                "license": "MIT",
+                "name": "Map Collection to boolean",
+                "readme": "# JBrowse2 Precuration Tracks with Related Species Alignments\n\nThis workflow generates JBrowse2 instances with genome assembly tracks and alignments against related species, to assist the manual curation of genome assemblies. It complements the Hi-C contact map workflow by providing a complementary genome browser view of the same precuration tracks alongside synteny with related species.\n\nThe workflow takes the assembly haplotype(s) and the precuration tracks (telomeres, gaps, coverage, optional gene annotations), aligns the assembly against a list of related species, and packages everything into a JBrowse2 instance that curators can open directly in their browser.\n\n## Inputs\n\n### Required Inputs\n\n1. **Species Name** [text] - Species identifier used in the assembly info report\n2. **Assembly Name** [text] - Assembly identifier (e.g., toLID)\n3. **Haplotype 1** [fasta] - Primary haplotype assembly (recommended: with H1 suffix added to scaffold names)\n4. **Will you use a second haplotype?** [boolean] - Set to true for diploid assemblies\n5. **Haplotype 2** [fasta, optional] - Secondary haplotype assembly (required if using two haplotypes)\n6. **Related Species** [collection of fasta.gz] - Simple list of gzipped FASTA files of related species genomes for synteny alignment. **Sequence names must be unique across the entire collection** - the workflow performs a duplicate-name check on the merged related-species fastas and will fail early if any sequence name appears in more than one file. A common pattern is to prefix each species' scaffolds with the species name (e.g. `Species_1_scaffold_1`).\n7. **Telomere P** [BED] - P-arm telomere coordinates\n8. **Telomere Q** [BED] - Q-arm telomere coordinates (can be empty)\n9. **Gaps** [BED] - Assembly gap coordinates\n10. **Coverage** [BigWig] - PacBio HiFi read coverage track\n\n### Gene Annotation Options\n\n11. **Do you want to provide gene annotation for your assembly?** [boolean] - Enable to include a gene annotation track in the JBrowse2 instance\n12. **Genes** [GFF, optional] - Gene annotation track (required if gene annotations enabled)\n\n## Outputs\n\n1. **Assembly Info** - Summary of species and assembly name\n2. **JBrowse2 Single Haplotype with related species** [collection] - JBrowse2 instance for a single haplotype with related species alignments (when only one haplotype is used)\n3. **JBrowse2 Single Haplotype with related species and Gene Tracks** [collection] - As above, with gene annotation tracks included\n4. **JBrowse2 Hap1 and hap2 with related species** [collection] - JBrowse2 instance for two haplotypes with related species alignments (when two haplotypes are used)\n5. **JBrowse2 Hap1 and hap2 with related species and gene tracks** [collection] - As above, with gene annotation tracks included\n\n### Additional outputs\n\nThese JBrowse2 instances are produced without the related-species alignment tracks and can be useful for curators who only need the assembly-internal view.\n\n6. **JBrowse2 Single Haplotype** [collection] - JBrowse2 instance for a single haplotype with assembly tracks only (telomeres, gaps, coverage), no related-species alignments\n7. **JBrowse2 Single Haplotype with Gene Track** [collection] - As above, with gene annotation tracks included\n8. **JBrowse2 Hap1 vs Hap2** [collection] - JBrowse2 instance for two haplotypes with the hap1-vs-hap2 alignment, no related-species alignments\n9. **JBrowse2 Hap1 vs Hap2 with gene tracks** [collection] - As above, with gene annotation tracks included\n\n### Validation output\n\n10. **Fail if there are duplicated sequence names between the fasta files** [boolean] - Internal validation flag. The workflow fails fast if any sequence name appears in more than one of the related-species fastas.\n\n## Usage Notes\n\n### Pairing with the Hi-C contact map workflow\n\nThis workflow is designed to consume the precuration track outputs of the [Hi-C contact map for assembly manual curation](../hi-c-contact-map-for-assembly-manual-curation) workflow:\n\n| Hi-C workflow output | Use here as input |\n|---|---|\n| `Decontaminated Hap1 with Suffix` | `Haplotype 1` |\n| `Decontaminated Hap2 with Suffix` | `Haplotype 2` |\n| `P telomeres bed` | `Telomere P` |\n| `Q telomeres Bed` | `Telomere Q` |\n| `Gaps Bed` | `Gaps` |\n| `BigWig Coverage` | `Coverage` |\n| `Compleasm Genes track` | `Genes` |\n\n### Related species selection\n\nChoose related species whose genomes are evolutionarily close to the assembly under curation, so synteny is informative for spotting misassemblies. Provide them as gzipped FASTA files in a simple list collection.\n\n**Sequence names must be unique across the collection.** The workflow validates this and fails fast if duplicates are detected (e.g. two species both contain `>scaffold_1`). Prefix per-species scaffold names before uploading, for example:\n\n```bash\nzcat Species_1.fasta.gz | sed 's/^>/>Species_1_/' | gzip > Species_1_renamed.fasta.gz\n```\n\n### Scaffold name suffixes\n\nIf using two haplotypes, the recommended workflow is to apply per-haplotype suffixes (e.g. `H1`/`H2`) to scaffold names *before* running this workflow, so that scaffolds from each haplotype are unambiguously identified in the JBrowse view and in synteny tracks.\n\n## Citation\n\nIf you use this workflow, please cite:\n- JBrowse2 ([Diesh et al., 2023](https://doi.org/10.1186/s13059-023-02914-z))\n- minimap2 (used for related-species alignment)\n- Other tools as listed in the workflow\n",
+                "report": {
+                    "markdown": "# Precuration  workflow on:\n\n```galaxy\nhistory_dataset_embedded(output=\"Assembly Info\")\n```\n\n## Duplication Stats\n\nSamtools markdup deduplication stats (if applicable)\n\n\n```galaxy\nhistory_dataset_as_table(output=\"Hi-C duplication stats\")\n```\n\n\n\nPairtools stats\n```galaxy\nhistory_dataset_as_table(output=\"Hi-C duplication stats: MultiQC\")\n```\n\n## Telomere report\n\n```galaxy\nhistory_dataset_embedded(output=\"Telomere Report\")\n```\n\n## Pretext Snapshots\n\nWith Multimapping\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Pretext Snapshot With tracks - Multimapping\")\n```\n\n\nWith MAPQ filtering\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Pretext Snapshot With tracks\")\n```\n\n\n"
+                },
+                "steps": {
+                    "0": {
+                        "annotation": "Note: Duplicated sequence names between the species in the collection will cause inaccurate alignment visualization in JBrowse2.  ",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 0,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "Note: Duplicated sequence names between the species in the collection will cause inaccurate alignment visualization in JBrowse2.  ",
+                                "name": "Related Species"
+                            }
+                        ],
+                        "label": "Related Species",
+                        "name": "Input dataset collection",
+                        "outputs": [],
+                        "position": {
+                            "left": 0,
+                            "top": 0
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": true, \"format\": [\"fasta.gz\"], \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
+                        "tool_version": null,
+                        "type": "data_collection_input",
+                        "uuid": "b1d57707-483c-43cd-8256-0a2888af1246",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "1": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                        "errors": null,
+                        "id": 1,
+                        "input_connections": {
+                            "input_param_type|input_param": {
+                                "id": 0,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "Two Haplotypes 2",
+                        "name": "Map parameter value",
+                        "outputs": [
+                            {
+                                "name": "output_param_boolean",
+                                "type": "expression.json"
+                            }
+                        ],
+                        "position": {
+                            "left": 507.52614703835707,
+                            "top": 68.65082494054082
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionoutput_param_boolean": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output_param_boolean"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "5ac8a4bf7a8d",
+                            "name": "map_param_value",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"input_param_type\": {\"type\": \"data\", \"__current_case__\": 4, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": []}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "0.2.0",
+                        "type": "tool",
+                        "uuid": "30ef2c07-c458-4a90-94b7-5e5ae4885844",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "2": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                        "errors": null,
+                        "id": 2,
+                        "input_connections": {
+                            "input_param_type|input_param": {
+                                "id": 1,
+                                "output_name": "output_param_boolean"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "Two Haplotypes 3",
+                        "name": "Map parameter value",
+                        "outputs": [
+                            {
+                                "name": "output_param_text",
+                                "type": "expression.json"
+                            }
+                        ],
+                        "position": {
+                            "left": 801.9711946226973,
+                            "top": 268.066568476228
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionoutput_param_boolean": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output_param_boolean"
+                            },
+                            "HideDatasetActionoutput_param_text": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output_param_text"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "5ac8a4bf7a8d",
+                            "name": "map_param_value",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": []}, \"output_param_type\": \"text\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "0.2.0",
+                        "type": "tool",
+                        "uuid": "5be371df-1c67-42ae-a535-da4ca4bf1e51",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "3": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_text_file_with_recurring_lines/9.5+galaxy3",
+                        "errors": null,
+                        "id": 3,
+                        "input_connections": {
+                            "token_set_0|line": {
+                                "id": 2,
+                                "output_name": "output_param_text"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Create text file",
+                        "outputs": [
+                            {
+                                "name": "outfile",
+                                "type": "txt"
+                            }
+                        ],
+                        "position": {
+                            "left": 1031.2529071684971,
+                            "top": 141.25993418553026
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionoutfile": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "outfile"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_text_file_with_recurring_lines/9.5+galaxy3",
+                        "tool_shed_repository": {
+                            "changeset_revision": "ab83aa685821",
+                            "name": "text_processing",
+                            "owner": "bgruening",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"token_set\": [{\"__index__\": 0, \"line\": {\"__class__\": \"ConnectedValue\"}, \"repeat_select\": {\"repeat_select_opts\": \"user\", \"__current_case__\": 0, \"times\": \"1\"}}], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "9.5+galaxy3",
+                        "type": "tool",
+                        "uuid": "f2c6b8fd-f348-494d-867e-28d82492a589",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "4": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy3",
+                        "errors": null,
+                        "id": 4,
+                        "input_connections": {
+                            "inputs": {
+                                "id": 3,
+                                "output_name": "outfile"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Concatenate datasets",
+                        "outputs": [
+                            {
+                                "name": "out_file1",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 1404.1850282401706,
+                            "top": 159.59233303291586
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionout_file1": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "out_file1"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy3",
+                        "tool_shed_repository": {
+                            "changeset_revision": "ab83aa685821",
+                            "name": "text_processing",
+                            "owner": "bgruening",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"inputs\": {\"__class__\": \"ConnectedValue\"}, \"queries\": [], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "9.5+galaxy3",
+                        "type": "tool",
+                        "uuid": "951df8ae-cb04-448c-9b26-1b1c72e52354",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "5": {
+                        "annotation": "",
+                        "content_id": "Show beginning1",
+                        "errors": null,
+                        "id": 5,
+                        "input_connections": {
+                            "input": {
+                                "id": 4,
+                                "output_name": "out_file1"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Select first",
+                        "outputs": [
+                            {
+                                "name": "out_file1",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 1591.5813587970113,
+                            "top": 415.32944461901855
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionout_file1": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "out_file1"
+                            }
+                        },
+                        "tool_id": "Show beginning1",
+                        "tool_state": "{\"header\": false, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineNum\": \"1\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "1.0.2",
+                        "type": "tool",
+                        "uuid": "6777b035-d40f-471e-b677-c886520c5f08",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "6": {
+                        "annotation": "",
+                        "content_id": "param_value_from_file",
+                        "errors": null,
+                        "id": 6,
+                        "input_connections": {
+                            "input1": {
+                                "id": 5,
+                                "output_name": "out_file1"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Parse parameter value",
+                        "outputs": [
+                            {
+                                "name": "boolean_param",
+                                "type": "expression.json"
+                            }
+                        ],
+                        "position": {
+                            "left": 1900.9513665053723,
+                            "top": 426.5056982072265
+                        },
+                        "post_job_actions": {},
+                        "tool_id": "param_value_from_file",
+                        "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"boolean\", \"remove_newlines\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "0.1.0",
+                        "type": "tool",
+                        "uuid": "39916b95-3287-497f-83ea-822bb970a388",
+                        "when": null,
+                        "workflow_outputs": [
+                            {
+                                "label": "boolean_param",
+                                "output_name": "boolean_param",
+                                "uuid": "651aac03-f463-4bb0-bae9-c1e6d0d808d8"
+                            }
+                        ]
+                    }
+                },
+                "tags": [],
+                "uuid": "877369eb-5f6e-4a0f-9519-c6f3bb328653"
+            },
+            "tool_id": null,
+            "type": "subworkflow",
+            "uuid": "8669739f-1749-4124-8391-0bcaf518a2ba",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "14": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+            "errors": null,
+            "id": 14,
+            "input_connections": {
+                "input_param_type|input_param": {
+                    "id": 11,
+                    "output_name": "output_param_boolean"
+                }
+            },
+            "inputs": [],
+            "label": "Only one Haplotype",
+            "name": "Map parameter value",
             "outputs": [
                 {
-                    "name": "data_param",
-                    "type": "input"
+                    "name": "output_param_boolean",
+                    "type": "expression.json"
                 }
             ],
             "position": {
-                "left": 2050.977397800029,
-                "top": 1042.9931586846508
+                "left": 1736.3581103638398,
+                "top": 406.30248468574564
             },
             "post_job_actions": {
-                "HideDatasetActiondata_param": {
+                "HideDatasetActionoutput_param_boolean": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
-                    "output_name": "data_param"
+                    "output_name": "output_param_boolean"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
             "tool_shed_repository": {
-                "changeset_revision": "b19e21af9c52",
-                "name": "pick_value",
+                "changeset_revision": "5ac8a4bf7a8d",
+                "name": "map_param_value",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"style_cond\": {\"pick_style\": \"first\", \"__current_case__\": 0, \"type_cond\": {\"param_type\": \"data\", \"__current_case__\": 4, \"pick_from\": [{\"__index__\": 0, \"value\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"value\": {\"__class__\": \"ConnectedValue\"}}]}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": true, \"to\": \"False\"}, {\"__index__\": 1, \"from\": false, \"to\": \"True\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "87a497ce-176b-4e85-adf2-0f3e58b24670",
+            "uuid": "df19ed91-a001-4caa-91f8-8d9051fde5c9",
             "when": null,
             "workflow_outputs": []
         },
-        "16": {
+        "15": {
             "annotation": "",
-            "content_id": "CONVERTER_gz_to_uncompressed",
-            "errors": null,
-            "id": 16,
-            "input_connections": {
-                "input1": {
-                    "id": 11,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Convert gz compressed file to uncompressed.",
-            "outputs": [
-                {
-                    "name": "output1",
-                    "type": "auto"
-                }
-            ],
-            "position": {
-                "left": 1685.3438207068607,
-                "top": 928.4985122876616
-            },
-            "post_job_actions": {
-                "ChangeDatatypeActionoutput1": {
-                    "action_arguments": {
-                        "newtype": "fasta"
-                    },
-                    "action_type": "ChangeDatatypeAction",
-                    "output_name": "output1"
-                },
-                "HideDatasetActionoutput1": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output1"
-                }
-            },
-            "tool_id": "CONVERTER_gz_to_uncompressed",
-            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_uuid": null,
-            "tool_version": "1.0.0",
-            "type": "tool",
-            "uuid": "6f868700-ff9c-4415-98d7-81befe9dde9e",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "17": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.5+galaxy3",
-            "errors": null,
-            "id": 17,
-            "input_connections": {
-                "infile": {
-                    "id": 16,
-                    "output_name": "output1"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Search in textfiles",
-            "outputs": [
-                {
-                    "name": "output",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 2193.787159776598,
-                "top": 516.9501479775356
-            },
-            "post_job_actions": {
-                "ChangeDatatypeActionoutput": {
-                    "action_arguments": {
-                        "newtype": "tabular"
-                    },
-                    "action_type": "ChangeDatatypeAction",
-                    "output_name": "output"
-                },
-                "HideDatasetActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.5+galaxy3",
-            "tool_shed_repository": {
-                "changeset_revision": "ab83aa685821",
-                "name": "text_processing",
-                "owner": "bgruening",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"case_sensitive\": \"-i\", \"color\": \"NOCOLOR\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"invert\": \"\", \"lines_after\": \"0\", \"lines_before\": \"0\", \"regex_type\": \"-P\", \"url_paste\": \">\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_uuid": null,
-            "tool_version": "9.5+galaxy3",
-            "type": "tool",
-            "uuid": "24671126-d835-4ecf-94c6-f22fa01d6abd",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "18": {
-            "annotation": "",
-            "id": 18,
+            "id": 15,
             "input_connections": {
                 "Coverage": {
-                    "id": 10,
-                    "input_subworkflow_step_id": 5,
+                    "id": 8,
+                    "input_subworkflow_step_id": 6,
                     "output_name": "output"
                 },
                 "Gaps": {
-                    "id": 9,
-                    "input_subworkflow_step_id": 4,
+                    "id": 7,
+                    "input_subworkflow_step_id": 5,
                     "output_name": "output"
                 },
                 "Genes": {
-                    "id": 15,
-                    "input_subworkflow_step_id": 6,
-                    "output_name": "data_param"
-                },
-                "Genes?": {
-                    "id": 5,
+                    "id": 4,
                     "input_subworkflow_step_id": 7,
                     "output_name": "output"
                 },
@@ -684,23 +869,2576 @@
                     "input_subworkflow_step_id": 0,
                     "output_name": "output"
                 },
-                "Related Species": {
-                    "id": 16,
+                "Hap2 fasta": {
+                    "id": 12,
                     "input_subworkflow_step_id": 1,
-                    "output_name": "output1"
+                    "output_name": "data_param"
+                },
+                "Related Species": {
+                    "id": 9,
+                    "input_subworkflow_step_id": 2,
+                    "output_name": "output"
                 },
                 "Telomeres P": {
-                    "id": 8,
-                    "input_subworkflow_step_id": 3,
+                    "id": 6,
+                    "input_subworkflow_step_id": 4,
                     "output_name": "output"
                 },
                 "Telomeres Q": {
-                    "id": 7,
-                    "input_subworkflow_step_id": 2,
+                    "id": 5,
+                    "input_subworkflow_step_id": 3,
+                    "output_name": "output"
+                },
+                "when": {
+                    "id": 11,
+                    "output_name": "output_param_boolean"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Jbrowse for pre-curation",
+            "outputs": [],
+            "position": {
+                "left": 3359.99060088773,
+                "top": 733.3009897445525
+            },
+            "subworkflow": {
+                "a_galaxy_workflow": "true",
+                "annotation": "",
+                "comments": [],
+                "format-version": "0.1",
+                "name": "Jbrowse for pre-curation",
+                "report": {
+                    "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
+                },
+                "steps": {
+                    "0": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 0,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Hap1 fasta"
+                            }
+                        ],
+                        "label": "Hap1 fasta",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 0,
+                            "top": 89.79666666028459
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "4a20362f-2551-4a60-9118-e4c3e7c4f264",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "1": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 1,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Hap2 fasta"
+                            }
+                        ],
+                        "label": "Hap2 fasta",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 51.81545453466647,
+                            "top": 209.29539228726594
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "177f6825-e58e-45e9-a3fc-8c7623187e02",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "2": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 2,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Related Species"
+                            }
+                        ],
+                        "label": "Related Species",
+                        "name": "Input dataset collection",
+                        "outputs": [],
+                        "position": {
+                            "left": 249.05479741897238,
+                            "top": 610.6761230025993
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": true, \"format\": [\"fasta.gz\"], \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
+                        "tool_version": null,
+                        "type": "data_collection_input",
+                        "uuid": "20f7abfb-20b8-49bb-b522-cd911fd1ec4c",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "3": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 3,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Telomeres Q"
+                            }
+                        ],
+                        "label": "Telomeres Q",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 347.4491076529599,
+                            "top": 770.2540634659473
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "ce01ac46-a3c2-4013-ba5b-ea8a0e46be64",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "4": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 4,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Telomeres P"
+                            }
+                        ],
+                        "label": "Telomeres P",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 455.5329585464028,
+                            "top": 874.3517570740245
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "8044ff06-8a3b-4ac1-b6ee-521cc28e585d",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "5": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 5,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Gaps"
+                            }
+                        ],
+                        "label": "Gaps",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 524.1536909971493,
+                            "top": 967.7185159530706
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "37e56713-8aa6-474e-9a87-6c702d7d6b49",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "6": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 6,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Coverage"
+                            }
+                        ],
+                        "label": "Coverage",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 581.1909253334677,
+                            "top": 1054.8379828664645
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"format\": [\"bigwig\"], \"tag\": \"\"}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "738f43fc-5f88-4117-bcc3-4a9c1b01c0a1",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "7": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 7,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
+                                "name": "Genes"
+                            }
+                        ],
+                        "label": "Genes",
+                        "name": "Input dataset",
+                        "outputs": [],
+                        "position": {
+                            "left": 683.9939626471161,
+                            "top": 1247.6492139360419
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": true, \"tag\": null}",
+                        "tool_version": null,
+                        "type": "data_input",
+                        "uuid": "dabdef6f-cb85-410c-a5ef-229d9ae21a3b",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "8": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
+                        "errors": null,
+                        "id": 8,
+                        "input_connections": {
+                            "query": {
+                                "id": 0,
+                                "output_name": "output"
+                            },
+                            "reflist": {
+                                "id": 1,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "Align Haplotypes Hap1 is query",
+                        "name": "mashmap",
+                        "outputs": [
+                            {
+                                "name": "mashout",
+                                "type": "paf"
+                            }
+                        ],
+                        "position": {
+                            "left": 1618.8488760964965,
+                            "top": 794.9612701920845
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionmashout": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "mashout"
+                            },
+                            "RenameDatasetActionmashout": {
+                                "action_arguments": {
+                                    "newname": "Alignment Hap1 vs Hap2"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "mashout"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "a3a6b0b31f2d",
+                            "name": "mashmap",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"dense\": false, \"filter_mode\": \"map\", \"kmerComplexity\": null, \"kmerThreshold\": null, \"noHgFilter\": false, \"noMerge\": false, \"perc_identity\": \"90.0\", \"query\": {\"__class__\": \"ConnectedValue\"}, \"reflist\": {\"__class__\": \"ConnectedValue\"}, \"reportPercentage\": false, \"seqLength\": \"5000\", \"sketchSize\": \"0\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "3.1.3+galaxy0",
+                        "type": "tool",
+                        "uuid": "c7740c1c-5674-43d4-aa00-aeca2dcc7fa6",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "9": {
+                        "annotation": "",
+                        "id": 9,
+                        "input_connections": {
+                            "Related Species": {
+                                "id": 2,
+                                "input_subworkflow_step_id": 0,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Map Collection to boolean",
+                        "outputs": [],
+                        "position": {
+                            "left": 746.0912271164992,
+                            "top": 99.3825085692532
+                        },
+                        "subworkflow": {
+                            "a_galaxy_workflow": "true",
+                            "annotation": "",
+                            "comments": [],
+                            "creator": [
+                                {
+                                    "class": "Person",
+                                    "identifier": "https://orcid.org/0000-0001-6228-2785",
+                                    "name": "Patrik Smeds"
+                                },
+                                {
+                                    "class": "Person",
+                                    "identifier": "https://orcid.org/0000-0001-6421-3484",
+                                    "name": "Delphine Lariviere"
+                                }
+                            ],
+                            "format-version": "0.1",
+                            "license": "MIT",
+                            "name": "Map Collection to boolean",
+                            "readme": "# JBrowse2 Precuration Tracks with Related Species Alignments\n\nThis workflow generates JBrowse2 instances with genome assembly tracks and alignments against related species, to assist the manual curation of genome assemblies. It complements the Hi-C contact map workflow by providing a complementary genome browser view of the same precuration tracks alongside synteny with related species.\n\nThe workflow takes the assembly haplotype(s) and the precuration tracks (telomeres, gaps, coverage, optional gene annotations), aligns the assembly against a list of related species, and packages everything into a JBrowse2 instance that curators can open directly in their browser.\n\n## Inputs\n\n### Required Inputs\n\n1. **Species Name** [text] - Species identifier used in the assembly info report\n2. **Assembly Name** [text] - Assembly identifier (e.g., toLID)\n3. **Haplotype 1** [fasta] - Primary haplotype assembly (recommended: with H1 suffix added to scaffold names)\n4. **Will you use a second haplotype?** [boolean] - Set to true for diploid assemblies\n5. **Haplotype 2** [fasta, optional] - Secondary haplotype assembly (required if using two haplotypes)\n6. **Related Species** [collection of fasta.gz] - Simple list of gzipped FASTA files of related species genomes for synteny alignment. **Sequence names must be unique across the entire collection** - the workflow performs a duplicate-name check on the merged related-species fastas and will fail early if any sequence name appears in more than one file. A common pattern is to prefix each species' scaffolds with the species name (e.g. `Species_1_scaffold_1`).\n7. **Telomere P** [BED] - P-arm telomere coordinates\n8. **Telomere Q** [BED] - Q-arm telomere coordinates (can be empty)\n9. **Gaps** [BED] - Assembly gap coordinates\n10. **Coverage** [BigWig] - PacBio HiFi read coverage track\n\n### Gene Annotation Options\n\n11. **Do you want to provide gene annotation for your assembly?** [boolean] - Enable to include a gene annotation track in the JBrowse2 instance\n12. **Genes** [GFF, optional] - Gene annotation track (required if gene annotations enabled)\n\n## Outputs\n\n1. **Assembly Info** - Summary of species and assembly name\n2. **JBrowse2 Single Haplotype with related species** [collection] - JBrowse2 instance for a single haplotype with related species alignments (when only one haplotype is used)\n3. **JBrowse2 Single Haplotype with related species and Gene Tracks** [collection] - As above, with gene annotation tracks included\n4. **JBrowse2 Hap1 and hap2 with related species** [collection] - JBrowse2 instance for two haplotypes with related species alignments (when two haplotypes are used)\n5. **JBrowse2 Hap1 and hap2 with related species and gene tracks** [collection] - As above, with gene annotation tracks included\n\n### Additional outputs\n\nThese JBrowse2 instances are produced without the related-species alignment tracks and can be useful for curators who only need the assembly-internal view.\n\n6. **JBrowse2 Single Haplotype** [collection] - JBrowse2 instance for a single haplotype with assembly tracks only (telomeres, gaps, coverage), no related-species alignments\n7. **JBrowse2 Single Haplotype with Gene Track** [collection] - As above, with gene annotation tracks included\n8. **JBrowse2 Hap1 vs Hap2** [collection] - JBrowse2 instance for two haplotypes with the hap1-vs-hap2 alignment, no related-species alignments\n9. **JBrowse2 Hap1 vs Hap2 with gene tracks** [collection] - As above, with gene annotation tracks included\n\n### Validation output\n\n10. **Fail if there are duplicated sequence names between the fasta files** [boolean] - Internal validation flag. The workflow fails fast if any sequence name appears in more than one of the related-species fastas.\n\n## Usage Notes\n\n### Pairing with the Hi-C contact map workflow\n\nThis workflow is designed to consume the precuration track outputs of the [Hi-C contact map for assembly manual curation](../hi-c-contact-map-for-assembly-manual-curation) workflow:\n\n| Hi-C workflow output | Use here as input |\n|---|---|\n| `Decontaminated Hap1 with Suffix` | `Haplotype 1` |\n| `Decontaminated Hap2 with Suffix` | `Haplotype 2` |\n| `P telomeres bed` | `Telomere P` |\n| `Q telomeres Bed` | `Telomere Q` |\n| `Gaps Bed` | `Gaps` |\n| `BigWig Coverage` | `Coverage` |\n| `Compleasm Genes track` | `Genes` |\n\n### Related species selection\n\nChoose related species whose genomes are evolutionarily close to the assembly under curation, so synteny is informative for spotting misassemblies. Provide them as gzipped FASTA files in a simple list collection.\n\n**Sequence names must be unique across the collection.** The workflow validates this and fails fast if duplicates are detected (e.g. two species both contain `>scaffold_1`). Prefix per-species scaffold names before uploading, for example:\n\n```bash\nzcat Species_1.fasta.gz | sed 's/^>/>Species_1_/' | gzip > Species_1_renamed.fasta.gz\n```\n\n### Scaffold name suffixes\n\nIf using two haplotypes, the recommended workflow is to apply per-haplotype suffixes (e.g. `H1`/`H2`) to scaffold names *before* running this workflow, so that scaffolds from each haplotype are unambiguously identified in the JBrowse view and in synteny tracks.\n\n## Citation\n\nIf you use this workflow, please cite:\n- JBrowse2 ([Diesh et al., 2023](https://doi.org/10.1186/s13059-023-02914-z))\n- minimap2 (used for related-species alignment)\n- Other tools as listed in the workflow\n",
+                            "report": {
+                                "markdown": "# Precuration  workflow on:\n\n```galaxy\nhistory_dataset_embedded(output=\"Assembly Info\")\n```\n\n## Duplication Stats\n\nSamtools markdup deduplication stats (if applicable)\n\n\n```galaxy\nhistory_dataset_as_table(output=\"Hi-C duplication stats\")\n```\n\n\n\nPairtools stats\n```galaxy\nhistory_dataset_as_table(output=\"Hi-C duplication stats: MultiQC\")\n```\n\n## Telomere report\n\n```galaxy\nhistory_dataset_embedded(output=\"Telomere Report\")\n```\n\n## Pretext Snapshots\n\nWith Multimapping\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Pretext Snapshot With tracks - Multimapping\")\n```\n\n\nWith MAPQ filtering\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Pretext Snapshot With tracks\")\n```\n\n\n"
+                            },
+                            "steps": {
+                                "0": {
+                                    "annotation": "Note: Duplicated sequence names between the species in the collection will cause inaccurate alignment visualization in JBrowse2.  ",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 0,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "Note: Duplicated sequence names between the species in the collection will cause inaccurate alignment visualization in JBrowse2.  ",
+                                            "name": "Related Species"
+                                        }
+                                    ],
+                                    "label": "Related Species",
+                                    "name": "Input dataset collection",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 0,
+                                        "top": 0
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": true, \"format\": [\"fasta.gz\"], \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
+                                    "tool_version": null,
+                                    "type": "data_collection_input",
+                                    "uuid": "b1d57707-483c-43cd-8256-0a2888af1246",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "1": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "errors": null,
+                                    "id": 1,
+                                    "input_connections": {
+                                        "input_param_type|input_param": {
+                                            "id": 0,
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": "Two Haplotypes 2",
+                                    "name": "Map parameter value",
+                                    "outputs": [
+                                        {
+                                            "name": "output_param_boolean",
+                                            "type": "expression.json"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 507.52614703835707,
+                                        "top": 68.65082494054082
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActionoutput_param_boolean": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "output_param_boolean"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "5ac8a4bf7a8d",
+                                        "name": "map_param_value",
+                                        "owner": "iuc",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"input_param_type\": {\"type\": \"data\", \"__current_case__\": 4, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": []}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "0.2.0",
+                                    "type": "tool",
+                                    "uuid": "30ef2c07-c458-4a90-94b7-5e5ae4885844",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "2": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "errors": null,
+                                    "id": 2,
+                                    "input_connections": {
+                                        "input_param_type|input_param": {
+                                            "id": 1,
+                                            "output_name": "output_param_boolean"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": "Two Haplotypes 3",
+                                    "name": "Map parameter value",
+                                    "outputs": [
+                                        {
+                                            "name": "output_param_text",
+                                            "type": "expression.json"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 801.9711946226973,
+                                        "top": 268.066568476228
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActionoutput_param_boolean": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "output_param_boolean"
+                                        },
+                                        "HideDatasetActionoutput_param_text": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "output_param_text"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "5ac8a4bf7a8d",
+                                        "name": "map_param_value",
+                                        "owner": "iuc",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": []}, \"output_param_type\": \"text\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "0.2.0",
+                                    "type": "tool",
+                                    "uuid": "5be371df-1c67-42ae-a535-da4ca4bf1e51",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "3": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_text_file_with_recurring_lines/9.5+galaxy3",
+                                    "errors": null,
+                                    "id": 3,
+                                    "input_connections": {
+                                        "token_set_0|line": {
+                                            "id": 2,
+                                            "output_name": "output_param_text"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Create text file",
+                                    "outputs": [
+                                        {
+                                            "name": "outfile",
+                                            "type": "txt"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 1031.2529071684971,
+                                        "top": 141.25993418553026
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActionoutfile": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "outfile"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_text_file_with_recurring_lines/9.5+galaxy3",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "ab83aa685821",
+                                        "name": "text_processing",
+                                        "owner": "bgruening",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"token_set\": [{\"__index__\": 0, \"line\": {\"__class__\": \"ConnectedValue\"}, \"repeat_select\": {\"repeat_select_opts\": \"user\", \"__current_case__\": 0, \"times\": \"1\"}}], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "9.5+galaxy3",
+                                    "type": "tool",
+                                    "uuid": "f2c6b8fd-f348-494d-867e-28d82492a589",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "4": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy3",
+                                    "errors": null,
+                                    "id": 4,
+                                    "input_connections": {
+                                        "inputs": {
+                                            "id": 3,
+                                            "output_name": "outfile"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Concatenate datasets",
+                                    "outputs": [
+                                        {
+                                            "name": "out_file1",
+                                            "type": "input"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 1404.1850282401706,
+                                        "top": 159.59233303291586
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActionout_file1": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "out_file1"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy3",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "ab83aa685821",
+                                        "name": "text_processing",
+                                        "owner": "bgruening",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"inputs\": {\"__class__\": \"ConnectedValue\"}, \"queries\": [], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "9.5+galaxy3",
+                                    "type": "tool",
+                                    "uuid": "951df8ae-cb04-448c-9b26-1b1c72e52354",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "5": {
+                                    "annotation": "",
+                                    "content_id": "Show beginning1",
+                                    "errors": null,
+                                    "id": 5,
+                                    "input_connections": {
+                                        "input": {
+                                            "id": 4,
+                                            "output_name": "out_file1"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Select first",
+                                    "outputs": [
+                                        {
+                                            "name": "out_file1",
+                                            "type": "input"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 1591.5813587970113,
+                                        "top": 415.32944461901855
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActionout_file1": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "out_file1"
+                                        }
+                                    },
+                                    "tool_id": "Show beginning1",
+                                    "tool_state": "{\"header\": false, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineNum\": \"1\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "1.0.2",
+                                    "type": "tool",
+                                    "uuid": "6777b035-d40f-471e-b677-c886520c5f08",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "6": {
+                                    "annotation": "",
+                                    "content_id": "param_value_from_file",
+                                    "errors": null,
+                                    "id": 6,
+                                    "input_connections": {
+                                        "input1": {
+                                            "id": 5,
+                                            "output_name": "out_file1"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Parse parameter value",
+                                    "outputs": [
+                                        {
+                                            "name": "boolean_param",
+                                            "type": "expression.json"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 1900.9513665053723,
+                                        "top": 426.5056982072265
+                                    },
+                                    "post_job_actions": {},
+                                    "tool_id": "param_value_from_file",
+                                    "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"boolean\", \"remove_newlines\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "0.1.0",
+                                    "type": "tool",
+                                    "uuid": "39916b95-3287-497f-83ea-822bb970a388",
+                                    "when": null,
+                                    "workflow_outputs": [
+                                        {
+                                            "label": "boolean_param",
+                                            "output_name": "boolean_param",
+                                            "uuid": "651aac03-f463-4bb0-bae9-c1e6d0d808d8"
+                                        }
+                                    ]
+                                }
+                            },
+                            "tags": [],
+                            "uuid": "877369eb-5f6e-4a0f-9519-c6f3bb328653"
+                        },
+                        "tool_id": null,
+                        "type": "subworkflow",
+                        "uuid": "1e7bc4d3-c4e5-42df-bf18-beb340b1493b",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "10": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                        "errors": null,
+                        "id": 10,
+                        "input_connections": {
+                            "input_param_type|input_param": {
+                                "id": 7,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Map parameter value",
+                        "outputs": [
+                            {
+                                "name": "output_param_boolean",
+                                "type": "expression.json"
+                            }
+                        ],
+                        "position": {
+                            "left": 1187.515644704917,
+                            "top": 1370.7082691223843
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionoutput_param_boolean": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output_param_boolean"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "5ac8a4bf7a8d",
+                            "name": "map_param_value",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"input_param_type\": {\"type\": \"data\", \"__current_case__\": 4, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": []}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "0.2.0",
+                        "type": "tool",
+                        "uuid": "627f5baa-1be8-4c50-8708-88ce7c0c86c3",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "11": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
+                        "errors": null,
+                        "id": 11,
+                        "input_connections": {
+                            "query": {
+                                "id": 0,
+                                "output_name": "output"
+                            },
+                            "reflist": {
+                                "id": 2,
+                                "output_name": "output"
+                            },
+                            "when": {
+                                "id": 9,
+                                "output_name": "boolean_param"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "Hap1 vs Species",
+                        "name": "mashmap",
+                        "outputs": [
+                            {
+                                "name": "mashout",
+                                "type": "paf"
+                            }
+                        ],
+                        "position": {
+                            "left": 1373.796550800666,
+                            "top": 190.60802095876576
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionmashout": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "mashout"
+                            },
+                            "RenameDatasetActionmashout": {
+                                "action_arguments": {
+                                    "newname": "Species to Hap2"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "mashout"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "a3a6b0b31f2d",
+                            "name": "mashmap",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"dense\": false, \"filter_mode\": \"one-to-one\", \"kmerComplexity\": null, \"kmerThreshold\": null, \"noHgFilter\": false, \"noMerge\": false, \"perc_identity\": \"85.0\", \"query\": {\"__class__\": \"ConnectedValue\"}, \"reflist\": {\"__class__\": \"ConnectedValue\"}, \"reportPercentage\": false, \"seqLength\": \"5000\", \"sketchSize\": \"0\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "3.1.3+galaxy0",
+                        "type": "tool",
+                        "uuid": "ba8fe065-a989-4cff-bcda-2e6883b1f6cd",
+                        "when": "$(inputs.when)",
+                        "workflow_outputs": []
+                    },
+                    "12": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
+                        "errors": null,
+                        "id": 12,
+                        "input_connections": {
+                            "query": {
+                                "id": 2,
+                                "output_name": "output"
+                            },
+                            "reflist": {
+                                "id": 1,
+                                "output_name": "output"
+                            },
+                            "when": {
+                                "id": 9,
+                                "output_name": "boolean_param"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "Species vs Hap2",
+                        "name": "mashmap",
+                        "outputs": [
+                            {
+                                "name": "mashout",
+                                "type": "paf"
+                            }
+                        ],
+                        "position": {
+                            "left": 1373.0046279283763,
+                            "top": 474.33892908289124
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionmashout": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "mashout"
+                            },
+                            "RenameDatasetActionmashout": {
+                                "action_arguments": {
+                                    "newname": "Species to Hap2"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "mashout"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "a3a6b0b31f2d",
+                            "name": "mashmap",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"dense\": false, \"filter_mode\": \"one-to-one\", \"kmerComplexity\": null, \"kmerThreshold\": null, \"noHgFilter\": false, \"noMerge\": false, \"perc_identity\": \"85.0\", \"query\": {\"__class__\": \"ConnectedValue\"}, \"reflist\": {\"__class__\": \"ConnectedValue\"}, \"reportPercentage\": false, \"seqLength\": \"5000\", \"sketchSize\": \"0\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "3.1.3+galaxy0",
+                        "type": "tool",
+                        "uuid": "cf1e95b5-3bd6-41c1-a2d4-93ac6c1b1b1a",
+                        "when": "$(inputs.when)",
+                        "workflow_outputs": []
+                    },
+                    "13": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                        "errors": null,
+                        "id": 13,
+                        "input_connections": {
+                            "input_param_type|input_param": {
+                                "id": 10,
+                                "output_name": "output_param_boolean"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Map parameter value",
+                        "outputs": [
+                            {
+                                "name": "output_param_boolean",
+                                "type": "expression.json"
+                            }
+                        ],
+                        "position": {
+                            "left": 1454.7038382847572,
+                            "top": 1062.9892225005478
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionoutput_param_boolean": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output_param_boolean"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "5ac8a4bf7a8d",
+                            "name": "map_param_value",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": true, \"to\": \"False\"}, {\"__index__\": 1, \"from\": false, \"to\": \"True\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "0.2.0",
+                        "type": "tool",
+                        "uuid": "03bd04b4-815e-471e-8bf2-b51054b8390e",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "14": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                        "errors": null,
+                        "id": 14,
+                        "input_connections": {
+                            "assemblies_0|reference_genome|genome": {
+                                "id": 0,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 8,
+                                "output_name": "mashout"
+                            },
+                            "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 3,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_1|data_tracks_1|data_format|annotation_cond|annotation": {
+                                "id": 4,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 5,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 6,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_4|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 7,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|reference_genome|genome": {
+                                "id": 0,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 3,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_0|data_tracks_1|data_format|annotation_cond|annotation": {
+                                "id": 4,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 5,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 6,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 7,
+                                "output_name": "output"
+                            },
+                            "when": {
+                                "id": 10,
+                                "output_name": "output_param_boolean"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "JBrowse2 Hap1 vs Hap2 with gene tracks",
+                        "name": "JBrowse2",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "html"
+                            }
+                        ],
+                        "position": {
+                            "left": 2132.3926171121566,
+                            "top": 631.5194878176554
+                        },
+                        "post_job_actions": {
+                            "RenameDatasetActionoutput": {
+                                "action_arguments": {
+                                    "newname": "JBrowse2 Hap1 vs Hap2 with gene tracks"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "output"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "bd903fbbc26e",
+                            "name": "jbrowse2",
+                            "owner": "fubar",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Alignments\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Telomeres Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_off\"}}]}, {\"__index__\": 2, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 4, \"category\": \"Annotation\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 1, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Telomeres\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"Annotation\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "3.7.0+galaxy0",
+                        "type": "tool",
+                        "uuid": "8579f589-f836-4f8e-ad72-aa14a8b6c450",
+                        "when": "$(inputs.when)",
+                        "workflow_outputs": [
+                            {
+                                "label": "JBrowse2 Hap1 vs Hap2 with gene tracks",
+                                "output_name": "output",
+                                "uuid": "4db7f57b-58ba-4932-9d15-8a0e3cde1f9b"
+                            }
+                        ]
+                    },
+                    "15": {
+                        "annotation": "",
+                        "id": 15,
+                        "input_connections": {
+                            "Coverage": {
+                                "id": 6,
+                                "input_subworkflow_step_id": 8,
+                                "output_name": "output"
+                            },
+                            "Gaps": {
+                                "id": 5,
+                                "input_subworkflow_step_id": 7,
+                                "output_name": "output"
+                            },
+                            "Genes": {
+                                "id": 7,
+                                "input_subworkflow_step_id": 9,
+                                "output_name": "output"
+                            },
+                            "Hap1 fasta": {
+                                "id": 0,
+                                "input_subworkflow_step_id": 0,
+                                "output_name": "output"
+                            },
+                            "Hap1 vs Species": {
+                                "id": 11,
+                                "input_subworkflow_step_id": 4,
+                                "output_name": "mashout"
+                            },
+                            "Hap2 fasta": {
+                                "id": 1,
+                                "input_subworkflow_step_id": 1,
+                                "output_name": "output"
+                            },
+                            "Related Species": {
+                                "id": 2,
+                                "input_subworkflow_step_id": 2,
+                                "output_name": "output"
+                            },
+                            "Species vs Hap2": {
+                                "id": 12,
+                                "input_subworkflow_step_id": 3,
+                                "output_name": "mashout"
+                            },
+                            "Telomeres P": {
+                                "id": 4,
+                                "input_subworkflow_step_id": 6,
+                                "output_name": "output"
+                            },
+                            "Telomeres Q": {
+                                "id": 3,
+                                "input_subworkflow_step_id": 5,
+                                "output_name": "output"
+                            },
+                            "when": {
+                                "id": 9,
+                                "output_name": "boolean_param"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Jbrowse2 for 1 related species",
+                        "outputs": [],
+                        "position": {
+                            "left": 1906.299975360162,
+                            "top": 0.0
+                        },
+                        "subworkflow": {
+                            "a_galaxy_workflow": "true",
+                            "annotation": "",
+                            "comments": [],
+                            "format-version": "0.1",
+                            "name": "Jbrowse2 for 1 related species",
+                            "report": {
+                                "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
+                            },
+                            "steps": {
+                                "0": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 0,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Hap1 fasta"
+                                        }
+                                    ],
+                                    "label": "Hap1 fasta",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 0,
+                                        "top": 271.13908772215916
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "4a20362f-2551-4a60-9118-e4c3e7c4f264",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "1": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 1,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Hap2 fasta"
+                                        }
+                                    ],
+                                    "label": "Hap2 fasta",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 53.14881800970572,
+                                        "top": 420.7641795440555
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "177f6825-e58e-45e9-a3fc-8c7623187e02",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "2": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 2,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Related Species"
+                                        }
+                                    ],
+                                    "label": "Related Species",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 98.91709918730632,
+                                        "top": 553.1054764799819
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": true, \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "604a6bec-8c1f-47e3-8884-c32f63246589",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "3": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 3,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Species vs Hap2"
+                                        }
+                                    ],
+                                    "label": "Species vs Hap2",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 147.9198303415696,
+                                        "top": 670.2931389328182
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": true, \"format\": [\"paf\"], \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "ebdc47b3-16f5-48e9-a101-c82b2370181a",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "4": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 4,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Hap1 vs Species"
+                                        }
+                                    ],
+                                    "label": "Hap1 vs Species",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 175.64670268098203,
+                                        "top": 777.2105888619357
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": true, \"format\": [\"paf\"], \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "385825a9-198e-425f-9fb3-55af892d20dc",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "5": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 5,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Telomeres Q"
+                                        }
+                                    ],
+                                    "label": "Telomeres Q",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 206.21568172170709,
+                                        "top": 895.0983900914266
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "ce01ac46-a3c2-4013-ba5b-ea8a0e46be64",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "6": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 6,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Telomeres P"
+                                        }
+                                    ],
+                                    "label": "Telomeres P",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 300.9375,
+                                        "top": 1049.75
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "8044ff06-8a3b-4ac1-b6ee-521cc28e585d",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "7": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 7,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Gaps"
+                                        }
+                                    ],
+                                    "label": "Gaps",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 353.8919295731858,
+                                        "top": 1244.9653893778952
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "37e56713-8aa6-474e-9a87-6c702d7d6b49",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "8": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 8,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Coverage"
+                                        }
+                                    ],
+                                    "label": "Coverage",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 391.49614814580605,
+                                        "top": 1410.3962329181184
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": false, \"format\": [\"bigwig\"], \"tag\": \"\"}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "2131fd1e-4f34-4662-be5c-382101fcbc76",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "9": {
+                                    "annotation": "",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 9,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "",
+                                            "name": "Genes"
+                                        }
+                                    ],
+                                    "label": "Genes",
+                                    "name": "Input dataset",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 467.99484572288014,
+                                        "top": 1557.4724288450213
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": true, \"tag\": null}",
+                                    "tool_version": null,
+                                    "type": "data_input",
+                                    "uuid": "496c7358-def1-4256-b4e8-6698cac34f97",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "10": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+                                    "errors": null,
+                                    "id": 10,
+                                    "input_connections": {
+                                        "style_cond|type_cond|pick_from_0|value": {
+                                            "id": 2,
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Pick parameter value",
+                                    "outputs": [
+                                        {
+                                            "name": "data_param",
+                                            "type": "input"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 819.3045693419575,
+                                        "top": 344.4531003778494
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActiondata_param": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "data_param"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "b19e21af9c52",
+                                        "name": "pick_value",
+                                        "owner": "iuc",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"style_cond\": {\"pick_style\": \"first_or_error\", \"__current_case__\": 2, \"type_cond\": {\"param_type\": \"data\", \"__current_case__\": 4, \"pick_from\": [{\"__index__\": 0, \"value\": {\"__class__\": \"RuntimeValue\"}}]}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "0.2.0",
+                                    "type": "tool",
+                                    "uuid": "7399e65c-fc45-48bc-9a66-32ce47c70e9d",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "11": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+                                    "errors": null,
+                                    "id": 11,
+                                    "input_connections": {
+                                        "style_cond|type_cond|pick_from_0|value": {
+                                            "id": 3,
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Pick parameter value",
+                                    "outputs": [
+                                        {
+                                            "name": "data_param",
+                                            "type": "input"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 982.8012108841962,
+                                        "top": 480.8711270227511
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActiondata_param": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "data_param"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "b19e21af9c52",
+                                        "name": "pick_value",
+                                        "owner": "iuc",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"style_cond\": {\"pick_style\": \"first_or_error\", \"__current_case__\": 2, \"type_cond\": {\"param_type\": \"data\", \"__current_case__\": 4, \"pick_from\": [{\"__index__\": 0, \"value\": {\"__class__\": \"RuntimeValue\"}}]}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "0.2.0",
+                                    "type": "tool",
+                                    "uuid": "f3d385a7-8a88-459e-8d4b-c680e7a433e7",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "12": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+                                    "errors": null,
+                                    "id": 12,
+                                    "input_connections": {
+                                        "style_cond|type_cond|pick_from_0|value": {
+                                            "id": 4,
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Pick parameter value",
+                                    "outputs": [
+                                        {
+                                            "name": "data_param",
+                                            "type": "input"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 908.8858060336889,
+                                        "top": 822.840387531385
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActiondata_param": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "data_param"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "b19e21af9c52",
+                                        "name": "pick_value",
+                                        "owner": "iuc",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"style_cond\": {\"pick_style\": \"first_or_error\", \"__current_case__\": 2, \"type_cond\": {\"param_type\": \"data\", \"__current_case__\": 4, \"pick_from\": [{\"__index__\": 0, \"value\": {\"__class__\": \"RuntimeValue\"}}]}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "0.2.0",
+                                    "type": "tool",
+                                    "uuid": "38659345-a8cc-462a-bf02-e7e8ef9a3e80",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "13": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "errors": null,
+                                    "id": 13,
+                                    "input_connections": {
+                                        "input_param_type|input_param": {
+                                            "id": 9,
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Map parameter value",
+                                    "outputs": [
+                                        {
+                                            "name": "output_param_boolean",
+                                            "type": "expression.json"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 894.3942403582007,
+                                        "top": 1144.0865983396454
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActionoutput_param_boolean": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "output_param_boolean"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "5ac8a4bf7a8d",
+                                        "name": "map_param_value",
+                                        "owner": "iuc",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"input_param_type\": {\"type\": \"data\", \"__current_case__\": 4, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": []}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "0.2.0",
+                                    "type": "tool",
+                                    "uuid": "70c8e882-f5c7-42a7-b7a1-db1e27761813",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "14": {
+                                    "annotation": "",
+                                    "content_id": "CONVERTER_gz_to_uncompressed",
+                                    "errors": null,
+                                    "id": 14,
+                                    "input_connections": {
+                                        "input1": {
+                                            "id": 10,
+                                            "output_name": "data_param"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Convert gz compressed file to uncompressed.",
+                                    "outputs": [
+                                        {
+                                            "name": "output1",
+                                            "type": "auto"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 1214.1368049655293,
+                                        "top": 250.31238436598994
+                                    },
+                                    "post_job_actions": {
+                                        "ChangeDatatypeActionoutput1": {
+                                            "action_arguments": {
+                                                "newtype": "fasta"
+                                            },
+                                            "action_type": "ChangeDatatypeAction",
+                                            "output_name": "output1"
+                                        },
+                                        "HideDatasetActionoutput1": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "output1"
+                                        }
+                                    },
+                                    "tool_id": "CONVERTER_gz_to_uncompressed",
+                                    "tool_state": "{\"input1\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "1.0.0",
+                                    "type": "tool",
+                                    "uuid": "81f21f4a-6c9c-4b8d-bb19-8a7343d77dc6",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "15": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "errors": null,
+                                    "id": 15,
+                                    "input_connections": {
+                                        "input_param_type|input_param": {
+                                            "id": 13,
+                                            "output_name": "output_param_boolean"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": "No Gene track",
+                                    "name": "Map parameter value",
+                                    "outputs": [
+                                        {
+                                            "name": "output_param_boolean",
+                                            "type": "expression.json"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 1186.413509119842,
+                                        "top": 1363.2948622310325
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActionoutput_param_boolean": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "output_param_boolean"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "5ac8a4bf7a8d",
+                                        "name": "map_param_value",
+                                        "owner": "iuc",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": false, \"to\": \"True\"}, {\"__index__\": 1, \"from\": false, \"to\": \"False\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "0.2.0",
+                                    "type": "tool",
+                                    "uuid": "d8f71bf4-51a3-4af7-8cf2-fd16730469b4",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "16": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                                    "errors": null,
+                                    "id": 16,
+                                    "input_connections": {
+                                        "assemblies_0|reference_genome|genome": {
+                                            "id": 0,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 12,
+                                            "output_name": "data_param"
+                                        },
+                                        "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 5,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_1|data_tracks_1|data_format|annotation_cond|annotation": {
+                                            "id": 6,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 7,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 8,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_4|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 9,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_1|reference_genome|genome": {
+                                            "id": 14,
+                                            "output_name": "output1"
+                                        },
+                                        "assemblies_1|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 11,
+                                            "output_name": "data_param"
+                                        },
+                                        "assemblies_2|reference_genome|genome": {
+                                            "id": 1,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 5,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_0|data_tracks_1|data_format|annotation_cond|annotation": {
+                                            "id": 6,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 7,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 8,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 9,
+                                            "output_name": "output"
+                                        },
+                                        "when": {
+                                            "id": 13,
+                                            "output_name": "output_param_boolean"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
+                                    "name": "JBrowse2",
+                                    "outputs": [
+                                        {
+                                            "name": "output",
+                                            "type": "html"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 2604.560544371787,
+                                        "top": 306.40203071991476
+                                    },
+                                    "post_job_actions": {
+                                        "RenameDatasetActionoutput": {
+                                            "action_arguments": {
+                                                "newname": "JBrowse2 Hap1 and hap2 with related species and gene tracks"
+                                            },
+                                            "action_type": "RenameDatasetAction",
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "bd903fbbc26e",
+                                        "name": "jbrowse2",
+                                        "owner": "fubar",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Synteny Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Telomeres Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 4, \"category\": \"Annotations\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 1, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Synteny Hap2\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 2, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Telomeres Haplotype 2\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"Annotations\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "3.7.0+galaxy0",
+                                    "type": "tool",
+                                    "uuid": "c4b25ca4-bdd4-4260-ac8b-80ae381da1ab",
+                                    "when": "$(inputs.when)",
+                                    "workflow_outputs": [
+                                        {
+                                            "label": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
+                                            "output_name": "output",
+                                            "uuid": "78b83679-2eea-4812-9936-54e27a2c404d"
+                                        }
+                                    ]
+                                },
+                                "17": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                                    "errors": null,
+                                    "id": 17,
+                                    "input_connections": {
+                                        "assemblies_0|reference_genome|genome": {
+                                            "id": 0,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 12,
+                                            "output_name": "data_param"
+                                        },
+                                        "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 5,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_1|data_tracks_1|data_format|annotation_cond|annotation": {
+                                            "id": 6,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 7,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_0|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 8,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_1|reference_genome|genome": {
+                                            "id": 14,
+                                            "output_name": "output1"
+                                        },
+                                        "assemblies_1|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 11,
+                                            "output_name": "data_param"
+                                        },
+                                        "assemblies_2|reference_genome|genome": {
+                                            "id": 1,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 5,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_0|data_tracks_1|data_format|annotation_cond|annotation": {
+                                            "id": 6,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 7,
+                                            "output_name": "output"
+                                        },
+                                        "assemblies_2|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                            "id": 8,
+                                            "output_name": "output"
+                                        },
+                                        "when": {
+                                            "id": 15,
+                                            "output_name": "output_param_boolean"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": "JBrowse2 Hap1 and hap2 with 1st related species",
+                                    "name": "JBrowse2",
+                                    "outputs": [
+                                        {
+                                            "name": "output",
+                                            "type": "html"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 1960.7191746063156,
+                                        "top": 0
+                                    },
+                                    "post_job_actions": {
+                                        "RenameDatasetActionoutput": {
+                                            "action_arguments": {
+                                                "newname": "JBrowse2 Hap1 and hap2 with related species"
+                                            },
+                                            "action_type": "RenameDatasetAction",
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "bd903fbbc26e",
+                                        "name": "jbrowse2",
+                                        "owner": "fubar",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Synteny Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Telomeres Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 1, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Synteny Hap2\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 2, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Telomeres Haplotype 2\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "3.7.0+galaxy0",
+                                    "type": "tool",
+                                    "uuid": "0dba1c5e-903c-46f3-a58c-2b9341b92a15",
+                                    "when": "$(inputs.when)",
+                                    "workflow_outputs": [
+                                        {
+                                            "label": "JBrowse2 Hap1 and hap2 with related species",
+                                            "output_name": "output",
+                                            "uuid": "ce6026de-ad8b-4dec-8926-fccc97f25df6"
+                                        }
+                                    ]
+                                }
+                            },
+                            "tags": [],
+                            "uuid": "e27defb2-86fb-4547-baf7-445ff2765428"
+                        },
+                        "tool_id": null,
+                        "type": "subworkflow",
+                        "uuid": "e134915a-f5b7-4b32-a511-921e0b363bff",
+                        "when": "$(inputs.when)",
+                        "workflow_outputs": [
+                            {
+                                "label": "JBrowse2 Hap1 and hap2 with related species",
+                                "output_name": "JBrowse2 Hap1 and hap2 with related species",
+                                "uuid": "7562c81f-4b86-4932-8056-52f4dc17d2a9"
+                            },
+                            {
+                                "label": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
+                                "output_name": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
+                                "uuid": "ca3249af-b46a-450d-8dbe-696490325d42"
+                            }
+                        ]
+                    },
+                    "16": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                        "errors": null,
+                        "id": 16,
+                        "input_connections": {
+                            "assemblies_0|reference_genome|genome": {
+                                "id": 0,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 8,
+                                "output_name": "mashout"
+                            },
+                            "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 3,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_1|data_tracks_1|data_format|annotation_cond|annotation": {
+                                "id": 4,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 5,
+                                "output_name": "output"
+                            },
+                            "assemblies_0|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 6,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|reference_genome|genome": {
+                                "id": 0,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 3,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_0|data_tracks_1|data_format|annotation_cond|annotation": {
+                                "id": 4,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 5,
+                                "output_name": "output"
+                            },
+                            "assemblies_1|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
+                                "id": 6,
+                                "output_name": "output"
+                            },
+                            "when": {
+                                "id": 13,
+                                "output_name": "output_param_boolean"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "JBrowse2 Hap1 vs Hap2",
+                        "name": "JBrowse2",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "html"
+                            }
+                        ],
+                        "position": {
+                            "left": 2427.3955083914084,
+                            "top": 105.84839360779135
+                        },
+                        "post_job_actions": {
+                            "RenameDatasetActionoutput": {
+                                "action_arguments": {
+                                    "newname": "JBrowse2 Hap1 vs Hap2"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "output"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "bd903fbbc26e",
+                            "name": "jbrowse2",
+                            "owner": "fubar",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Alignments\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Telomeres Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_off\"}}]}, {\"__index__\": 2, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 1, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Telomeres\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "3.7.0+galaxy0",
+                        "type": "tool",
+                        "uuid": "1838736c-68a4-41fd-b6c8-cd4de0aad595",
+                        "when": "$(inputs.when)",
+                        "workflow_outputs": [
+                            {
+                                "label": "JBrowse2 Hap1 vs Hap2",
+                                "output_name": "output",
+                                "uuid": "a3d1e37d-ea4d-44e6-ac96-c456fef1395f"
+                            }
+                        ]
+                    }
+                },
+                "tags": [],
+                "uuid": "db1e0e52-f223-4168-ae05-a4ba02ba34d1"
+            },
+            "tool_id": null,
+            "type": "subworkflow",
+            "uuid": "c65e39fb-f036-47f7-9bd1-c63d161b736f",
+            "when": "$(inputs.when)",
+            "workflow_outputs": [
+                {
+                    "label": "JBrowse2 Hap1 vs Hap2",
+                    "output_name": "JBrowse2 Hap1 vs Hap2",
+                    "uuid": "a0cefb53-5c71-4e7a-8415-760c5f49d254"
+                },
+                {
+                    "label": "JBrowse2 Hap1 and hap2 with related species",
+                    "output_name": "JBrowse2 Hap1 and hap2 with related species",
+                    "uuid": "1d0f2614-f167-446d-b874-f2435995ca7a"
+                },
+                {
+                    "label": "JBrowse2 Hap1 vs Hap2 with gene tracks",
+                    "output_name": "JBrowse2 Hap1 vs Hap2 with gene tracks",
+                    "uuid": "42a88cd2-d2d5-4cfe-a00c-145d647cb12b"
+                },
+                {
+                    "label": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
+                    "output_name": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
+                    "uuid": "4a390dc0-8929-4bf5-aea4-2ca8352a8987"
+                }
+            ]
+        },
+        "16": {
+            "annotation": "",
+            "id": 16,
+            "input_connections": {
+                "Related Species": {
+                    "id": 9,
+                    "input_subworkflow_step_id": 0,
                     "output_name": "output"
                 },
                 "when": {
                     "id": 13,
+                    "output_name": "boolean_param"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Validate No Duplicated names",
+            "outputs": [],
+            "position": {
+                "left": 2964.3431657962838,
+                "top": 245.025230274267
+            },
+            "subworkflow": {
+                "a_galaxy_workflow": "true",
+                "annotation": "",
+                "comments": [],
+                "creator": [
+                    {
+                        "class": "Person",
+                        "identifier": "https://orcid.org/0000-0001-6228-2785",
+                        "name": "Patrik Smeds"
+                    },
+                    {
+                        "class": "Person",
+                        "identifier": "https://orcid.org/0000-0001-6421-3484",
+                        "name": "Delphine Lariviere"
+                    }
+                ],
+                "format-version": "0.1",
+                "license": "MIT",
+                "name": "Validate No Duplicated names",
+                "readme": "# JBrowse2 Precuration Tracks with Related Species Alignments\n\nThis workflow generates JBrowse2 instances with genome assembly tracks and alignments against related species, to assist the manual curation of genome assemblies. It complements the Hi-C contact map workflow by providing a complementary genome browser view of the same precuration tracks alongside synteny with related species.\n\nThe workflow takes the assembly haplotype(s) and the precuration tracks (telomeres, gaps, coverage, optional gene annotations), aligns the assembly against a list of related species, and packages everything into a JBrowse2 instance that curators can open directly in their browser.\n\n## Inputs\n\n### Required Inputs\n\n1. **Species Name** [text] - Species identifier used in the assembly info report\n2. **Assembly Name** [text] - Assembly identifier (e.g., toLID)\n3. **Haplotype 1** [fasta] - Primary haplotype assembly (recommended: with H1 suffix added to scaffold names)\n4. **Will you use a second haplotype?** [boolean] - Set to true for diploid assemblies\n5. **Haplotype 2** [fasta, optional] - Secondary haplotype assembly (required if using two haplotypes)\n6. **Related Species** [collection of fasta.gz] - Simple list of gzipped FASTA files of related species genomes for synteny alignment. **Sequence names must be unique across the entire collection** - the workflow performs a duplicate-name check on the merged related-species fastas and will fail early if any sequence name appears in more than one file. A common pattern is to prefix each species' scaffolds with the species name (e.g. `Species_1_scaffold_1`).\n7. **Telomere P** [BED] - P-arm telomere coordinates\n8. **Telomere Q** [BED] - Q-arm telomere coordinates (can be empty)\n9. **Gaps** [BED] - Assembly gap coordinates\n10. **Coverage** [BigWig] - PacBio HiFi read coverage track\n\n### Gene Annotation Options\n\n11. **Do you want to provide gene annotation for your assembly?** [boolean] - Enable to include a gene annotation track in the JBrowse2 instance\n12. **Genes** [GFF, optional] - Gene annotation track (required if gene annotations enabled)\n\n## Outputs\n\n1. **Assembly Info** - Summary of species and assembly name\n2. **JBrowse2 Single Haplotype with related species** [collection] - JBrowse2 instance for a single haplotype with related species alignments (when only one haplotype is used)\n3. **JBrowse2 Single Haplotype with related species and Gene Tracks** [collection] - As above, with gene annotation tracks included\n4. **JBrowse2 Hap1 and hap2 with related species** [collection] - JBrowse2 instance for two haplotypes with related species alignments (when two haplotypes are used)\n5. **JBrowse2 Hap1 and hap2 with related species and gene tracks** [collection] - As above, with gene annotation tracks included\n\n### Additional outputs\n\nThese JBrowse2 instances are produced without the related-species alignment tracks and can be useful for curators who only need the assembly-internal view.\n\n6. **JBrowse2 Single Haplotype** [collection] - JBrowse2 instance for a single haplotype with assembly tracks only (telomeres, gaps, coverage), no related-species alignments\n7. **JBrowse2 Single Haplotype with Gene Track** [collection] - As above, with gene annotation tracks included\n8. **JBrowse2 Hap1 vs Hap2** [collection] - JBrowse2 instance for two haplotypes with the hap1-vs-hap2 alignment, no related-species alignments\n9. **JBrowse2 Hap1 vs Hap2 with gene tracks** [collection] - As above, with gene annotation tracks included\n\n### Validation output\n\n10. **Fail if there are duplicated sequence names between the fasta files** [boolean] - Internal validation flag. The workflow fails fast if any sequence name appears in more than one of the related-species fastas.\n\n## Usage Notes\n\n### Pairing with the Hi-C contact map workflow\n\nThis workflow is designed to consume the precuration track outputs of the [Hi-C contact map for assembly manual curation](../hi-c-contact-map-for-assembly-manual-curation) workflow:\n\n| Hi-C workflow output | Use here as input |\n|---|---|\n| `Decontaminated Hap1 with Suffix` | `Haplotype 1` |\n| `Decontaminated Hap2 with Suffix` | `Haplotype 2` |\n| `P telomeres bed` | `Telomere P` |\n| `Q telomeres Bed` | `Telomere Q` |\n| `Gaps Bed` | `Gaps` |\n| `BigWig Coverage` | `Coverage` |\n| `Compleasm Genes track` | `Genes` |\n\n### Related species selection\n\nChoose related species whose genomes are evolutionarily close to the assembly under curation, so synteny is informative for spotting misassemblies. Provide them as gzipped FASTA files in a simple list collection.\n\n**Sequence names must be unique across the collection.** The workflow validates this and fails fast if duplicates are detected (e.g. two species both contain `>scaffold_1`). Prefix per-species scaffold names before uploading, for example:\n\n```bash\nzcat Species_1.fasta.gz | sed 's/^>/>Species_1_/' | gzip > Species_1_renamed.fasta.gz\n```\n\n### Scaffold name suffixes\n\nIf using two haplotypes, the recommended workflow is to apply per-haplotype suffixes (e.g. `H1`/`H2`) to scaffold names *before* running this workflow, so that scaffolds from each haplotype are unambiguously identified in the JBrowse view and in synteny tracks.\n\n## Citation\n\nIf you use this workflow, please cite:\n- JBrowse2 ([Diesh et al., 2023](https://doi.org/10.1186/s13059-023-02914-z))\n- minimap2 (used for related-species alignment)\n- Other tools as listed in the workflow\n",
+                "report": {
+                    "markdown": "# Precuration  workflow on:\n\n```galaxy\nhistory_dataset_embedded(output=\"Assembly Info\")\n```\n\n## Duplication Stats\n\nSamtools markdup deduplication stats (if applicable)\n\n\n```galaxy\nhistory_dataset_as_table(output=\"Hi-C duplication stats\")\n```\n\n\n\nPairtools stats\n```galaxy\nhistory_dataset_as_table(output=\"Hi-C duplication stats: MultiQC\")\n```\n\n## Telomere report\n\n```galaxy\nhistory_dataset_embedded(output=\"Telomere Report\")\n```\n\n## Pretext Snapshots\n\nWith Multimapping\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Pretext Snapshot With tracks - Multimapping\")\n```\n\n\nWith MAPQ filtering\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Pretext Snapshot With tracks\")\n```\n\n\n"
+                },
+                "steps": {
+                    "0": {
+                        "annotation": "Note: Duplicated sequence names between the species in the collection will cause inaccurate alignment visualization in JBrowse2.  ",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 0,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "Note: Duplicated sequence names between the species in the collection will cause inaccurate alignment visualization in JBrowse2.  ",
+                                "name": "Related Species"
+                            }
+                        ],
+                        "label": "Related Species",
+                        "name": "Input dataset collection",
+                        "outputs": [],
+                        "position": {
+                            "left": 0.0,
+                            "top": 587.3142014429646
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": true, \"format\": [\"fasta.gz\"], \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
+                        "tool_version": null,
+                        "type": "data_collection_input",
+                        "uuid": "b1d57707-483c-43cd-8256-0a2888af1246",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "1": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+                        "errors": null,
+                        "id": 1,
+                        "input_connections": {
+                            "style_cond|type_cond|pick_from_0|value": {
+                                "id": 0,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Pick parameter value",
+                        "outputs": [
+                            {
+                                "name": "data_param",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 453.18167963754297,
+                            "top": 842.9610379933346
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActiondata_param": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "data_param"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "b19e21af9c52",
+                            "name": "pick_value",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"style_cond\": {\"pick_style\": \"first_or_error\", \"__current_case__\": 2, \"type_cond\": {\"param_type\": \"data\", \"__current_case__\": 4, \"pick_from\": [{\"__index__\": 0, \"value\": {\"__class__\": \"RuntimeValue\"}}]}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "0.2.0",
+                        "type": "tool",
+                        "uuid": "c6317bbd-c7fd-424d-b2d5-5d9b0bae61df",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "2": {
+                        "annotation": "",
+                        "content_id": "CONVERTER_gz_to_uncompressed",
+                        "errors": null,
+                        "id": 2,
+                        "input_connections": {
+                            "input1": {
+                                "id": 1,
+                                "output_name": "data_param"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Convert gz compressed file to uncompressed.",
+                        "outputs": [
+                            {
+                                "name": "output1",
+                                "type": "auto"
+                            }
+                        ],
+                        "position": {
+                            "left": 832.2978216471757,
+                            "top": 657.4627007832238
+                        },
+                        "post_job_actions": {
+                            "ChangeDatatypeActionoutput1": {
+                                "action_arguments": {
+                                    "newtype": "fasta"
+                                },
+                                "action_type": "ChangeDatatypeAction",
+                                "output_name": "output1"
+                            },
+                            "HideDatasetActionoutput1": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output1"
+                            }
+                        },
+                        "tool_id": "CONVERTER_gz_to_uncompressed",
+                        "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "1.0.0",
+                        "type": "tool",
+                        "uuid": "6f868700-ff9c-4415-98d7-81befe9dde9e",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "3": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.5+galaxy3",
+                        "errors": null,
+                        "id": 3,
+                        "input_connections": {
+                            "infile": {
+                                "id": 2,
+                                "output_name": "output1"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Search in textfiles",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 1281.6271430795382,
+                            "top": 516.9501479775356
+                        },
+                        "post_job_actions": {
+                            "ChangeDatatypeActionoutput": {
+                                "action_arguments": {
+                                    "newtype": "tabular"
+                                },
+                                "action_type": "ChangeDatatypeAction",
+                                "output_name": "output"
+                            },
+                            "HideDatasetActionoutput": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_grep_tool/9.5+galaxy3",
+                        "tool_shed_repository": {
+                            "changeset_revision": "ab83aa685821",
+                            "name": "text_processing",
+                            "owner": "bgruening",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"case_sensitive\": \"-i\", \"color\": \"NOCOLOR\", \"infile\": {\"__class__\": \"ConnectedValue\"}, \"invert\": \"\", \"lines_after\": \"0\", \"lines_before\": \"0\", \"regex_type\": \"-P\", \"url_paste\": \">\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "9.5+galaxy3",
+                        "type": "tool",
+                        "uuid": "24671126-d835-4ecf-94c6-f22fa01d6abd",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "4": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+                        "errors": null,
+                        "id": 4,
+                        "input_connections": {
+                            "input_list": {
+                                "id": 3,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Collapse Collection",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 1587.396456528243,
+                            "top": 293.47025968475924
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionoutput": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "90981f86000f",
+                            "name": "collapse_collections",
+                            "owner": "nml",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"filename\": {\"add_name\": false, \"__current_case__\": 1}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "5.1.0",
+                        "type": "tool",
+                        "uuid": "6e2e1a5d-5849-4852-898d-6646c379ee0d",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "5": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/9.5+galaxy3",
+                        "errors": null,
+                        "id": 5,
+                        "input_connections": {
+                            "infile": {
+                                "id": 4,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Unique",
+                        "outputs": [
+                            {
+                                "name": "outfile",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 1941.4028403619313,
+                            "top": 0
+                        },
+                        "post_job_actions": {
+                            "ChangeDatatypeActionoutfile": {
+                                "action_arguments": {
+                                    "newtype": "tabular"
+                                },
+                                "action_type": "ChangeDatatypeAction",
+                                "output_name": "outfile"
+                            },
+                            "HideDatasetActionoutfile": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "outfile"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/9.5+galaxy3",
+                        "tool_shed_repository": {
+                            "changeset_revision": "ab83aa685821",
+                            "name": "text_processing",
+                            "owner": "bgruening",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"adv_opts\": {\"adv_opts_selector\": \"basic\", \"__current_case__\": 0}, \"header\": \"0\", \"ignore_case\": false, \"infile\": {\"__class__\": \"ConnectedValue\"}, \"is_numeric\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "9.5+galaxy3",
+                        "type": "tool",
+                        "uuid": "4e7c4704-4734-49f8-b51e-53c500853bbc",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "6": {
+                        "annotation": "",
+                        "content_id": "wc_gnu",
+                        "errors": null,
+                        "id": 6,
+                        "input_connections": {
+                            "input1": {
+                                "id": 4,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Line/Word/Character count",
+                        "outputs": [
+                            {
+                                "name": "out_file1",
+                                "type": "tabular"
+                            }
+                        ],
+                        "position": {
+                            "left": 1900.3906014415902,
+                            "top": 510.6734558790175
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionout_file1": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "out_file1"
+                            }
+                        },
+                        "tool_id": "wc_gnu",
+                        "tool_state": "{\"include_header\": false, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"options\": [\"lines\"], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "1.0.0",
+                        "type": "tool",
+                        "uuid": "71d76ee3-7dac-450a-98e9-bb57111df8c5",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "7": {
+                        "annotation": "",
+                        "content_id": "wc_gnu",
+                        "errors": null,
+                        "id": 7,
+                        "input_connections": {
+                            "input1": {
+                                "id": 5,
+                                "output_name": "outfile"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Line/Word/Character count",
+                        "outputs": [
+                            {
+                                "name": "out_file1",
+                                "type": "tabular"
+                            }
+                        ],
+                        "position": {
+                            "left": 2153.997360223585,
+                            "top": 268.5825615907663
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionout_file1": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "out_file1"
+                            }
+                        },
+                        "tool_id": "wc_gnu",
+                        "tool_state": "{\"include_header\": false, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"options\": [\"lines\"], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "1.0.0",
+                        "type": "tool",
+                        "uuid": "2da84228-d818-493b-bafd-a95959ee2de3",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "8": {
+                        "annotation": "",
+                        "content_id": "param_value_from_file",
+                        "errors": null,
+                        "id": 8,
+                        "input_connections": {
+                            "input1": {
+                                "id": 6,
+                                "output_name": "out_file1"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Parse parameter value",
+                        "outputs": [
+                            {
+                                "name": "integer_param",
+                                "type": "expression.json"
+                            }
+                        ],
+                        "position": {
+                            "left": 2324.5531699243356,
+                            "top": 502.9407403932288
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActioninteger_param": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "integer_param"
+                            }
+                        },
+                        "tool_id": "param_value_from_file",
+                        "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"integer\", \"remove_newlines\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "0.1.0",
+                        "type": "tool",
+                        "uuid": "c03bb38c-3383-4d3f-843f-9f74c70b1c47",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "9": {
+                        "annotation": "",
+                        "content_id": "param_value_from_file",
+                        "errors": null,
+                        "id": 9,
+                        "input_connections": {
+                            "input1": {
+                                "id": 7,
+                                "output_name": "out_file1"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Parse parameter value",
+                        "outputs": [
+                            {
+                                "name": "integer_param",
+                                "type": "expression.json"
+                            }
+                        ],
+                        "position": {
+                            "left": 2437.4978065099026,
+                            "top": 103.77316093552422
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActioninteger_param": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "integer_param"
+                            }
+                        },
+                        "tool_id": "param_value_from_file",
+                        "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"integer\", \"remove_newlines\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "0.1.0",
+                        "type": "tool",
+                        "uuid": "5ad8559e-e863-45e9-bae2-ede8be8314c7",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "10": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/calculate_numeric_param/calculate_numeric_param/0.1.0",
+                        "errors": null,
+                        "id": 10,
+                        "input_connections": {
+                            "components_0|param_type|component_value": {
+                                "id": 8,
+                                "output_name": "integer_param"
+                            },
+                            "components_1|param_type|component_value": {
+                                "id": 9,
+                                "output_name": "integer_param"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Calculate numeric parameter value",
+                        "outputs": [
+                            {
+                                "name": "integer_param",
+                                "type": "expression.json"
+                            }
+                        ],
+                        "position": {
+                            "left": 2820.8058443780224,
+                            "top": 307.71874378596993
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActioninteger_param": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "integer_param"
+                            },
+                            "RenameDatasetActioninteger_param": {
+                                "action_arguments": {
+                                    "newname": "Number of Sequences with the same name"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "integer_param"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/calculate_numeric_param/calculate_numeric_param/0.1.0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "0e586762f97b",
+                            "name": "calculate_numeric_param",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 0, \"component_value\": {\"__class__\": \"ConnectedValue\"}}, \"arith\": \"-\"}, {\"__index__\": 1, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 0, \"component_value\": {\"__class__\": \"ConnectedValue\"}}, \"arith\": \"\"}], \"output_type\": \"integer\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "0.1.0",
+                        "type": "tool",
+                        "uuid": "bdc1a0bf-1614-47f8-90f8-89cc139edf9a",
+                        "when": null,
+                        "workflow_outputs": [
+                            {
+                                "label": "Number of Sequences with the same name",
+                                "output_name": "integer_param",
+                                "uuid": "7af4de2a-83be-44a2-a8de-b42d3501e405"
+                            }
+                        ]
+                    }
+                },
+                "tags": [],
+                "uuid": "02f7eddc-de0e-44ad-ade0-e505a0a98848"
+            },
+            "tool_id": null,
+            "type": "subworkflow",
+            "uuid": "171d269a-7197-40af-aa00-794b97d7e8c1",
+            "when": "$(inputs.when)",
+            "workflow_outputs": []
+        },
+        "17": {
+            "annotation": "",
+            "id": 17,
+            "input_connections": {
+                "Coverage": {
+                    "id": 8,
+                    "input_subworkflow_step_id": 5,
+                    "output_name": "output"
+                },
+                "Gaps": {
+                    "id": 7,
+                    "input_subworkflow_step_id": 4,
+                    "output_name": "output"
+                },
+                "Genes": {
+                    "id": 4,
+                    "input_subworkflow_step_id": 6,
+                    "output_name": "output"
+                },
+                "Hap1 fasta": {
+                    "id": 2,
+                    "input_subworkflow_step_id": 0,
+                    "output_name": "output"
+                },
+                "Related Species": {
+                    "id": 9,
+                    "input_subworkflow_step_id": 1,
+                    "output_name": "output"
+                },
+                "Telomeres P": {
+                    "id": 6,
+                    "input_subworkflow_step_id": 3,
+                    "output_name": "output"
+                },
+                "Telomeres Q": {
+                    "id": 5,
+                    "input_subworkflow_step_id": 2,
+                    "output_name": "output"
+                },
+                "when": {
+                    "id": 14,
                     "output_name": "output_param_boolean"
                 }
             },
@@ -709,8 +3447,8 @@
             "name": "Jbrowse for pre-curation single haplotype - 1 related Species ",
             "outputs": [],
             "position": {
-                "left": 2934.6624331027892,
-                "top": 744.4198856816727
+                "left": 2829.2929257523115,
+                "top": 965.6608835393258
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -765,11 +3503,11 @@
                         "name": "Input dataset collection",
                         "outputs": [],
                         "position": {
-                            "left": 77.86825459522053,
-                            "top": 794.9152357793989
+                            "left": 78.89568385575014,
+                            "top": 794.3749846026999
                         },
                         "tool_id": null,
-                        "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
+                        "tool_state": "{\"optional\": true, \"format\": [\"fasta.gz\"], \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
                         "tool_version": null,
                         "type": "data_collection_input",
                         "uuid": "771229b7-cdcc-462a-a1e5-314204a3fca1",
@@ -904,7 +3642,7 @@
                             "top": 1345.5356433169977
                         },
                         "tool_id": null,
-                        "tool_state": "{\"optional\": false, \"tag\": \"\"}",
+                        "tool_state": "{\"optional\": true, \"tag\": \"\"}",
                         "tool_version": null,
                         "type": "data_input",
                         "uuid": "3831fc6f-0526-46ab-869b-5a07c6cded67",
@@ -913,36 +3651,403 @@
                     },
                     "7": {
                         "annotation": "",
-                        "content_id": null,
-                        "errors": null,
                         "id": 7,
-                        "input_connections": {},
-                        "inputs": [
-                            {
-                                "description": "",
-                                "name": "Genes?"
+                        "input_connections": {
+                            "Related Species": {
+                                "id": 1,
+                                "input_subworkflow_step_id": 0,
+                                "output_name": "output"
                             }
-                        ],
-                        "label": "Genes?",
-                        "name": "Input parameter",
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Map Collection to boolean",
                         "outputs": [],
                         "position": {
-                            "left": 535.8872921148474,
-                            "top": 1451.6354804278585
+                            "left": 1126.266841620324,
+                            "top": 708.6678487625938
+                        },
+                        "subworkflow": {
+                            "a_galaxy_workflow": "true",
+                            "annotation": "",
+                            "comments": [],
+                            "creator": [
+                                {
+                                    "class": "Person",
+                                    "identifier": "https://orcid.org/0000-0001-6228-2785",
+                                    "name": "Patrik Smeds"
+                                },
+                                {
+                                    "class": "Person",
+                                    "identifier": "https://orcid.org/0000-0001-6421-3484",
+                                    "name": "Delphine Lariviere"
+                                }
+                            ],
+                            "format-version": "0.1",
+                            "license": "MIT",
+                            "name": "Map Collection to boolean",
+                            "readme": "# JBrowse2 Precuration Tracks with Related Species Alignments\n\nThis workflow generates JBrowse2 instances with genome assembly tracks and alignments against related species, to assist the manual curation of genome assemblies. It complements the Hi-C contact map workflow by providing a complementary genome browser view of the same precuration tracks alongside synteny with related species.\n\nThe workflow takes the assembly haplotype(s) and the precuration tracks (telomeres, gaps, coverage, optional gene annotations), aligns the assembly against a list of related species, and packages everything into a JBrowse2 instance that curators can open directly in their browser.\n\n## Inputs\n\n### Required Inputs\n\n1. **Species Name** [text] - Species identifier used in the assembly info report\n2. **Assembly Name** [text] - Assembly identifier (e.g., toLID)\n3. **Haplotype 1** [fasta] - Primary haplotype assembly (recommended: with H1 suffix added to scaffold names)\n4. **Will you use a second haplotype?** [boolean] - Set to true for diploid assemblies\n5. **Haplotype 2** [fasta, optional] - Secondary haplotype assembly (required if using two haplotypes)\n6. **Related Species** [collection of fasta.gz] - Simple list of gzipped FASTA files of related species genomes for synteny alignment. **Sequence names must be unique across the entire collection** - the workflow performs a duplicate-name check on the merged related-species fastas and will fail early if any sequence name appears in more than one file. A common pattern is to prefix each species' scaffolds with the species name (e.g. `Species_1_scaffold_1`).\n7. **Telomere P** [BED] - P-arm telomere coordinates\n8. **Telomere Q** [BED] - Q-arm telomere coordinates (can be empty)\n9. **Gaps** [BED] - Assembly gap coordinates\n10. **Coverage** [BigWig] - PacBio HiFi read coverage track\n\n### Gene Annotation Options\n\n11. **Do you want to provide gene annotation for your assembly?** [boolean] - Enable to include a gene annotation track in the JBrowse2 instance\n12. **Genes** [GFF, optional] - Gene annotation track (required if gene annotations enabled)\n\n## Outputs\n\n1. **Assembly Info** - Summary of species and assembly name\n2. **JBrowse2 Single Haplotype with related species** [collection] - JBrowse2 instance for a single haplotype with related species alignments (when only one haplotype is used)\n3. **JBrowse2 Single Haplotype with related species and Gene Tracks** [collection] - As above, with gene annotation tracks included\n4. **JBrowse2 Hap1 and hap2 with related species** [collection] - JBrowse2 instance for two haplotypes with related species alignments (when two haplotypes are used)\n5. **JBrowse2 Hap1 and hap2 with related species and gene tracks** [collection] - As above, with gene annotation tracks included\n\n### Additional outputs\n\nThese JBrowse2 instances are produced without the related-species alignment tracks and can be useful for curators who only need the assembly-internal view.\n\n6. **JBrowse2 Single Haplotype** [collection] - JBrowse2 instance for a single haplotype with assembly tracks only (telomeres, gaps, coverage), no related-species alignments\n7. **JBrowse2 Single Haplotype with Gene Track** [collection] - As above, with gene annotation tracks included\n8. **JBrowse2 Hap1 vs Hap2** [collection] - JBrowse2 instance for two haplotypes with the hap1-vs-hap2 alignment, no related-species alignments\n9. **JBrowse2 Hap1 vs Hap2 with gene tracks** [collection] - As above, with gene annotation tracks included\n\n### Validation output\n\n10. **Fail if there are duplicated sequence names between the fasta files** [boolean] - Internal validation flag. The workflow fails fast if any sequence name appears in more than one of the related-species fastas.\n\n## Usage Notes\n\n### Pairing with the Hi-C contact map workflow\n\nThis workflow is designed to consume the precuration track outputs of the [Hi-C contact map for assembly manual curation](../hi-c-contact-map-for-assembly-manual-curation) workflow:\n\n| Hi-C workflow output | Use here as input |\n|---|---|\n| `Decontaminated Hap1 with Suffix` | `Haplotype 1` |\n| `Decontaminated Hap2 with Suffix` | `Haplotype 2` |\n| `P telomeres bed` | `Telomere P` |\n| `Q telomeres Bed` | `Telomere Q` |\n| `Gaps Bed` | `Gaps` |\n| `BigWig Coverage` | `Coverage` |\n| `Compleasm Genes track` | `Genes` |\n\n### Related species selection\n\nChoose related species whose genomes are evolutionarily close to the assembly under curation, so synteny is informative for spotting misassemblies. Provide them as gzipped FASTA files in a simple list collection.\n\n**Sequence names must be unique across the collection.** The workflow validates this and fails fast if duplicates are detected (e.g. two species both contain `>scaffold_1`). Prefix per-species scaffold names before uploading, for example:\n\n```bash\nzcat Species_1.fasta.gz | sed 's/^>/>Species_1_/' | gzip > Species_1_renamed.fasta.gz\n```\n\n### Scaffold name suffixes\n\nIf using two haplotypes, the recommended workflow is to apply per-haplotype suffixes (e.g. `H1`/`H2`) to scaffold names *before* running this workflow, so that scaffolds from each haplotype are unambiguously identified in the JBrowse view and in synteny tracks.\n\n## Citation\n\nIf you use this workflow, please cite:\n- JBrowse2 ([Diesh et al., 2023](https://doi.org/10.1186/s13059-023-02914-z))\n- minimap2 (used for related-species alignment)\n- Other tools as listed in the workflow\n",
+                            "report": {
+                                "markdown": "# Precuration  workflow on:\n\n```galaxy\nhistory_dataset_embedded(output=\"Assembly Info\")\n```\n\n## Duplication Stats\n\nSamtools markdup deduplication stats (if applicable)\n\n\n```galaxy\nhistory_dataset_as_table(output=\"Hi-C duplication stats\")\n```\n\n\n\nPairtools stats\n```galaxy\nhistory_dataset_as_table(output=\"Hi-C duplication stats: MultiQC\")\n```\n\n## Telomere report\n\n```galaxy\nhistory_dataset_embedded(output=\"Telomere Report\")\n```\n\n## Pretext Snapshots\n\nWith Multimapping\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Pretext Snapshot With tracks - Multimapping\")\n```\n\n\nWith MAPQ filtering\n\n\n```galaxy\nhistory_dataset_as_image(output=\"Pretext Snapshot With tracks\")\n```\n\n\n"
+                            },
+                            "steps": {
+                                "0": {
+                                    "annotation": "Note: Duplicated sequence names between the species in the collection will cause inaccurate alignment visualization in JBrowse2.  ",
+                                    "content_id": null,
+                                    "errors": null,
+                                    "id": 0,
+                                    "input_connections": {},
+                                    "inputs": [
+                                        {
+                                            "description": "Note: Duplicated sequence names between the species in the collection will cause inaccurate alignment visualization in JBrowse2.  ",
+                                            "name": "Related Species"
+                                        }
+                                    ],
+                                    "label": "Related Species",
+                                    "name": "Input dataset collection",
+                                    "outputs": [],
+                                    "position": {
+                                        "left": 0,
+                                        "top": 0
+                                    },
+                                    "tool_id": null,
+                                    "tool_state": "{\"optional\": true, \"format\": [\"fasta.gz\"], \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
+                                    "tool_version": null,
+                                    "type": "data_collection_input",
+                                    "uuid": "b1d57707-483c-43cd-8256-0a2888af1246",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "1": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "errors": null,
+                                    "id": 1,
+                                    "input_connections": {
+                                        "input_param_type|input_param": {
+                                            "id": 0,
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": "Two Haplotypes 2",
+                                    "name": "Map parameter value",
+                                    "outputs": [
+                                        {
+                                            "name": "output_param_boolean",
+                                            "type": "expression.json"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 507.52614703835707,
+                                        "top": 68.65082494054082
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActionoutput_param_boolean": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "output_param_boolean"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "5ac8a4bf7a8d",
+                                        "name": "map_param_value",
+                                        "owner": "iuc",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"input_param_type\": {\"type\": \"data\", \"__current_case__\": 4, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": []}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "0.2.0",
+                                    "type": "tool",
+                                    "uuid": "30ef2c07-c458-4a90-94b7-5e5ae4885844",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "2": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "errors": null,
+                                    "id": 2,
+                                    "input_connections": {
+                                        "input_param_type|input_param": {
+                                            "id": 1,
+                                            "output_name": "output_param_boolean"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": "Two Haplotypes 3",
+                                    "name": "Map parameter value",
+                                    "outputs": [
+                                        {
+                                            "name": "output_param_text",
+                                            "type": "expression.json"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 801.9711946226973,
+                                        "top": 268.066568476228
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActionoutput_param_boolean": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "output_param_boolean"
+                                        },
+                                        "HideDatasetActionoutput_param_text": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "output_param_text"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "5ac8a4bf7a8d",
+                                        "name": "map_param_value",
+                                        "owner": "iuc",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": []}, \"output_param_type\": \"text\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "0.2.0",
+                                    "type": "tool",
+                                    "uuid": "5be371df-1c67-42ae-a535-da4ca4bf1e51",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "3": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_text_file_with_recurring_lines/9.5+galaxy3",
+                                    "errors": null,
+                                    "id": 3,
+                                    "input_connections": {
+                                        "token_set_0|line": {
+                                            "id": 2,
+                                            "output_name": "output_param_text"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Create text file",
+                                    "outputs": [
+                                        {
+                                            "name": "outfile",
+                                            "type": "txt"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 1031.2529071684971,
+                                        "top": 141.25993418553026
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActionoutfile": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "outfile"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_text_file_with_recurring_lines/9.5+galaxy3",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "ab83aa685821",
+                                        "name": "text_processing",
+                                        "owner": "bgruening",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"token_set\": [{\"__index__\": 0, \"line\": {\"__class__\": \"ConnectedValue\"}, \"repeat_select\": {\"repeat_select_opts\": \"user\", \"__current_case__\": 0, \"times\": \"1\"}}], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "9.5+galaxy3",
+                                    "type": "tool",
+                                    "uuid": "f2c6b8fd-f348-494d-867e-28d82492a589",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "4": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy3",
+                                    "errors": null,
+                                    "id": 4,
+                                    "input_connections": {
+                                        "inputs": {
+                                            "id": 3,
+                                            "output_name": "outfile"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Concatenate datasets",
+                                    "outputs": [
+                                        {
+                                            "name": "out_file1",
+                                            "type": "input"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 1404.1850282401706,
+                                        "top": 159.59233303291586
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActionout_file1": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "out_file1"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy3",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "ab83aa685821",
+                                        "name": "text_processing",
+                                        "owner": "bgruening",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"inputs\": {\"__class__\": \"ConnectedValue\"}, \"queries\": [], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "9.5+galaxy3",
+                                    "type": "tool",
+                                    "uuid": "951df8ae-cb04-448c-9b26-1b1c72e52354",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "5": {
+                                    "annotation": "",
+                                    "content_id": "Show beginning1",
+                                    "errors": null,
+                                    "id": 5,
+                                    "input_connections": {
+                                        "input": {
+                                            "id": 4,
+                                            "output_name": "out_file1"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Select first",
+                                    "outputs": [
+                                        {
+                                            "name": "out_file1",
+                                            "type": "input"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 1591.5813587970113,
+                                        "top": 415.32944461901855
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActionout_file1": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "out_file1"
+                                        }
+                                    },
+                                    "tool_id": "Show beginning1",
+                                    "tool_state": "{\"header\": false, \"input\": {\"__class__\": \"ConnectedValue\"}, \"lineNum\": \"1\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "1.0.2",
+                                    "type": "tool",
+                                    "uuid": "6777b035-d40f-471e-b677-c886520c5f08",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "6": {
+                                    "annotation": "",
+                                    "content_id": "param_value_from_file",
+                                    "errors": null,
+                                    "id": 6,
+                                    "input_connections": {
+                                        "input1": {
+                                            "id": 5,
+                                            "output_name": "out_file1"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Parse parameter value",
+                                    "outputs": [
+                                        {
+                                            "name": "boolean_param",
+                                            "type": "expression.json"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 1900.9513665053723,
+                                        "top": 426.5056982072265
+                                    },
+                                    "post_job_actions": {},
+                                    "tool_id": "param_value_from_file",
+                                    "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"boolean\", \"remove_newlines\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "0.1.0",
+                                    "type": "tool",
+                                    "uuid": "39916b95-3287-497f-83ea-822bb970a388",
+                                    "when": null,
+                                    "workflow_outputs": [
+                                        {
+                                            "label": "boolean_param",
+                                            "output_name": "boolean_param",
+                                            "uuid": "651aac03-f463-4bb0-bae9-c1e6d0d808d8"
+                                        }
+                                    ]
+                                }
+                            },
+                            "tags": [],
+                            "uuid": "877369eb-5f6e-4a0f-9519-c6f3bb328653"
                         },
                         "tool_id": null,
-                        "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
-                        "tool_version": null,
-                        "type": "parameter_input",
-                        "uuid": "bc1b0c8a-64af-4cac-a825-6eb7a70cbbeb",
+                        "type": "subworkflow",
+                        "uuid": "e94777b6-3b4b-495c-8225-154261540382",
                         "when": null,
                         "workflow_outputs": []
                     },
                     "8": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
                         "errors": null,
                         "id": 8,
+                        "input_connections": {
+                            "input_param_type|input_param": {
+                                "id": 6,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Map parameter value",
+                        "outputs": [
+                            {
+                                "name": "output_param_boolean",
+                                "type": "expression.json"
+                            }
+                        ],
+                        "position": {
+                            "left": 859.5308837376912,
+                            "top": 354.3262966418495
+                        },
+                        "post_job_actions": {
+                            "HideDatasetActionoutput_param_boolean": {
+                                "action_arguments": {},
+                                "action_type": "HideDatasetAction",
+                                "output_name": "output_param_boolean"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "5ac8a4bf7a8d",
+                            "name": "map_param_value",
+                            "owner": "iuc",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"input_param_type\": {\"type\": \"data\", \"__current_case__\": 4, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": []}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "0.2.0",
+                        "type": "tool",
+                        "uuid": "881a5654-873e-43f9-8731-3023ec1bea9b",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "9": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
+                        "errors": null,
+                        "id": 9,
                         "input_connections": {
                             "query": {
                                 "id": 0,
@@ -951,6 +4056,10 @@
                             "reflist": {
                                 "id": 1,
                                 "output_name": "output"
+                            },
+                            "when": {
+                                "id": 7,
+                                "output_name": "boolean_param"
                             }
                         },
                         "inputs": [],
@@ -963,8 +4072,8 @@
                             }
                         ],
                         "position": {
-                            "left": 1026.595772250997,
-                            "top": 858.7635819182626
+                            "left": 1748.7451070250318,
+                            "top": 1065.6902746606195
                         },
                         "post_job_actions": {
                             "HideDatasetActionmashout": {
@@ -992,18 +4101,18 @@
                         "tool_version": "3.1.3+galaxy0",
                         "type": "tool",
                         "uuid": "b1a857dd-1140-4641-943b-cb141b6a6f81",
-                        "when": null,
+                        "when": "$(inputs.when)",
                         "workflow_outputs": []
                     },
-                    "9": {
+                    "10": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
                         "errors": null,
-                        "id": 9,
+                        "id": 10,
                         "input_connections": {
                             "input_param_type|input_param": {
-                                "id": 7,
-                                "output_name": "output"
+                                "id": 8,
+                                "output_name": "output_param_boolean"
                             }
                         },
                         "inputs": [],
@@ -1016,8 +4125,8 @@
                             }
                         ],
                         "position": {
-                            "left": 909.3164880438957,
-                            "top": 1632.3549251437048
+                            "left": 1152.7909069113884,
+                            "top": 306.13159851542645
                         },
                         "post_job_actions": {
                             "HideDatasetActionoutput_param_boolean": {
@@ -1041,11 +4150,11 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "10": {
+                    "11": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
                         "errors": null,
-                        "id": 10,
+                        "id": 11,
                         "input_connections": {
                             "assemblies_0|reference_genome|genome": {
                                 "id": 0,
@@ -1072,8 +4181,8 @@
                                 "output_name": "output"
                             },
                             "when": {
-                                "id": 7,
-                                "output_name": "output"
+                                "id": 8,
+                                "output_name": "output_param_boolean"
                             }
                         },
                         "inputs": [],
@@ -1086,8 +4195,8 @@
                             }
                         ],
                         "position": {
-                            "left": 1896.9114798587966,
-                            "top": 990.3320527378663
+                            "left": 2283.70977067512,
+                            "top": 41.012471287696755
                         },
                         "post_job_actions": {
                             "RenameDatasetActionoutput": {
@@ -1105,7 +4214,7 @@
                             "owner": "fubar",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
-                        "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"RuntimeValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Telomeres\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_off\"}}]}, {\"__index__\": 1, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"Annotations\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Telomeres\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_off\"}}]}, {\"__index__\": 1, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"Annotations\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
                         "tool_uuid": null,
                         "tool_version": "3.7.0+galaxy0",
                         "type": "tool",
@@ -1119,9 +4228,9 @@
                             }
                         ]
                     },
-                    "11": {
+                    "12": {
                         "annotation": "",
-                        "id": 11,
+                        "id": 12,
                         "input_connections": {
                             "Coverage": {
                                 "id": 5,
@@ -1138,18 +4247,13 @@
                                 "input_subworkflow_step_id": 7,
                                 "output_name": "output"
                             },
-                            "Genes?": {
-                                "id": 7,
-                                "input_subworkflow_step_id": 8,
-                                "output_name": "output"
-                            },
                             "Hap1 fasta": {
                                 "id": 0,
                                 "input_subworkflow_step_id": 0,
                                 "output_name": "output"
                             },
                             "Hap1 vs Species": {
-                                "id": 8,
+                                "id": 9,
                                 "input_subworkflow_step_id": 2,
                                 "output_name": "mashout"
                             },
@@ -1167,6 +4271,10 @@
                                 "id": 2,
                                 "input_subworkflow_step_id": 3,
                                 "output_name": "output"
+                            },
+                            "when": {
+                                "id": 7,
+                                "output_name": "boolean_param"
                             }
                         },
                         "inputs": [],
@@ -1174,8 +4282,8 @@
                         "name": "Jbrowse2 for 1 related species - single haplotype",
                         "outputs": [],
                         "position": {
-                            "left": 1504.531864079652,
-                            "top": 1218.259001224898
+                            "left": 2229.6998454459986,
+                            "top": 1230.1735808481742
                         },
                         "subworkflow": {
                             "a_galaxy_workflow": "true",
@@ -1234,7 +4342,7 @@
                                         "top": 339.63559170456904
                                     },
                                     "tool_id": null,
-                                    "tool_state": "{\"optional\": false, \"tag\": null}",
+                                    "tool_state": "{\"optional\": true, \"tag\": null}",
                                     "tool_version": null,
                                     "type": "data_input",
                                     "uuid": "385825a9-198e-425f-9fb3-55af892d20dc",
@@ -1261,7 +4369,7 @@
                                         "top": 479.1639618101156
                                     },
                                     "tool_id": null,
-                                    "tool_state": "{\"optional\": false, \"format\": [\"paf\"], \"tag\": null}",
+                                    "tool_state": "{\"optional\": true, \"format\": [\"paf\"], \"tag\": null}",
                                     "tool_version": null,
                                     "type": "data_input",
                                     "uuid": "c18b3a25-89e8-4853-81fe-affb519a9ae0",
@@ -1392,11 +4500,11 @@
                                     "name": "Input dataset",
                                     "outputs": [],
                                     "position": {
-                                        "left": 564.2214660523151,
-                                        "top": 1297.0956580243692
+                                        "left": 541.5464695972953,
+                                        "top": 1218.2490175701384
                                     },
                                     "tool_id": null,
-                                    "tool_state": "{\"optional\": false, \"tag\": null}",
+                                    "tool_state": "{\"optional\": true, \"tag\": null}",
                                     "tool_version": null,
                                     "type": "data_input",
                                     "uuid": "f6db855c-e1de-49f7-836c-87a510e955aa",
@@ -1405,39 +4513,104 @@
                                 },
                                 "8": {
                                     "annotation": "",
-                                    "content_id": null,
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
                                     "errors": null,
                                     "id": 8,
-                                    "input_connections": {},
-                                    "inputs": [
+                                    "input_connections": {
+                                        "style_cond|type_cond|pick_from_0|value": {
+                                            "id": 1,
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Pick parameter value",
+                                    "outputs": [
                                         {
-                                            "description": "",
-                                            "name": "Genes?"
+                                            "name": "data_param",
+                                            "type": "input"
                                         }
                                     ],
-                                    "label": "Genes?",
-                                    "name": "Input parameter",
-                                    "outputs": [],
                                     "position": {
-                                        "left": 676.3375507125828,
-                                        "top": 1426.4770174033545
+                                        "left": 514.7385434096283,
+                                        "top": 319.35295187850693
                                     },
-                                    "tool_id": null,
-                                    "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
-                                    "tool_version": null,
-                                    "type": "parameter_input",
-                                    "uuid": "a7391d09-c347-4520-91c2-8b07fd147efa",
+                                    "post_job_actions": {
+                                        "HideDatasetActiondata_param": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "data_param"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "b19e21af9c52",
+                                        "name": "pick_value",
+                                        "owner": "iuc",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"style_cond\": {\"pick_style\": \"first_or_error\", \"__current_case__\": 2, \"type_cond\": {\"param_type\": \"data\", \"__current_case__\": 4, \"pick_from\": [{\"__index__\": 0, \"value\": {\"__class__\": \"ConnectedValue\"}}]}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "0.2.0",
+                                    "type": "tool",
+                                    "uuid": "30d3a9e5-b5b0-4e04-8950-74c3c0c6f772",
                                     "when": null,
                                     "workflow_outputs": []
                                 },
                                 "9": {
                                     "annotation": "",
-                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
                                     "errors": null,
                                     "id": 9,
                                     "input_connections": {
+                                        "style_cond|type_cond|pick_from_0|value": {
+                                            "id": 2,
+                                            "output_name": "output"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Pick parameter value",
+                                    "outputs": [
+                                        {
+                                            "name": "data_param",
+                                            "type": "input"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 791.7095008745389,
+                                        "top": 702.9542201693089
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActiondata_param": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "data_param"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "b19e21af9c52",
+                                        "name": "pick_value",
+                                        "owner": "iuc",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"style_cond\": {\"pick_style\": \"first_or_error\", \"__current_case__\": 2, \"type_cond\": {\"param_type\": \"data\", \"__current_case__\": 4, \"pick_from\": [{\"__index__\": 0, \"value\": {\"__class__\": \"ConnectedValue\"}}]}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "0.2.0",
+                                    "type": "tool",
+                                    "uuid": "e8b2b609-6fb6-4708-806f-9bc519806d6f",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "10": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "errors": null,
+                                    "id": 10,
+                                    "input_connections": {
                                         "input_param_type|input_param": {
-                                            "id": 8,
+                                            "id": 7,
                                             "output_name": "output"
                                         }
                                     },
@@ -1451,8 +4624,8 @@
                                         }
                                     ],
                                     "position": {
-                                        "left": 1443.6518169393487,
-                                        "top": 980.4294207784309
+                                        "left": 1047.1756169820526,
+                                        "top": 1156.3320897874444
                                     },
                                     "post_job_actions": {
                                         "HideDatasetActionoutput_param_boolean": {
@@ -1468,7 +4641,100 @@
                                         "owner": "iuc",
                                         "tool_shed": "toolshed.g2.bx.psu.edu"
                                     },
-                                    "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": false, \"to\": \"True\"}, {\"__index__\": 1, \"from\": true, \"to\": \"False\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_state": "{\"input_param_type\": {\"type\": \"data\", \"__current_case__\": 4, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": []}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "0.2.0",
+                                    "type": "tool",
+                                    "uuid": "480c228f-4d21-48c2-8786-920c43590c72",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "11": {
+                                    "annotation": "",
+                                    "content_id": "CONVERTER_gz_to_uncompressed",
+                                    "errors": null,
+                                    "id": 11,
+                                    "input_connections": {
+                                        "input1": {
+                                            "id": 8,
+                                            "output_name": "data_param"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Convert gz compressed file to uncompressed.",
+                                    "outputs": [
+                                        {
+                                            "name": "output1",
+                                            "type": "auto"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 907.1606030128123,
+                                        "top": 121.02662028802301
+                                    },
+                                    "post_job_actions": {
+                                        "ChangeDatatypeActionoutput1": {
+                                            "action_arguments": {
+                                                "newtype": "fasta"
+                                            },
+                                            "action_type": "ChangeDatatypeAction",
+                                            "output_name": "output1"
+                                        },
+                                        "HideDatasetActionoutput1": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "output1"
+                                        }
+                                    },
+                                    "tool_id": "CONVERTER_gz_to_uncompressed",
+                                    "tool_state": "{\"input1\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                                    "tool_uuid": null,
+                                    "tool_version": "1.0.0",
+                                    "type": "tool",
+                                    "uuid": "17100313-6cd1-4992-89f6-d2136fbd2cc9",
+                                    "when": null,
+                                    "workflow_outputs": []
+                                },
+                                "12": {
+                                    "annotation": "",
+                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "errors": null,
+                                    "id": 12,
+                                    "input_connections": {
+                                        "input_param_type|input_param": {
+                                            "id": 10,
+                                            "output_name": "output_param_boolean"
+                                        }
+                                    },
+                                    "inputs": [],
+                                    "label": null,
+                                    "name": "Map parameter value",
+                                    "outputs": [
+                                        {
+                                            "name": "output_param_boolean",
+                                            "type": "expression.json"
+                                        }
+                                    ],
+                                    "position": {
+                                        "left": 1443.640629349266,
+                                        "top": 980.955490296477
+                                    },
+                                    "post_job_actions": {
+                                        "HideDatasetActionoutput_param_boolean": {
+                                            "action_arguments": {},
+                                            "action_type": "HideDatasetAction",
+                                            "output_name": "output_param_boolean"
+                                        }
+                                    },
+                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
+                                    "tool_shed_repository": {
+                                        "changeset_revision": "5ac8a4bf7a8d",
+                                        "name": "map_param_value",
+                                        "owner": "iuc",
+                                        "tool_shed": "toolshed.g2.bx.psu.edu"
+                                    },
+                                    "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": true, \"to\": \"False\"}, {\"__index__\": 1, \"from\": false, \"to\": \"True\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
                                     "tool_uuid": null,
                                     "tool_version": "0.2.0",
                                     "type": "tool",
@@ -1476,19 +4742,19 @@
                                     "when": null,
                                     "workflow_outputs": []
                                 },
-                                "10": {
+                                "13": {
                                     "annotation": "",
                                     "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
                                     "errors": null,
-                                    "id": 10,
+                                    "id": 13,
                                     "input_connections": {
                                         "assemblies_0|reference_genome|genome": {
                                             "id": 0,
                                             "output_name": "output"
                                         },
                                         "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 2,
-                                            "output_name": "output"
+                                            "id": 9,
+                                            "output_name": "data_param"
                                         },
                                         "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
                                             "id": 3,
@@ -1511,12 +4777,12 @@
                                             "output_name": "output"
                                         },
                                         "assemblies_1|reference_genome|genome": {
-                                            "id": 1,
-                                            "output_name": "output"
+                                            "id": 11,
+                                            "output_name": "output1"
                                         },
                                         "when": {
-                                            "id": 8,
-                                            "output_name": "output"
+                                            "id": 10,
+                                            "output_name": "output_param_boolean"
                                         }
                                     },
                                     "inputs": [],
@@ -1529,8 +4795,8 @@
                                         }
                                     ],
                                     "position": {
-                                        "left": 2561.3898434899743,
-                                        "top": 900.6399388618673
+                                        "left": 2561.3748868997627,
+                                        "top": 901.9506006750755
                                     },
                                     "post_job_actions": {
                                         "RenameDatasetActionoutput": {
@@ -1562,19 +4828,19 @@
                                         }
                                     ]
                                 },
-                                "11": {
+                                "14": {
                                     "annotation": "",
                                     "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
                                     "errors": null,
-                                    "id": 11,
+                                    "id": 14,
                                     "input_connections": {
                                         "assemblies_0|reference_genome|genome": {
                                             "id": 0,
                                             "output_name": "output"
                                         },
                                         "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 2,
-                                            "output_name": "output"
+                                            "id": 9,
+                                            "output_name": "data_param"
                                         },
                                         "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
                                             "id": 3,
@@ -1593,11 +4859,11 @@
                                             "output_name": "output"
                                         },
                                         "assemblies_1|reference_genome|genome": {
-                                            "id": 1,
-                                            "output_name": "output"
+                                            "id": 11,
+                                            "output_name": "output1"
                                         },
                                         "when": {
-                                            "id": 9,
+                                            "id": 12,
                                             "output_name": "output_param_boolean"
                                         }
                                     },
@@ -1646,12 +4912,12 @@
                                 }
                             },
                             "tags": [],
-                            "uuid": "236c7163-dde8-4597-a9b5-a7d55314997e"
+                            "uuid": "3f60b623-c574-44bf-a302-0d6f0dca499f"
                         },
                         "tool_id": null,
                         "type": "subworkflow",
                         "uuid": "6ad9fa44-c0d3-49e8-af09-e1a93e66eb8a",
-                        "when": null,
+                        "when": "$(inputs.when)",
                         "workflow_outputs": [
                             {
                                 "label": "JBrowse2 Single Haplotype with related species and Gene Tracks",
@@ -1665,11 +4931,11 @@
                             }
                         ]
                     },
-                    "12": {
+                    "13": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
                         "errors": null,
-                        "id": 12,
+                        "id": 13,
                         "input_connections": {
                             "assemblies_0|reference_genome|genome": {
                                 "id": 0,
@@ -1692,7 +4958,7 @@
                                 "output_name": "output"
                             },
                             "when": {
-                                "id": 9,
+                                "id": 10,
                                 "output_name": "output_param_boolean"
                             }
                         },
@@ -1707,7 +4973,7 @@
                         ],
                         "position": {
                             "left": 1896.5312607039984,
-                            "top": 0.0
+                            "top": 0
                         },
                         "post_job_actions": {
                             "RenameDatasetActionoutput": {
@@ -1741,7 +5007,7 @@
                     }
                 },
                 "tags": [],
-                "uuid": "aa94bcea-e6b3-4677-9709-176f6f732c75"
+                "uuid": "86fc2aa8-bf64-4e3f-a515-b2bcd0166c65"
             },
             "tool_id": null,
             "type": "subworkflow",
@@ -1749,9 +5015,9 @@
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
-                    "label": "JBrowse2 Single Haplotype",
-                    "output_name": "JBrowse2 Single Haplotype",
-                    "uuid": "6a22e395-9c90-4c39-8649-a02200a5f9d3"
+                    "label": "JBrowse2 Single Haplotype with related species and Gene Tracks",
+                    "output_name": "JBrowse2 Single Haplotype with related species and Gene Tracks",
+                    "uuid": "010b5194-1e89-4f30-9b20-1e3d7eac7aeb"
                 },
                 {
                     "label": "JBrowse2 Single Haplotype with related species",
@@ -1759,9 +5025,9 @@
                     "uuid": "0651be6a-3ad9-4302-a501-702a7d435ea4"
                 },
                 {
-                    "label": "JBrowse2 Single Haplotype with related species and Gene Tracks",
-                    "output_name": "JBrowse2 Single Haplotype with related species and Gene Tracks",
-                    "uuid": "010b5194-1e89-4f30-9b20-1e3d7eac7aeb"
+                    "label": "JBrowse2 Single Haplotype",
+                    "output_name": "JBrowse2 Single Haplotype",
+                    "uuid": "6a22e395-9c90-4c39-8649-a02200a5f9d3"
                 },
                 {
                     "label": "JBrowse2 Single Haplotype with Gene Track",
@@ -1770,1753 +5036,19 @@
                 }
             ]
         },
-        "19": {
-            "annotation": "",
-            "id": 19,
-            "input_connections": {
-                "Coverage": {
-                    "id": 10,
-                    "input_subworkflow_step_id": 6,
-                    "output_name": "output"
-                },
-                "Gaps": {
-                    "id": 9,
-                    "input_subworkflow_step_id": 5,
-                    "output_name": "output"
-                },
-                "Genes": {
-                    "id": 15,
-                    "input_subworkflow_step_id": 8,
-                    "output_name": "data_param"
-                },
-                "Genes?": {
-                    "id": 5,
-                    "input_subworkflow_step_id": 7,
-                    "output_name": "output"
-                },
-                "Hap1 fasta": {
-                    "id": 2,
-                    "input_subworkflow_step_id": 0,
-                    "output_name": "output"
-                },
-                "Hap2 fasta": {
-                    "id": 14,
-                    "input_subworkflow_step_id": 1,
-                    "output_name": "data_param"
-                },
-                "Related Species": {
-                    "id": 16,
-                    "input_subworkflow_step_id": 2,
-                    "output_name": "output1"
-                },
-                "Telomeres P": {
-                    "id": 8,
-                    "input_subworkflow_step_id": 4,
-                    "output_name": "output"
-                },
-                "Telomeres Q": {
-                    "id": 7,
-                    "input_subworkflow_step_id": 3,
-                    "output_name": "output"
-                },
-                "when": {
-                    "id": 3,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Jbrowse for pre-curation",
-            "outputs": [],
-            "position": {
-                "left": 3359.99060088773,
-                "top": 782.0624564807059
-            },
-            "subworkflow": {
-                "a_galaxy_workflow": "true",
-                "annotation": "",
-                "comments": [],
-                "format-version": "0.1",
-                "name": "Jbrowse for pre-curation",
-                "report": {
-                    "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
-                },
-                "steps": {
-                    "0": {
-                        "annotation": "",
-                        "content_id": null,
-                        "errors": null,
-                        "id": 0,
-                        "input_connections": {},
-                        "inputs": [
-                            {
-                                "description": "",
-                                "name": "Hap1 fasta"
-                            }
-                        ],
-                        "label": "Hap1 fasta",
-                        "name": "Input dataset",
-                        "outputs": [],
-                        "position": {
-                            "left": 0,
-                            "top": 85.5397415161874
-                        },
-                        "tool_id": null,
-                        "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
-                        "tool_version": null,
-                        "type": "data_input",
-                        "uuid": "4a20362f-2551-4a60-9118-e4c3e7c4f264",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "1": {
-                        "annotation": "",
-                        "content_id": null,
-                        "errors": null,
-                        "id": 1,
-                        "input_connections": {},
-                        "inputs": [
-                            {
-                                "description": "",
-                                "name": "Hap2 fasta"
-                            }
-                        ],
-                        "label": "Hap2 fasta",
-                        "name": "Input dataset",
-                        "outputs": [],
-                        "position": {
-                            "left": 51.81545453466647,
-                            "top": 205.03846714316876
-                        },
-                        "tool_id": null,
-                        "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
-                        "tool_version": null,
-                        "type": "data_input",
-                        "uuid": "177f6825-e58e-45e9-a3fc-8c7623187e02",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "2": {
-                        "annotation": "",
-                        "content_id": null,
-                        "errors": null,
-                        "id": 2,
-                        "input_connections": {},
-                        "inputs": [
-                            {
-                                "description": "",
-                                "name": "Related Species"
-                            }
-                        ],
-                        "label": "Related Species",
-                        "name": "Input dataset collection",
-                        "outputs": [],
-                        "position": {
-                            "left": 297.860981218189,
-                            "top": 609.7270107228887
-                        },
-                        "tool_id": null,
-                        "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
-                        "tool_version": null,
-                        "type": "data_collection_input",
-                        "uuid": "20f7abfb-20b8-49bb-b522-cd911fd1ec4c",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "3": {
-                        "annotation": "",
-                        "content_id": null,
-                        "errors": null,
-                        "id": 3,
-                        "input_connections": {},
-                        "inputs": [
-                            {
-                                "description": "",
-                                "name": "Telomeres Q"
-                            }
-                        ],
-                        "label": "Telomeres Q",
-                        "name": "Input dataset",
-                        "outputs": [],
-                        "position": {
-                            "left": 347.4491076529599,
-                            "top": 765.9971383218501
-                        },
-                        "tool_id": null,
-                        "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
-                        "tool_version": null,
-                        "type": "data_input",
-                        "uuid": "ce01ac46-a3c2-4013-ba5b-ea8a0e46be64",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "4": {
-                        "annotation": "",
-                        "content_id": null,
-                        "errors": null,
-                        "id": 4,
-                        "input_connections": {},
-                        "inputs": [
-                            {
-                                "description": "",
-                                "name": "Telomeres P"
-                            }
-                        ],
-                        "label": "Telomeres P",
-                        "name": "Input dataset",
-                        "outputs": [],
-                        "position": {
-                            "left": 455.5329585464028,
-                            "top": 870.0948319299273
-                        },
-                        "tool_id": null,
-                        "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
-                        "tool_version": null,
-                        "type": "data_input",
-                        "uuid": "8044ff06-8a3b-4ac1-b6ee-521cc28e585d",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "5": {
-                        "annotation": "",
-                        "content_id": null,
-                        "errors": null,
-                        "id": 5,
-                        "input_connections": {},
-                        "inputs": [
-                            {
-                                "description": "",
-                                "name": "Gaps"
-                            }
-                        ],
-                        "label": "Gaps",
-                        "name": "Input dataset",
-                        "outputs": [],
-                        "position": {
-                            "left": 524.1536909971493,
-                            "top": 963.4615908089734
-                        },
-                        "tool_id": null,
-                        "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
-                        "tool_version": null,
-                        "type": "data_input",
-                        "uuid": "37e56713-8aa6-474e-9a87-6c702d7d6b49",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "6": {
-                        "annotation": "",
-                        "content_id": null,
-                        "errors": null,
-                        "id": 6,
-                        "input_connections": {},
-                        "inputs": [
-                            {
-                                "description": "",
-                                "name": "Coverage"
-                            }
-                        ],
-                        "label": "Coverage",
-                        "name": "Input dataset",
-                        "outputs": [],
-                        "position": {
-                            "left": 581.1909253334677,
-                            "top": 1050.5810577223672
-                        },
-                        "tool_id": null,
-                        "tool_state": "{\"optional\": false, \"format\": [\"bigwig\"], \"tag\": \"\"}",
-                        "tool_version": null,
-                        "type": "data_input",
-                        "uuid": "738f43fc-5f88-4117-bcc3-4a9c1b01c0a1",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "7": {
-                        "annotation": "",
-                        "content_id": null,
-                        "errors": null,
-                        "id": 7,
-                        "input_connections": {},
-                        "inputs": [
-                            {
-                                "description": "",
-                                "name": "Genes?"
-                            }
-                        ],
-                        "label": "Genes?",
-                        "name": "Input parameter",
-                        "outputs": [],
-                        "position": {
-                            "left": 632.8136499329014,
-                            "top": 1153.233851898539
-                        },
-                        "tool_id": null,
-                        "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
-                        "tool_version": null,
-                        "type": "parameter_input",
-                        "uuid": "7c8dc365-9ea0-4f5a-af57-0983008b7ade",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "8": {
-                        "annotation": "",
-                        "content_id": null,
-                        "errors": null,
-                        "id": 8,
-                        "input_connections": {},
-                        "inputs": [
-                            {
-                                "description": "",
-                                "name": "Genes"
-                            }
-                        ],
-                        "label": "Genes",
-                        "name": "Input dataset",
-                        "outputs": [],
-                        "position": {
-                            "left": 683.9939626471161,
-                            "top": 1243.3922887919446
-                        },
-                        "tool_id": null,
-                        "tool_state": "{\"optional\": false, \"tag\": null}",
-                        "tool_version": null,
-                        "type": "data_input",
-                        "uuid": "dabdef6f-cb85-410c-a5ef-229d9ae21a3b",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "9": {
-                        "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
-                        "errors": null,
-                        "id": 9,
-                        "input_connections": {
-                            "query": {
-                                "id": 0,
-                                "output_name": "output"
-                            },
-                            "reflist": {
-                                "id": 1,
-                                "output_name": "output"
-                            }
-                        },
-                        "inputs": [],
-                        "label": "Align Haplotypes Hap1 is query",
-                        "name": "mashmap",
-                        "outputs": [
-                            {
-                                "name": "mashout",
-                                "type": "paf"
-                            }
-                        ],
-                        "position": {
-                            "left": 1507.3273804321968,
-                            "top": 793.8614046625582
-                        },
-                        "post_job_actions": {
-                            "HideDatasetActionmashout": {
-                                "action_arguments": {},
-                                "action_type": "HideDatasetAction",
-                                "output_name": "mashout"
-                            },
-                            "RenameDatasetActionmashout": {
-                                "action_arguments": {
-                                    "newname": "Alignment Hap1 vs Hap2"
-                                },
-                                "action_type": "RenameDatasetAction",
-                                "output_name": "mashout"
-                            }
-                        },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
-                        "tool_shed_repository": {
-                            "changeset_revision": "a3a6b0b31f2d",
-                            "name": "mashmap",
-                            "owner": "iuc",
-                            "tool_shed": "toolshed.g2.bx.psu.edu"
-                        },
-                        "tool_state": "{\"dense\": false, \"filter_mode\": \"map\", \"kmerComplexity\": null, \"kmerThreshold\": null, \"noHgFilter\": false, \"noMerge\": false, \"perc_identity\": \"90.0\", \"query\": {\"__class__\": \"ConnectedValue\"}, \"reflist\": {\"__class__\": \"ConnectedValue\"}, \"reportPercentage\": false, \"seqLength\": \"5000\", \"sketchSize\": \"0\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-                        "tool_uuid": null,
-                        "tool_version": "3.1.3+galaxy0",
-                        "type": "tool",
-                        "uuid": "c7740c1c-5674-43d4-aa00-aeca2dcc7fa6",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "10": {
-                        "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
-                        "errors": null,
-                        "id": 10,
-                        "input_connections": {
-                            "query": {
-                                "id": 0,
-                                "output_name": "output"
-                            },
-                            "reflist": {
-                                "id": 2,
-                                "output_name": "output"
-                            }
-                        },
-                        "inputs": [],
-                        "label": "Hap1 vs Species",
-                        "name": "mashmap",
-                        "outputs": [
-                            {
-                                "name": "mashout",
-                                "type": "paf"
-                            }
-                        ],
-                        "position": {
-                            "left": 1211.2240968936799,
-                            "top": 0
-                        },
-                        "post_job_actions": {
-                            "HideDatasetActionmashout": {
-                                "action_arguments": {},
-                                "action_type": "HideDatasetAction",
-                                "output_name": "mashout"
-                            },
-                            "RenameDatasetActionmashout": {
-                                "action_arguments": {
-                                    "newname": "Species to Hap2"
-                                },
-                                "action_type": "RenameDatasetAction",
-                                "output_name": "mashout"
-                            }
-                        },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
-                        "tool_shed_repository": {
-                            "changeset_revision": "a3a6b0b31f2d",
-                            "name": "mashmap",
-                            "owner": "iuc",
-                            "tool_shed": "toolshed.g2.bx.psu.edu"
-                        },
-                        "tool_state": "{\"dense\": false, \"filter_mode\": \"one-to-one\", \"kmerComplexity\": null, \"kmerThreshold\": null, \"noHgFilter\": false, \"noMerge\": false, \"perc_identity\": \"85.0\", \"query\": {\"__class__\": \"ConnectedValue\"}, \"reflist\": {\"__class__\": \"ConnectedValue\"}, \"reportPercentage\": false, \"seqLength\": \"5000\", \"sketchSize\": \"0\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-                        "tool_uuid": null,
-                        "tool_version": "3.1.3+galaxy0",
-                        "type": "tool",
-                        "uuid": "ba8fe065-a989-4cff-bcda-2e6883b1f6cd",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "11": {
-                        "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
-                        "errors": null,
-                        "id": 11,
-                        "input_connections": {
-                            "query": {
-                                "id": 2,
-                                "output_name": "output"
-                            },
-                            "reflist": {
-                                "id": 1,
-                                "output_name": "output"
-                            }
-                        },
-                        "inputs": [],
-                        "label": "Species vs Hap2",
-                        "name": "mashmap",
-                        "outputs": [
-                            {
-                                "name": "mashout",
-                                "type": "paf"
-                            }
-                        ],
-                        "position": {
-                            "left": 1225.3530086334274,
-                            "top": 365.8375864791642
-                        },
-                        "post_job_actions": {
-                            "HideDatasetActionmashout": {
-                                "action_arguments": {},
-                                "action_type": "HideDatasetAction",
-                                "output_name": "mashout"
-                            },
-                            "RenameDatasetActionmashout": {
-                                "action_arguments": {
-                                    "newname": "Species to Hap2"
-                                },
-                                "action_type": "RenameDatasetAction",
-                                "output_name": "mashout"
-                            }
-                        },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/mashmap/mashmap/3.1.3+galaxy0",
-                        "tool_shed_repository": {
-                            "changeset_revision": "a3a6b0b31f2d",
-                            "name": "mashmap",
-                            "owner": "iuc",
-                            "tool_shed": "toolshed.g2.bx.psu.edu"
-                        },
-                        "tool_state": "{\"dense\": false, \"filter_mode\": \"one-to-one\", \"kmerComplexity\": null, \"kmerThreshold\": null, \"noHgFilter\": false, \"noMerge\": false, \"perc_identity\": \"85.0\", \"query\": {\"__class__\": \"ConnectedValue\"}, \"reflist\": {\"__class__\": \"ConnectedValue\"}, \"reportPercentage\": false, \"seqLength\": \"5000\", \"sketchSize\": \"0\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-                        "tool_uuid": null,
-                        "tool_version": "3.1.3+galaxy0",
-                        "type": "tool",
-                        "uuid": "cf1e95b5-3bd6-41c1-a2d4-93ac6c1b1b1a",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "12": {
-                        "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
-                        "errors": null,
-                        "id": 12,
-                        "input_connections": {
-                            "input_param_type|input_param": {
-                                "id": 7,
-                                "output_name": "output"
-                            }
-                        },
-                        "inputs": [],
-                        "label": null,
-                        "name": "Map parameter value",
-                        "outputs": [
-                            {
-                                "name": "output_param_boolean",
-                                "type": "expression.json"
-                            }
-                        ],
-                        "position": {
-                            "left": 1107.9772160860653,
-                            "top": 1163.288147730554
-                        },
-                        "post_job_actions": {
-                            "HideDatasetActionoutput_param_boolean": {
-                                "action_arguments": {},
-                                "action_type": "HideDatasetAction",
-                                "output_name": "output_param_boolean"
-                            }
-                        },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
-                        "tool_shed_repository": {
-                            "changeset_revision": "5ac8a4bf7a8d",
-                            "name": "map_param_value",
-                            "owner": "iuc",
-                            "tool_shed": "toolshed.g2.bx.psu.edu"
-                        },
-                        "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": true, \"to\": \"False\"}, {\"__index__\": 1, \"from\": false, \"to\": \"True\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-                        "tool_uuid": null,
-                        "tool_version": "0.2.0",
-                        "type": "tool",
-                        "uuid": "03bd04b4-815e-471e-8bf2-b51054b8390e",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "13": {
-                        "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
-                        "errors": null,
-                        "id": 13,
-                        "input_connections": {
-                            "assemblies_0|reference_genome|genome": {
-                                "id": 0,
-                                "output_name": "output"
-                            },
-                            "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
-                                "id": 9,
-                                "output_name": "mashout"
-                            },
-                            "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
-                                "id": 3,
-                                "output_name": "output"
-                            },
-                            "assemblies_0|track_groups_1|data_tracks_1|data_format|annotation_cond|annotation": {
-                                "id": 4,
-                                "output_name": "output"
-                            },
-                            "assemblies_0|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
-                                "id": 5,
-                                "output_name": "output"
-                            },
-                            "assemblies_0|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
-                                "id": 6,
-                                "output_name": "output"
-                            },
-                            "assemblies_0|track_groups_4|data_tracks_0|data_format|annotation_cond|annotation": {
-                                "id": 8,
-                                "output_name": "output"
-                            },
-                            "assemblies_1|reference_genome|genome": {
-                                "id": 0,
-                                "output_name": "output"
-                            },
-                            "assemblies_1|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
-                                "id": 3,
-                                "output_name": "output"
-                            },
-                            "assemblies_1|track_groups_0|data_tracks_1|data_format|annotation_cond|annotation": {
-                                "id": 4,
-                                "output_name": "output"
-                            },
-                            "assemblies_1|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
-                                "id": 5,
-                                "output_name": "output"
-                            },
-                            "assemblies_1|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
-                                "id": 6,
-                                "output_name": "output"
-                            },
-                            "assemblies_1|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
-                                "id": 8,
-                                "output_name": "output"
-                            },
-                            "when": {
-                                "id": 7,
-                                "output_name": "output"
-                            }
-                        },
-                        "inputs": [],
-                        "label": "JBrowse2 Hap1 vs Hap2 with gene tracks",
-                        "name": "JBrowse2",
-                        "outputs": [
-                            {
-                                "name": "output",
-                                "type": "html"
-                            }
-                        ],
-                        "position": {
-                            "left": 2146.8088643141236,
-                            "top": 602.2449366027035
-                        },
-                        "post_job_actions": {
-                            "RenameDatasetActionoutput": {
-                                "action_arguments": {
-                                    "newname": "JBrowse2 Hap1 vs Hap2 with gene tracks"
-                                },
-                                "action_type": "RenameDatasetAction",
-                                "output_name": "output"
-                            }
-                        },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
-                        "tool_shed_repository": {
-                            "changeset_revision": "bd903fbbc26e",
-                            "name": "jbrowse2",
-                            "owner": "fubar",
-                            "tool_shed": "toolshed.g2.bx.psu.edu"
-                        },
-                        "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"RuntimeValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Alignments\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Telomeres Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_off\"}}]}, {\"__index__\": 2, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 4, \"category\": \"Annotation\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 1, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"RuntimeValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Telomeres\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"Annotation\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-                        "tool_uuid": null,
-                        "tool_version": "3.7.0+galaxy0",
-                        "type": "tool",
-                        "uuid": "8579f589-f836-4f8e-ad72-aa14a8b6c450",
-                        "when": "$(inputs.when)",
-                        "workflow_outputs": [
-                            {
-                                "label": "JBrowse2 Hap1 vs Hap2 with gene tracks",
-                                "output_name": "output",
-                                "uuid": "4db7f57b-58ba-4932-9d15-8a0e3cde1f9b"
-                            }
-                        ]
-                    },
-                    "14": {
-                        "annotation": "",
-                        "id": 14,
-                        "input_connections": {
-                            "Coverage": {
-                                "id": 6,
-                                "input_subworkflow_step_id": 8,
-                                "output_name": "output"
-                            },
-                            "Gaps": {
-                                "id": 5,
-                                "input_subworkflow_step_id": 7,
-                                "output_name": "output"
-                            },
-                            "Genes": {
-                                "id": 8,
-                                "input_subworkflow_step_id": 10,
-                                "output_name": "output"
-                            },
-                            "Genes?": {
-                                "id": 7,
-                                "input_subworkflow_step_id": 9,
-                                "output_name": "output"
-                            },
-                            "Hap1 fasta": {
-                                "id": 0,
-                                "input_subworkflow_step_id": 0,
-                                "output_name": "output"
-                            },
-                            "Hap1 vs Species": {
-                                "id": 10,
-                                "input_subworkflow_step_id": 4,
-                                "output_name": "mashout"
-                            },
-                            "Hap2 fasta": {
-                                "id": 1,
-                                "input_subworkflow_step_id": 1,
-                                "output_name": "output"
-                            },
-                            "Related Species": {
-                                "id": 2,
-                                "input_subworkflow_step_id": 2,
-                                "output_name": "output"
-                            },
-                            "Species vs Hap2": {
-                                "id": 11,
-                                "input_subworkflow_step_id": 3,
-                                "output_name": "mashout"
-                            },
-                            "Telomeres P": {
-                                "id": 4,
-                                "input_subworkflow_step_id": 6,
-                                "output_name": "output"
-                            },
-                            "Telomeres Q": {
-                                "id": 3,
-                                "input_subworkflow_step_id": 5,
-                                "output_name": "output"
-                            }
-                        },
-                        "inputs": [],
-                        "label": null,
-                        "name": "Jbrowse2 for 1 related species",
-                        "outputs": [],
-                        "position": {
-                            "left": 1887.4863910257557,
-                            "top": 102.53355703483975
-                        },
-                        "subworkflow": {
-                            "a_galaxy_workflow": "true",
-                            "annotation": "",
-                            "comments": [],
-                            "format-version": "0.1",
-                            "name": "Jbrowse2 for 1 related species",
-                            "report": {
-                                "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
-                            },
-                            "steps": {
-                                "0": {
-                                    "annotation": "",
-                                    "content_id": null,
-                                    "errors": null,
-                                    "id": 0,
-                                    "input_connections": {},
-                                    "inputs": [
-                                        {
-                                            "description": "",
-                                            "name": "Hap1 fasta"
-                                        }
-                                    ],
-                                    "label": "Hap1 fasta",
-                                    "name": "Input dataset",
-                                    "outputs": [],
-                                    "position": {
-                                        "left": 0,
-                                        "top": 271.13908772215916
-                                    },
-                                    "tool_id": null,
-                                    "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
-                                    "tool_version": null,
-                                    "type": "data_input",
-                                    "uuid": "4a20362f-2551-4a60-9118-e4c3e7c4f264",
-                                    "when": null,
-                                    "workflow_outputs": []
-                                },
-                                "1": {
-                                    "annotation": "",
-                                    "content_id": null,
-                                    "errors": null,
-                                    "id": 1,
-                                    "input_connections": {},
-                                    "inputs": [
-                                        {
-                                            "description": "",
-                                            "name": "Hap2 fasta"
-                                        }
-                                    ],
-                                    "label": "Hap2 fasta",
-                                    "name": "Input dataset",
-                                    "outputs": [],
-                                    "position": {
-                                        "left": 53.14881800970572,
-                                        "top": 420.7641795440555
-                                    },
-                                    "tool_id": null,
-                                    "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
-                                    "tool_version": null,
-                                    "type": "data_input",
-                                    "uuid": "177f6825-e58e-45e9-a3fc-8c7623187e02",
-                                    "when": null,
-                                    "workflow_outputs": []
-                                },
-                                "2": {
-                                    "annotation": "",
-                                    "content_id": null,
-                                    "errors": null,
-                                    "id": 2,
-                                    "input_connections": {},
-                                    "inputs": [
-                                        {
-                                            "description": "",
-                                            "name": "Related Species"
-                                        }
-                                    ],
-                                    "label": "Related Species",
-                                    "name": "Input dataset",
-                                    "outputs": [],
-                                    "position": {
-                                        "left": 98.91709918730632,
-                                        "top": 553.1054764799819
-                                    },
-                                    "tool_id": null,
-                                    "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
-                                    "tool_version": null,
-                                    "type": "data_input",
-                                    "uuid": "604a6bec-8c1f-47e3-8884-c32f63246589",
-                                    "when": null,
-                                    "workflow_outputs": []
-                                },
-                                "3": {
-                                    "annotation": "",
-                                    "content_id": null,
-                                    "errors": null,
-                                    "id": 3,
-                                    "input_connections": {},
-                                    "inputs": [
-                                        {
-                                            "description": "",
-                                            "name": "Species vs Hap2"
-                                        }
-                                    ],
-                                    "label": "Species vs Hap2",
-                                    "name": "Input dataset",
-                                    "outputs": [],
-                                    "position": {
-                                        "left": 147.9198303415696,
-                                        "top": 670.2931389328182
-                                    },
-                                    "tool_id": null,
-                                    "tool_state": "{\"optional\": false, \"format\": [\"paf\"], \"tag\": null}",
-                                    "tool_version": null,
-                                    "type": "data_input",
-                                    "uuid": "ebdc47b3-16f5-48e9-a101-c82b2370181a",
-                                    "when": null,
-                                    "workflow_outputs": []
-                                },
-                                "4": {
-                                    "annotation": "",
-                                    "content_id": null,
-                                    "errors": null,
-                                    "id": 4,
-                                    "input_connections": {},
-                                    "inputs": [
-                                        {
-                                            "description": "",
-                                            "name": "Hap1 vs Species"
-                                        }
-                                    ],
-                                    "label": "Hap1 vs Species",
-                                    "name": "Input dataset",
-                                    "outputs": [],
-                                    "position": {
-                                        "left": 175.64670268098203,
-                                        "top": 777.2105888619357
-                                    },
-                                    "tool_id": null,
-                                    "tool_state": "{\"optional\": false, \"format\": [\"paf\"], \"tag\": null}",
-                                    "tool_version": null,
-                                    "type": "data_input",
-                                    "uuid": "385825a9-198e-425f-9fb3-55af892d20dc",
-                                    "when": null,
-                                    "workflow_outputs": []
-                                },
-                                "5": {
-                                    "annotation": "",
-                                    "content_id": null,
-                                    "errors": null,
-                                    "id": 5,
-                                    "input_connections": {},
-                                    "inputs": [
-                                        {
-                                            "description": "",
-                                            "name": "Telomeres Q"
-                                        }
-                                    ],
-                                    "label": "Telomeres Q",
-                                    "name": "Input dataset",
-                                    "outputs": [],
-                                    "position": {
-                                        "left": 206.21568172170709,
-                                        "top": 895.0983900914266
-                                    },
-                                    "tool_id": null,
-                                    "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": null}",
-                                    "tool_version": null,
-                                    "type": "data_input",
-                                    "uuid": "ce01ac46-a3c2-4013-ba5b-ea8a0e46be64",
-                                    "when": null,
-                                    "workflow_outputs": []
-                                },
-                                "6": {
-                                    "annotation": "",
-                                    "content_id": null,
-                                    "errors": null,
-                                    "id": 6,
-                                    "input_connections": {},
-                                    "inputs": [
-                                        {
-                                            "description": "",
-                                            "name": "Telomeres P"
-                                        }
-                                    ],
-                                    "label": "Telomeres P",
-                                    "name": "Input dataset",
-                                    "outputs": [],
-                                    "position": {
-                                        "left": 274.77222990165984,
-                                        "top": 1069.4502766623036
-                                    },
-                                    "tool_id": null,
-                                    "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
-                                    "tool_version": null,
-                                    "type": "data_input",
-                                    "uuid": "8044ff06-8a3b-4ac1-b6ee-521cc28e585d",
-                                    "when": null,
-                                    "workflow_outputs": []
-                                },
-                                "7": {
-                                    "annotation": "",
-                                    "content_id": null,
-                                    "errors": null,
-                                    "id": 7,
-                                    "input_connections": {},
-                                    "inputs": [
-                                        {
-                                            "description": "",
-                                            "name": "Gaps"
-                                        }
-                                    ],
-                                    "label": "Gaps",
-                                    "name": "Input dataset",
-                                    "outputs": [],
-                                    "position": {
-                                        "left": 353.8919295731858,
-                                        "top": 1244.9653893778952
-                                    },
-                                    "tool_id": null,
-                                    "tool_state": "{\"optional\": false, \"format\": [\"bed\"], \"tag\": \"\"}",
-                                    "tool_version": null,
-                                    "type": "data_input",
-                                    "uuid": "37e56713-8aa6-474e-9a87-6c702d7d6b49",
-                                    "when": null,
-                                    "workflow_outputs": []
-                                },
-                                "8": {
-                                    "annotation": "",
-                                    "content_id": null,
-                                    "errors": null,
-                                    "id": 8,
-                                    "input_connections": {},
-                                    "inputs": [
-                                        {
-                                            "description": "",
-                                            "name": "Coverage"
-                                        }
-                                    ],
-                                    "label": "Coverage",
-                                    "name": "Input dataset",
-                                    "outputs": [],
-                                    "position": {
-                                        "left": 391.49614814580605,
-                                        "top": 1410.3962329181184
-                                    },
-                                    "tool_id": null,
-                                    "tool_state": "{\"optional\": false, \"format\": [\"bigwig\"], \"tag\": \"\"}",
-                                    "tool_version": null,
-                                    "type": "data_input",
-                                    "uuid": "2131fd1e-4f34-4662-be5c-382101fcbc76",
-                                    "when": null,
-                                    "workflow_outputs": []
-                                },
-                                "9": {
-                                    "annotation": "",
-                                    "content_id": null,
-                                    "errors": null,
-                                    "id": 9,
-                                    "input_connections": {},
-                                    "inputs": [
-                                        {
-                                            "description": "",
-                                            "name": "Genes?"
-                                        }
-                                    ],
-                                    "label": "Genes?",
-                                    "name": "Input parameter",
-                                    "outputs": [],
-                                    "position": {
-                                        "left": 419.6781495431659,
-                                        "top": 1559.6965461441787
-                                    },
-                                    "tool_id": null,
-                                    "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
-                                    "tool_version": null,
-                                    "type": "parameter_input",
-                                    "uuid": "ccb4de54-c370-4f56-a5d4-42708ee6c835",
-                                    "when": null,
-                                    "workflow_outputs": []
-                                },
-                                "10": {
-                                    "annotation": "",
-                                    "content_id": null,
-                                    "errors": null,
-                                    "id": 10,
-                                    "input_connections": {},
-                                    "inputs": [
-                                        {
-                                            "description": "",
-                                            "name": "Genes"
-                                        }
-                                    ],
-                                    "label": "Genes",
-                                    "name": "Input dataset",
-                                    "outputs": [],
-                                    "position": {
-                                        "left": 450.73254127706855,
-                                        "top": 1696.059196784704
-                                    },
-                                    "tool_id": null,
-                                    "tool_state": "{\"optional\": false, \"tag\": null}",
-                                    "tool_version": null,
-                                    "type": "data_input",
-                                    "uuid": "496c7358-def1-4256-b4e8-6698cac34f97",
-                                    "when": null,
-                                    "workflow_outputs": []
-                                },
-                                "11": {
-                                    "annotation": "",
-                                    "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
-                                    "errors": null,
-                                    "id": 11,
-                                    "input_connections": {
-                                        "input_param_type|input_param": {
-                                            "id": 9,
-                                            "output_name": "output"
-                                        }
-                                    },
-                                    "inputs": [],
-                                    "label": "No Gene track",
-                                    "name": "Map parameter value",
-                                    "outputs": [
-                                        {
-                                            "name": "output_param_boolean",
-                                            "type": "expression.json"
-                                        }
-                                    ],
-                                    "position": {
-                                        "left": 1030.3127513910322,
-                                        "top": 1346.1174612746302
-                                    },
-                                    "post_job_actions": {
-                                        "HideDatasetActionoutput_param_boolean": {
-                                            "action_arguments": {},
-                                            "action_type": "HideDatasetAction",
-                                            "output_name": "output_param_boolean"
-                                        }
-                                    },
-                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
-                                    "tool_shed_repository": {
-                                        "changeset_revision": "5ac8a4bf7a8d",
-                                        "name": "map_param_value",
-                                        "owner": "iuc",
-                                        "tool_shed": "toolshed.g2.bx.psu.edu"
-                                    },
-                                    "tool_state": "{\"input_param_type\": {\"type\": \"boolean\", \"__current_case__\": 3, \"input_param\": {\"__class__\": \"ConnectedValue\"}, \"mappings\": [{\"__index__\": 0, \"from\": false, \"to\": \"True\"}, {\"__index__\": 1, \"from\": false, \"to\": \"False\"}]}, \"output_param_type\": \"boolean\", \"unmapped\": {\"on_unmapped\": \"input\", \"__current_case__\": 0}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-                                    "tool_uuid": null,
-                                    "tool_version": "0.2.0",
-                                    "type": "tool",
-                                    "uuid": "d8f71bf4-51a3-4af7-8cf2-fd16730469b4",
-                                    "when": null,
-                                    "workflow_outputs": []
-                                },
-                                "12": {
-                                    "annotation": "",
-                                    "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
-                                    "errors": null,
-                                    "id": 12,
-                                    "input_connections": {
-                                        "assemblies_0|reference_genome|genome": {
-                                            "id": 0,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 4,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 5,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_0|track_groups_1|data_tracks_1|data_format|annotation_cond|annotation": {
-                                            "id": 6,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_0|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 7,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_0|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 8,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_0|track_groups_4|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 10,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_1|reference_genome|genome": {
-                                            "id": 2,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_1|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 3,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_2|reference_genome|genome": {
-                                            "id": 1,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_2|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 5,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_2|track_groups_0|data_tracks_1|data_format|annotation_cond|annotation": {
-                                            "id": 6,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_2|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 7,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_2|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 8,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_2|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 10,
-                                            "output_name": "output"
-                                        },
-                                        "when": {
-                                            "id": 9,
-                                            "output_name": "output"
-                                        }
-                                    },
-                                    "inputs": [],
-                                    "label": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
-                                    "name": "JBrowse2",
-                                    "outputs": [
-                                        {
-                                            "name": "output",
-                                            "type": "html"
-                                        }
-                                    ],
-                                    "position": {
-                                        "left": 2604.560544371787,
-                                        "top": 306.40203071991476
-                                    },
-                                    "post_job_actions": {
-                                        "RenameDatasetActionoutput": {
-                                            "action_arguments": {
-                                                "newname": "JBrowse2 Hap1 and hap2 with related species and gene tracks"
-                                            },
-                                            "action_type": "RenameDatasetAction",
-                                            "output_name": "output"
-                                        }
-                                    },
-                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
-                                    "tool_shed_repository": {
-                                        "changeset_revision": "bd903fbbc26e",
-                                        "name": "jbrowse2",
-                                        "owner": "fubar",
-                                        "tool_shed": "toolshed.g2.bx.psu.edu"
-                                    },
-                                    "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"RuntimeValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Synteny Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Telomeres Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 4, \"category\": \"Annotations\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 1, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"RuntimeValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Synteny Hap2\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 2, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"RuntimeValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Telomeres Haplotype 2\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"Annotations\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"RuntimeValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-                                    "tool_uuid": null,
-                                    "tool_version": "3.7.0+galaxy0",
-                                    "type": "tool",
-                                    "uuid": "c4b25ca4-bdd4-4260-ac8b-80ae381da1ab",
-                                    "when": "$(inputs.when)",
-                                    "workflow_outputs": [
-                                        {
-                                            "label": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
-                                            "output_name": "output",
-                                            "uuid": "78b83679-2eea-4812-9936-54e27a2c404d"
-                                        }
-                                    ]
-                                },
-                                "13": {
-                                    "annotation": "",
-                                    "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
-                                    "errors": null,
-                                    "id": 13,
-                                    "input_connections": {
-                                        "assemblies_0|reference_genome|genome": {
-                                            "id": 0,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 4,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 5,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_0|track_groups_1|data_tracks_1|data_format|annotation_cond|annotation": {
-                                            "id": 6,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_0|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 7,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_0|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 8,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_1|reference_genome|genome": {
-                                            "id": 2,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_1|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 3,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_2|reference_genome|genome": {
-                                            "id": 1,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_2|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 5,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_2|track_groups_0|data_tracks_1|data_format|annotation_cond|annotation": {
-                                            "id": 6,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_2|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 7,
-                                            "output_name": "output"
-                                        },
-                                        "assemblies_2|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
-                                            "id": 8,
-                                            "output_name": "output"
-                                        },
-                                        "when": {
-                                            "id": 11,
-                                            "output_name": "output_param_boolean"
-                                        }
-                                    },
-                                    "inputs": [],
-                                    "label": "JBrowse2 Hap1 and hap2 with 1st related species",
-                                    "name": "JBrowse2",
-                                    "outputs": [
-                                        {
-                                            "name": "output",
-                                            "type": "html"
-                                        }
-                                    ],
-                                    "position": {
-                                        "left": 1960.7191746063156,
-                                        "top": 0
-                                    },
-                                    "post_job_actions": {
-                                        "RenameDatasetActionoutput": {
-                                            "action_arguments": {
-                                                "newname": "JBrowse2 Hap1 and hap2 with related species"
-                                            },
-                                            "action_type": "RenameDatasetAction",
-                                            "output_name": "output"
-                                        }
-                                    },
-                                    "tool_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
-                                    "tool_shed_repository": {
-                                        "changeset_revision": "bd903fbbc26e",
-                                        "name": "jbrowse2",
-                                        "owner": "fubar",
-                                        "tool_shed": "toolshed.g2.bx.psu.edu"
-                                    },
-                                    "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Synteny Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Telomeres Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 1, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Synteny Hap2\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 2, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Telomeres Haplotype 2\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-                                    "tool_uuid": null,
-                                    "tool_version": "3.7.0+galaxy0",
-                                    "type": "tool",
-                                    "uuid": "0dba1c5e-903c-46f3-a58c-2b9341b92a15",
-                                    "when": "$(inputs.when)",
-                                    "workflow_outputs": [
-                                        {
-                                            "label": "JBrowse2 Hap1 and hap2 with related species",
-                                            "output_name": "output",
-                                            "uuid": "ce6026de-ad8b-4dec-8926-fccc97f25df6"
-                                        }
-                                    ]
-                                }
-                            },
-                            "tags": [],
-                            "uuid": "fb028d13-e1d0-4d81-b413-b2c662d5213a"
-                        },
-                        "tool_id": null,
-                        "type": "subworkflow",
-                        "uuid": "e134915a-f5b7-4b32-a511-921e0b363bff",
-                        "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
-                                "output_name": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
-                                "uuid": "ca3249af-b46a-450d-8dbe-696490325d42"
-                            },
-                            {
-                                "label": "JBrowse2 Hap1 and hap2 with related species",
-                                "output_name": "JBrowse2 Hap1 and hap2 with related species",
-                                "uuid": "7562c81f-4b86-4932-8056-52f4dc17d2a9"
-                            }
-                        ]
-                    },
-                    "15": {
-                        "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
-                        "errors": null,
-                        "id": 15,
-                        "input_connections": {
-                            "assemblies_0|reference_genome|genome": {
-                                "id": 0,
-                                "output_name": "output"
-                            },
-                            "assemblies_0|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
-                                "id": 9,
-                                "output_name": "mashout"
-                            },
-                            "assemblies_0|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
-                                "id": 3,
-                                "output_name": "output"
-                            },
-                            "assemblies_0|track_groups_1|data_tracks_1|data_format|annotation_cond|annotation": {
-                                "id": 4,
-                                "output_name": "output"
-                            },
-                            "assemblies_0|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
-                                "id": 5,
-                                "output_name": "output"
-                            },
-                            "assemblies_0|track_groups_3|data_tracks_0|data_format|annotation_cond|annotation": {
-                                "id": 6,
-                                "output_name": "output"
-                            },
-                            "assemblies_1|reference_genome|genome": {
-                                "id": 0,
-                                "output_name": "output"
-                            },
-                            "assemblies_1|track_groups_0|data_tracks_0|data_format|annotation_cond|annotation": {
-                                "id": 3,
-                                "output_name": "output"
-                            },
-                            "assemblies_1|track_groups_0|data_tracks_1|data_format|annotation_cond|annotation": {
-                                "id": 4,
-                                "output_name": "output"
-                            },
-                            "assemblies_1|track_groups_1|data_tracks_0|data_format|annotation_cond|annotation": {
-                                "id": 5,
-                                "output_name": "output"
-                            },
-                            "assemblies_1|track_groups_2|data_tracks_0|data_format|annotation_cond|annotation": {
-                                "id": 6,
-                                "output_name": "output"
-                            },
-                            "when": {
-                                "id": 12,
-                                "output_name": "output_param_boolean"
-                            }
-                        },
-                        "inputs": [],
-                        "label": "JBrowse2 Hap1 vs Hap2",
-                        "name": "JBrowse2",
-                        "outputs": [
-                            {
-                                "name": "output",
-                                "type": "html"
-                            }
-                        ],
-                        "position": {
-                            "left": 2427.3955083914084,
-                            "top": 101.59146846369417
-                        },
-                        "post_job_actions": {
-                            "RenameDatasetActionoutput": {
-                                "action_arguments": {
-                                    "newname": "JBrowse2 Hap1 vs Hap2"
-                                },
-                                "action_type": "RenameDatasetAction",
-                                "output_name": "output"
-                            }
-                        },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/fubar/jbrowse2/jbrowse2/3.7.0+galaxy0",
-                        "tool_shed_repository": {
-                            "changeset_revision": "bd903fbbc26e",
-                            "name": "jbrowse2",
-                            "owner": "fubar",
-                            "tool_shed": "toolshed.g2.bx.psu.edu"
-                        },
-                        "tool_state": "{\"action\": {\"action_select\": \"create\", \"__current_case__\": 0}, \"assemblies\": [{\"__index__\": 0, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Alignments\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"synteny\", \"__current_case__\": 7, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearSyntenyDisplay\", \"__current_case__\": 1}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Telomeres Hap1\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_off\"}}]}, {\"__index__\": 2, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 3, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}, {\"__index__\": 1, \"reference_genome\": {\"genome_type_select\": \"history\", \"__current_case__\": 1, \"genome\": {\"__class__\": \"ConnectedValue\"}}, \"defaultLocation\": \"\", \"ref_name_aliases\": {\"__class__\": \"RuntimeValue\"}, \"cytobands\": {\"__class__\": \"RuntimeValue\"}, \"track_groups\": [{\"__index__\": 0, \"category\": \"Telomeres\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}, {\"__index__\": 1, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 1, \"category\": \"Gaps\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"gene_calls\", \"__current_case__\": 0, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"index\": false, \"jbstyle\": {\"track_style\": {\"display\": \"LinearBasicDisplay\", \"__current_case__\": 0, \"display_mode\": \"normal\", \"show_labels\": true, \"labels_name\": \"jexl:get(feature,'name') || get(feature,'id')\", \"show_descriptions\": true, \"descriptions_name\": \"jexl:get(feature,'note') || get(feature,'description')\", \"max_height\": \"600\"}}, \"formatdetails\": {\"formatdetails_feature\": null, \"formatdetails_subfeature\": null, \"formatdetails_depth\": \"1\"}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}, {\"__index__\": 2, \"category\": \"HiFi Coverage\", \"data_tracks\": [{\"__index__\": 0, \"data_format\": {\"data_format_select\": \"wiggle\", \"__current_case__\": 3, \"annotation_cond\": {\"annotation_source\": \"history\", \"__current_case__\": 0, \"annotation\": {\"__class__\": \"ConnectedValue\"}}, \"jbstyle\": {\"track_style\": {\"display\": \"LinearWiggleDisplay\", \"__current_case__\": 0, \"wig_renderer\": \"xyplot\"}}, \"metadata\": {\"galaxy_metadata\": true, \"metadata_bonus\": {\"__class__\": \"RuntimeValue\"}}, \"track_visibility\": \"default_on\"}}]}]}], \"jbgen\": {\"enableAnalytics\": false, \"primary_color\": \"#0d233f\", \"secondary_color\": \"#721e63\", \"tertiary_color\": \"#135560\", \"quaternary_color\": \"#ffb11d\", \"font_size\": \"10\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-                        "tool_uuid": null,
-                        "tool_version": "3.7.0+galaxy0",
-                        "type": "tool",
-                        "uuid": "1838736c-68a4-41fd-b6c8-cd4de0aad595",
-                        "when": "$(inputs.when)",
-                        "workflow_outputs": [
-                            {
-                                "label": "JBrowse2 Hap1 vs Hap2",
-                                "output_name": "output",
-                                "uuid": "a3d1e37d-ea4d-44e6-ac96-c456fef1395f"
-                            }
-                        ]
-                    }
-                },
-                "tags": [],
-                "uuid": "feda97a2-4c3f-4211-80f4-3c4cd83555a0"
-            },
-            "tool_id": null,
-            "type": "subworkflow",
-            "uuid": "c65e39fb-f036-47f7-9bd1-c63d161b736f",
-            "when": "$(inputs.when)",
-            "workflow_outputs": [
-                {
-                    "label": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
-                    "output_name": "JBrowse2 Hap1 and hap2 with related species and gene tracks",
-                    "uuid": "4a390dc0-8929-4bf5-aea4-2ca8352a8987"
-                },
-                {
-                    "label": "JBrowse2 Hap1 and hap2 with related species",
-                    "output_name": "JBrowse2 Hap1 and hap2 with related species",
-                    "uuid": "1d0f2614-f167-446d-b874-f2435995ca7a"
-                },
-                {
-                    "label": "JBrowse2 Hap1 vs Hap2",
-                    "output_name": "JBrowse2 Hap1 vs Hap2",
-                    "uuid": "a0cefb53-5c71-4e7a-8415-760c5f49d254"
-                },
-                {
-                    "label": "JBrowse2 Hap1 vs Hap2 with gene tracks",
-                    "output_name": "JBrowse2 Hap1 vs Hap2 with gene tracks",
-                    "uuid": "42a88cd2-d2d5-4cfe-a00c-145d647cb12b"
-                }
-            ]
-        },
-        "20": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
-            "errors": null,
-            "id": 20,
-            "input_connections": {
-                "input_list": {
-                    "id": 17,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Collapse Collection",
-            "outputs": [
-                {
-                    "name": "output",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 2499.556473225303,
-                "top": 293.47025968475924
-            },
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
-            "tool_shed_repository": {
-                "changeset_revision": "90981f86000f",
-                "name": "collapse_collections",
-                "owner": "nml",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"filename\": {\"add_name\": false, \"__current_case__\": 1}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_uuid": null,
-            "tool_version": "5.1.0",
-            "type": "tool",
-            "uuid": "6e2e1a5d-5849-4852-898d-6646c379ee0d",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "21": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/9.5+galaxy3",
-            "errors": null,
-            "id": 21,
-            "input_connections": {
-                "infile": {
-                    "id": 20,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Unique",
-            "outputs": [
-                {
-                    "name": "outfile",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 2853.562857058991,
-                "top": 0
-            },
-            "post_job_actions": {
-                "ChangeDatatypeActionoutfile": {
-                    "action_arguments": {
-                        "newtype": "tabular"
-                    },
-                    "action_type": "ChangeDatatypeAction",
-                    "output_name": "outfile"
-                },
-                "HideDatasetActionoutfile": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "outfile"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_sorted_uniq/9.5+galaxy3",
-            "tool_shed_repository": {
-                "changeset_revision": "ab83aa685821",
-                "name": "text_processing",
-                "owner": "bgruening",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"adv_opts\": {\"adv_opts_selector\": \"basic\", \"__current_case__\": 0}, \"header\": \"0\", \"ignore_case\": false, \"infile\": {\"__class__\": \"ConnectedValue\"}, \"is_numeric\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_uuid": null,
-            "tool_version": "9.5+galaxy3",
-            "type": "tool",
-            "uuid": "4e7c4704-4734-49f8-b51e-53c500853bbc",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "22": {
-            "annotation": "",
-            "content_id": "wc_gnu",
-            "errors": null,
-            "id": 22,
-            "input_connections": {
-                "input1": {
-                    "id": 20,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Line/Word/Character count",
-            "outputs": [
-                {
-                    "name": "out_file1",
-                    "type": "tabular"
-                }
-            ],
-            "position": {
-                "left": 2812.55061813865,
-                "top": 510.6734558790175
-            },
-            "post_job_actions": {
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "out_file1"
-                }
-            },
-            "tool_id": "wc_gnu",
-            "tool_state": "{\"include_header\": false, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"options\": [\"lines\"], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_uuid": null,
-            "tool_version": "1.0.0",
-            "type": "tool",
-            "uuid": "71d76ee3-7dac-450a-98e9-bb57111df8c5",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "23": {
-            "annotation": "",
-            "content_id": "wc_gnu",
-            "errors": null,
-            "id": 23,
-            "input_connections": {
-                "input1": {
-                    "id": 21,
-                    "output_name": "outfile"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Line/Word/Character count",
-            "outputs": [
-                {
-                    "name": "out_file1",
-                    "type": "tabular"
-                }
-            ],
-            "position": {
-                "left": 3066.1573769206448,
-                "top": 268.5825615907663
-            },
-            "post_job_actions": {
-                "HideDatasetActionout_file1": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "out_file1"
-                }
-            },
-            "tool_id": "wc_gnu",
-            "tool_state": "{\"include_header\": false, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"options\": [\"lines\"], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_uuid": null,
-            "tool_version": "1.0.0",
-            "type": "tool",
-            "uuid": "2da84228-d818-493b-bafd-a95959ee2de3",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "24": {
-            "annotation": "",
-            "content_id": "param_value_from_file",
-            "errors": null,
-            "id": 24,
-            "input_connections": {
-                "input1": {
-                    "id": 22,
-                    "output_name": "out_file1"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Parse parameter value",
-            "outputs": [
-                {
-                    "name": "integer_param",
-                    "type": "expression.json"
-                }
-            ],
-            "position": {
-                "left": 3236.7131866213954,
-                "top": 502.9407403932288
-            },
-            "post_job_actions": {
-                "HideDatasetActioninteger_param": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "integer_param"
-                }
-            },
-            "tool_id": "param_value_from_file",
-            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"integer\", \"remove_newlines\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_uuid": null,
-            "tool_version": "0.1.0",
-            "type": "tool",
-            "uuid": "c03bb38c-3383-4d3f-843f-9f74c70b1c47",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "25": {
-            "annotation": "",
-            "content_id": "param_value_from_file",
-            "errors": null,
-            "id": 25,
-            "input_connections": {
-                "input1": {
-                    "id": 23,
-                    "output_name": "out_file1"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Parse parameter value",
-            "outputs": [
-                {
-                    "name": "integer_param",
-                    "type": "expression.json"
-                }
-            ],
-            "position": {
-                "left": 3349.6578232069623,
-                "top": 103.77316093552422
-            },
-            "post_job_actions": {
-                "HideDatasetActioninteger_param": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "integer_param"
-                }
-            },
-            "tool_id": "param_value_from_file",
-            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"param_type\": \"integer\", \"remove_newlines\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_uuid": null,
-            "tool_version": "0.1.0",
-            "type": "tool",
-            "uuid": "5ad8559e-e863-45e9-bae2-ede8be8314c7",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "26": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/calculate_numeric_param/calculate_numeric_param/0.1.0",
-            "errors": null,
-            "id": 26,
-            "input_connections": {
-                "components_0|param_type|component_value": {
-                    "id": 24,
-                    "output_name": "integer_param"
-                },
-                "components_1|param_type|component_value": {
-                    "id": 25,
-                    "output_name": "integer_param"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Calculate numeric parameter value",
-            "outputs": [
-                {
-                    "name": "integer_param",
-                    "type": "expression.json"
-                }
-            ],
-            "position": {
-                "left": 3600.8912340886463,
-                "top": 332.9150842713157
-            },
-            "post_job_actions": {
-                "HideDatasetActioninteger_param": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "integer_param"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/calculate_numeric_param/calculate_numeric_param/0.1.0",
-            "tool_shed_repository": {
-                "changeset_revision": "0e586762f97b",
-                "name": "calculate_numeric_param",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"components\": [{\"__index__\": 0, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 0, \"component_value\": {\"__class__\": \"ConnectedValue\"}}, \"arith\": \"-\"}, {\"__index__\": 1, \"param_type\": {\"select_param_type\": \"integer\", \"__current_case__\": 0, \"component_value\": {\"__class__\": \"ConnectedValue\"}}, \"arith\": \"\"}], \"output_type\": \"integer\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_uuid": null,
-            "tool_version": "0.1.0",
-            "type": "tool",
-            "uuid": "bdc1a0bf-1614-47f8-90f8-89cc139edf9a",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "27": {
+        "18": {
             "annotation": "This step is meant to warn the user that there are duplicated sequence names, which would cause inaccurate alignments results with MashMap. ",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/map_param_value/map_param_value/0.2.0",
             "errors": null,
-            "id": 27,
+            "id": 18,
             "input_connections": {
                 "input_param_type|input_param": {
-                    "id": 26,
-                    "output_name": "integer_param"
+                    "id": 16,
+                    "output_name": "Number of Sequences with the same name"
+                },
+                "when": {
+                    "id": 13,
+                    "output_name": "boolean_param"
                 }
             },
             "inputs": [],
@@ -3529,8 +5061,8 @@
                 }
             ],
             "position": {
-                "left": 3822.4432951091107,
-                "top": 766.5545148192659
+                "left": 3399.082051206245,
+                "top": 120.49976532949609
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput_param_boolean": {
@@ -3553,7 +5085,7 @@
             "tool_version": "0.2.0",
             "type": "tool",
             "uuid": "4af8e08f-5777-40db-b483-89d68084369b",
-            "when": null,
+            "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
                     "label": "Fail if there are duplicated sequence names between the fasta files",
@@ -3564,7 +5096,7 @@
         }
     },
     "tags": [],
-    "uuid": "62ed4482-aaa8-4942-b327-e16cae8f537f",
-    "version": 18,
-    "readme": "# JBrowse2 Precuration Tracks with Related Species Alignments\n\nThis workflow generates JBrowse2 instances with genome assembly tracks and alignments against related species, to assist the manual curation of genome assemblies. It complements the Hi-C contact map workflow by providing a complementary genome browser view of the same precuration tracks alongside synteny with related species.\n\nThe workflow takes the assembly haplotype(s) and the precuration tracks (telomeres, gaps, coverage, optional gene annotations), aligns the assembly against a list of related species, and packages everything into a JBrowse2 instance that curators can open directly in their browser.\n\n## Inputs\n\n### Required Inputs\n\n1. **Species Name** [text] - Species identifier used in the assembly info report\n2. **Assembly Name** [text] - Assembly identifier (e.g., toLID)\n3. **Haplotype 1** [fasta] - Primary haplotype assembly (recommended: with H1 suffix added to scaffold names)\n4. **Will you use a second haplotype?** [boolean] - Set to true for diploid assemblies\n5. **Haplotype 2** [fasta, optional] - Secondary haplotype assembly (required if using two haplotypes)\n6. **Related Species** [collection of fasta.gz] - Simple list of gzipped FASTA files of related species genomes for synteny alignment. **Sequence names must be unique across the entire collection** - the workflow performs a duplicate-name check on the merged related-species fastas and will fail early if any sequence name appears in more than one file. A common pattern is to prefix each species' scaffolds with the species name (e.g. `Species_1_scaffold_1`).\n7. **Telomere P** [BED] - P-arm telomere coordinates\n8. **Telomere Q** [BED] - Q-arm telomere coordinates (can be empty)\n9. **Gaps** [BED] - Assembly gap coordinates\n10. **Coverage** [BigWig] - PacBio HiFi read coverage track\n\n### Gene Annotation Options\n\n11. **Do you want to provide gene annotation for your assembly?** [boolean] - Enable to include a gene annotation track in the JBrowse2 instance\n12. **Genes** [GFF, optional] - Gene annotation track (required if gene annotations enabled)\n\n## Outputs\n\n1. **Assembly Info** - Summary of species and assembly name\n2. **JBrowse2 Single Haplotype with related species** [collection] - JBrowse2 instance for a single haplotype with related species alignments (when only one haplotype is used)\n3. **JBrowse2 Single Haplotype with related species and Gene Tracks** [collection] - As above, with gene annotation tracks included\n4. **JBrowse2 Hap1 and hap2 with related species** [collection] - JBrowse2 instance for two haplotypes with related species alignments (when two haplotypes are used)\n5. **JBrowse2 Hap1 and hap2 with related species and gene tracks** [collection] - As above, with gene annotation tracks included\n\n### Additional outputs\n\nThese JBrowse2 instances are produced without the related-species alignment tracks and can be useful for curators who only need the assembly-internal view.\n\n6. **JBrowse2 Single Haplotype** [collection] - JBrowse2 instance for a single haplotype with assembly tracks only (telomeres, gaps, coverage), no related-species alignments\n7. **JBrowse2 Single Haplotype with Gene Track** [collection] - As above, with gene annotation tracks included\n8. **JBrowse2 Hap1 vs Hap2** [collection] - JBrowse2 instance for two haplotypes with the hap1-vs-hap2 alignment, no related-species alignments\n9. **JBrowse2 Hap1 vs Hap2 with gene tracks** [collection] - As above, with gene annotation tracks included\n\n### Validation output\n\n10. **Fail if there are duplicated sequence names between the fasta files** [boolean] - Internal validation flag. The workflow fails fast if any sequence name appears in more than one of the related-species fastas.\n\n## Usage Notes\n\n### Pairing with the Hi-C contact map workflow\n\nThis workflow is designed to consume the precuration track outputs of the [Hi-C contact map for assembly manual curation](../hi-c-contact-map-for-assembly-manual-curation) workflow:\n\n| Hi-C workflow output | Use here as input |\n|---|---|\n| `Decontaminated Hap1 with Suffix` | `Haplotype 1` |\n| `Decontaminated Hap2 with Suffix` | `Haplotype 2` |\n| `P telomeres bed` | `Telomere P` |\n| `Q telomeres Bed` | `Telomere Q` |\n| `Gaps Bed` | `Gaps` |\n| `BigWig Coverage` | `Coverage` |\n| `Compleasm Genes track` | `Genes` |\n\n### Related species selection\n\nChoose related species whose genomes are evolutionarily close to the assembly under curation, so synteny is informative for spotting misassemblies. Provide them as gzipped FASTA files in a simple list collection.\n\n**Sequence names must be unique across the collection.** The workflow validates this and fails fast if duplicates are detected (e.g. two species both contain `>scaffold_1`). Prefix per-species scaffold names before uploading, for example:\n\n```bash\nzcat Species_1.fasta.gz | sed 's/^>/>Species_1_/' | gzip > Species_1_renamed.fasta.gz\n```\n\n### Scaffold name suffixes\n\nIf using two haplotypes, the recommended workflow is to apply per-haplotype suffixes (e.g. `H1`/`H2`) to scaffold names *before* running this workflow, so that scaffolds from each haplotype are unambiguously identified in the JBrowse view and in synteny tracks.\n\n## Citation\n\nIf you use this workflow, please cite:\n- JBrowse2 ([Diesh et al., 2023](https://doi.org/10.1186/s13059-023-02914-z))\n- minimap2 (used for related-species alignment)\n- Other tools as listed in the workflow\n"
+    "uuid": "e0ef6176-aa34-4385-9df3-04077015cdaa",
+    "version": 16,
+    "readme": "# JBrowse2 Precuration Tracks with Related Species Alignments\n\nThis workflow generates JBrowse2 instances with genome assembly tracks and alignments against related species, to assist the manual curation of genome assemblies. It complements the Hi-C contact map workflow by providing a complementary genome browser view of the same precuration tracks alongside synteny with related species.\n\nThe workflow takes the assembly haplotype(s) and the precuration tracks (telomeres, gaps, coverage, optional gene annotations), optionally aligns the assembly against a list of related species, and packages everything into a JBrowse2 instance that curators can open directly in their browser.\n\n## Inputs\n\nThe workflow auto-detects its operating mode from the data you provide \u2014 there are no toggle parameters to set:\n\n- Provide **Haplotype 2** to switch to dual-haplotype mode (includes hap1-vs-hap2 alignment)\n- Provide **Genes** to add a gene annotation track\n- Provide **Related Species** to add synteny alignments against external genomes\n\nEach of the four combinations produces a different JBrowse2 instance (see Outputs).\n\n### Required inputs\n\n1. **Species Name** [text] - Species identifier used in the assembly info report\n2. **Assembly Name** [text] - Assembly identifier (e.g., toLID)\n3. **Haplotype 1** [fasta] - Primary haplotype assembly (recommended: with H1 suffix added to scaffold names)\n4. **Telomere P** [BED] - P-arm telomere coordinates\n5. **Telomere Q** [BED] - Q-arm telomere coordinates (can be empty)\n6. **Gaps** [BED] - Assembly gap coordinates\n7. **Coverage** [BigWig] - PacBio HiFi read coverage track\n\n### Optional inputs\n\n8. **Haplotype 2** [fasta] - Secondary haplotype assembly. Provide for diploid assemblies; leave empty for single-haplotype mode.\n9. **Genes** [GFF3] - Gene annotation track. Provide to add a gene track to every JBrowse2 instance.\n10. **Related Species** [collection of fasta.gz] - Simple list of gzipped FASTA files of related species genomes for synteny alignment. **Sequence names must be unique across the entire collection** - the workflow performs a duplicate-name check on the merged related-species fastas and will fail early if any sequence name appears in more than one file. A common pattern is to prefix each species' scaffolds with the species name (e.g. `Species_1_scaffold_1`). Leave empty to skip related-species alignment entirely.\n\n## Outputs\n\nThe set of populated outputs depends on which optional inputs are provided. Outputs from inactive modes are present in the history but empty.\n\n### Single-haplotype outputs (Haplotype 2 not provided)\n\n1. **JBrowse2 Single Haplotype** [collection] - JBrowse2 instance for one haplotype with assembly tracks only (telomeres, gaps, coverage), no related-species alignments\n2. **JBrowse2 Single Haplotype with Gene Track** [collection] - As above, with gene annotation tracks included (when Genes provided)\n3. **JBrowse2 Single Haplotype with related species** [collection] - JBrowse2 instance for one haplotype with related-species alignments (when Related Species provided)\n4. **JBrowse2 Single Haplotype with related species and Gene Tracks** [collection] - As above, with gene annotation tracks included\n\n### Dual-haplotype outputs (Haplotype 2 provided)\n\n5. **JBrowse2 Hap1 vs Hap2** [collection] - JBrowse2 instance with hap1-vs-hap2 alignment, no related-species alignments\n6. **JBrowse2 Hap1 vs Hap2 with gene tracks** [collection] - As above, with gene annotation tracks included (when Genes provided)\n7. **JBrowse2 Hap1 and hap2 with related species** [collection] - JBrowse2 instance with hap1, hap2, and related-species alignments (when Related Species provided)\n8. **JBrowse2 Hap1 and hap2 with related species and gene tracks** [collection] - As above, with gene annotation tracks included\n\n### Other outputs\n\n9. **Assembly Info** - Summary of species and assembly name\n10. **Fail if there are duplicated sequence names between the fasta files** [boolean] - Internal validation flag. The workflow fails fast if any sequence name appears in more than one of the related-species fastas.\n\n## Usage Notes\n\n### Pairing with the Hi-C contact map workflow\n\nThis workflow is designed to consume the precuration track outputs of the [Hi-C contact map for assembly manual curation](../hi-c-contact-map-for-assembly-manual-curation) workflow:\n\n| Hi-C workflow output | Use here as input |\n|---|---|\n| `Decontaminated Hap1 with Suffix` | `Haplotype 1` |\n| `Decontaminated Hap2 with Suffix` | `Haplotype 2` |\n| `P telomeres bed` | `Telomere P` |\n| `Q telomeres Bed` | `Telomere Q` |\n| `Gaps Bed` | `Gaps` |\n| `BigWig Coverage` | `Coverage` |\n| `Compleasm Genes track` | `Genes` |\n\n### Related species selection\n\nChoose related species whose genomes are evolutionarily close to the assembly under curation, so synteny is informative for spotting misassemblies. Provide them as gzipped FASTA files in a simple list collection.\n\n**Sequence names must be unique across the collection.** The workflow validates this and fails fast if duplicates are detected (e.g. two species both contain `>scaffold_1`). Prefix per-species scaffold names before uploading, for example:\n\n```bash\nzcat Species_1.fasta.gz | sed 's/^>/>Species_1_/' | gzip > Species_1_renamed.fasta.gz\n```\n\n### Scaffold name suffixes\n\nIf using two haplotypes, the recommended workflow is to apply per-haplotype suffixes (e.g. `H1`/`H2`) to scaffold names *before* running this workflow, so that scaffolds from each haplotype are unambiguously identified in the JBrowse view and in synteny tracks.\n\n## Citation\n\nIf you use this workflow, please cite:\n- JBrowse2 ([Diesh et al., 2023](https://doi.org/10.1186/s13059-023-02914-z))\n- minimap2 (used for related-species alignment)\n- Other tools as listed in the workflow\n"
 }

--- a/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/README.md
+++ b/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/README.md
@@ -2,47 +2,55 @@
 
 This workflow generates JBrowse2 instances with genome assembly tracks and alignments against related species, to assist the manual curation of genome assemblies. It complements the Hi-C contact map workflow by providing a complementary genome browser view of the same precuration tracks alongside synteny with related species.
 
-The workflow takes the assembly haplotype(s) and the precuration tracks (telomeres, gaps, coverage, optional gene annotations), aligns the assembly against a list of related species, and packages everything into a JBrowse2 instance that curators can open directly in their browser.
+The workflow takes the assembly haplotype(s) and the precuration tracks (telomeres, gaps, coverage, optional gene annotations), optionally aligns the assembly against a list of related species, and packages everything into a JBrowse2 instance that curators can open directly in their browser.
 
 ## Inputs
 
-### Required Inputs
+The workflow auto-detects its operating mode from the data you provide — there are no toggle parameters to set:
+
+- Provide **Haplotype 2** to switch to dual-haplotype mode (includes hap1-vs-hap2 alignment)
+- Provide **Genes** to add a gene annotation track
+- Provide **Related Species** to add synteny alignments against external genomes
+
+Each of the four combinations produces a different JBrowse2 instance (see Outputs).
+
+### Required inputs
 
 1. **Species Name** [text] - Species identifier used in the assembly info report
 2. **Assembly Name** [text] - Assembly identifier (e.g., toLID)
 3. **Haplotype 1** [fasta] - Primary haplotype assembly (recommended: with H1 suffix added to scaffold names)
-4. **Will you use a second haplotype?** [boolean] - Set to true for diploid assemblies
-5. **Haplotype 2** [fasta, optional] - Secondary haplotype assembly (required if using two haplotypes)
-6. **Related Species** [collection of fasta.gz] - Simple list of gzipped FASTA files of related species genomes for synteny alignment. **Sequence names must be unique across the entire collection** - the workflow performs a duplicate-name check on the merged related-species fastas and will fail early if any sequence name appears in more than one file. A common pattern is to prefix each species' scaffolds with the species name (e.g. `Species_1_scaffold_1`).
-7. **Telomere P** [BED] - P-arm telomere coordinates
-8. **Telomere Q** [BED] - Q-arm telomere coordinates (can be empty)
-9. **Gaps** [BED] - Assembly gap coordinates
-10. **Coverage** [BigWig] - PacBio HiFi read coverage track
+4. **Telomere P** [BED] - P-arm telomere coordinates
+5. **Telomere Q** [BED] - Q-arm telomere coordinates (can be empty)
+6. **Gaps** [BED] - Assembly gap coordinates
+7. **Coverage** [BigWig] - PacBio HiFi read coverage track
 
-### Gene Annotation Options
+### Optional inputs
 
-11. **Do you want to provide gene annotation for your assembly?** [boolean] - Enable to include a gene annotation track in the JBrowse2 instance
-12. **Genes** [GFF, optional] - Gene annotation track (required if gene annotations enabled)
+8. **Haplotype 2** [fasta] - Secondary haplotype assembly. Provide for diploid assemblies; leave empty for single-haplotype mode.
+9. **Genes** [GFF3] - Gene annotation track. Provide to add a gene track to every JBrowse2 instance.
+10. **Related Species** [collection of fasta.gz] - Simple list of gzipped FASTA files of related species genomes for synteny alignment. **Sequence names must be unique across the entire collection** - the workflow performs a duplicate-name check on the merged related-species fastas and will fail early if any sequence name appears in more than one file. A common pattern is to prefix each species' scaffolds with the species name (e.g. `Species_1_scaffold_1`). Leave empty to skip related-species alignment entirely.
 
 ## Outputs
 
-1. **Assembly Info** - Summary of species and assembly name
-2. **JBrowse2 Single Haplotype with related species** [collection] - JBrowse2 instance for a single haplotype with related species alignments (when only one haplotype is used)
-3. **JBrowse2 Single Haplotype with related species and Gene Tracks** [collection] - As above, with gene annotation tracks included
-4. **JBrowse2 Hap1 and hap2 with related species** [collection] - JBrowse2 instance for two haplotypes with related species alignments (when two haplotypes are used)
-5. **JBrowse2 Hap1 and hap2 with related species and gene tracks** [collection] - As above, with gene annotation tracks included
+The set of populated outputs depends on which optional inputs are provided. Outputs from inactive modes are present in the history but empty.
 
-### Additional outputs
+### Single-haplotype outputs (Haplotype 2 not provided)
 
-These JBrowse2 instances are produced without the related-species alignment tracks and can be useful for curators who only need the assembly-internal view.
+1. **JBrowse2 Single Haplotype** [collection] - JBrowse2 instance for one haplotype with assembly tracks only (telomeres, gaps, coverage), no related-species alignments
+2. **JBrowse2 Single Haplotype with Gene Track** [collection] - As above, with gene annotation tracks included (when Genes provided)
+3. **JBrowse2 Single Haplotype with related species** [collection] - JBrowse2 instance for one haplotype with related-species alignments (when Related Species provided)
+4. **JBrowse2 Single Haplotype with related species and Gene Tracks** [collection] - As above, with gene annotation tracks included
 
-6. **JBrowse2 Single Haplotype** [collection] - JBrowse2 instance for a single haplotype with assembly tracks only (telomeres, gaps, coverage), no related-species alignments
-7. **JBrowse2 Single Haplotype with Gene Track** [collection] - As above, with gene annotation tracks included
-8. **JBrowse2 Hap1 vs Hap2** [collection] - JBrowse2 instance for two haplotypes with the hap1-vs-hap2 alignment, no related-species alignments
-9. **JBrowse2 Hap1 vs Hap2 with gene tracks** [collection] - As above, with gene annotation tracks included
+### Dual-haplotype outputs (Haplotype 2 provided)
 
-### Validation output
+5. **JBrowse2 Hap1 vs Hap2** [collection] - JBrowse2 instance with hap1-vs-hap2 alignment, no related-species alignments
+6. **JBrowse2 Hap1 vs Hap2 with gene tracks** [collection] - As above, with gene annotation tracks included (when Genes provided)
+7. **JBrowse2 Hap1 and hap2 with related species** [collection] - JBrowse2 instance with hap1, hap2, and related-species alignments (when Related Species provided)
+8. **JBrowse2 Hap1 and hap2 with related species and gene tracks** [collection] - As above, with gene annotation tracks included
 
+### Other outputs
+
+9. **Assembly Info** - Summary of species and assembly name
 10. **Fail if there are duplicated sequence names between the fasta files** [boolean] - Internal validation flag. The workflow fails fast if any sequence name appears in more than one of the related-species fastas.
 
 ## Usage Notes

--- a/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/README.md
+++ b/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/README.md
@@ -1,0 +1,70 @@
+# JBrowse2 Precuration Tracks with Related Species Alignments
+
+This workflow generates JBrowse2 instances with genome assembly tracks and alignments against related species, to assist the manual curation of genome assemblies. It complements the Hi-C contact map workflow by providing a complementary genome browser view of the same precuration tracks alongside synteny with related species.
+
+The workflow takes the assembly haplotype(s) and the precuration tracks (telomeres, gaps, coverage, optional gene annotations), aligns the assembly against a list of related species, and packages everything into a JBrowse2 instance that curators can open directly in their browser.
+
+## Inputs
+
+### Required Inputs
+
+1. **Species Name** [text] - Species identifier used in the assembly info report
+2. **Assembly Name** [text] - Assembly identifier (e.g., toLID)
+3. **Haplotype 1** [fasta] - Primary haplotype assembly (recommended: with H1 suffix added to scaffold names)
+4. **Will you use a second haplotype?** [boolean] - Set to true for diploid assemblies
+5. **Haplotype 2** [fasta, optional] - Secondary haplotype assembly (required if using two haplotypes)
+6. **Related Species** [collection of fasta.gz] - Simple list of gzipped FASTA files of related species genomes for synteny alignment. **Sequence names must be unique across the entire collection** - the workflow performs a duplicate-name check on the merged related-species fastas and will fail early if any sequence name appears in more than one file. A common pattern is to prefix each species' scaffolds with the species name (e.g. `Species_1_scaffold_1`).
+7. **Telomere P** [BED] - P-arm telomere coordinates
+8. **Telomere Q** [BED] - Q-arm telomere coordinates (can be empty)
+9. **Gaps** [BED] - Assembly gap coordinates
+10. **Coverage** [BigWig] - PacBio HiFi read coverage track
+
+### Gene Annotation Options
+
+11. **Do you want to provide gene annotation for your assembly?** [boolean] - Enable to include a gene annotation track in the JBrowse2 instance
+12. **Genes** [GFF, optional] - Gene annotation track (required if gene annotations enabled)
+
+## Outputs
+
+1. **Assembly Info** - Summary of species and assembly name
+2. **JBrowse2 Single Haplotype with related species** [collection] - JBrowse2 instance for a single haplotype with related species alignments (when only one haplotype is used)
+3. **JBrowse2 Single Haplotype with related species and Gene Tracks** [collection] - As above, with gene annotation tracks included
+4. **JBrowse2 Hap1 and hap2 with related species** [collection] - JBrowse2 instance for two haplotypes with related species alignments (when two haplotypes are used)
+5. **JBrowse2 Hap1 and hap2 with related species and gene tracks** [collection] - As above, with gene annotation tracks included
+
+## Usage Notes
+
+### Pairing with the Hi-C contact map workflow
+
+This workflow is designed to consume the precuration track outputs of the [Hi-C contact map for assembly manual curation](../hi-c-contact-map-for-assembly-manual-curation) workflow:
+
+| Hi-C workflow output | Use here as input |
+|---|---|
+| `Decontaminated Hap1 with Suffix` | `Haplotype 1` |
+| `Decontaminated Hap2 with Suffix` | `Haplotype 2` |
+| `P telomeres bed` | `Telomere P` |
+| `Q telomeres Bed` | `Telomere Q` |
+| `Gaps Bed` | `Gaps` |
+| `BigWig Coverage` | `Coverage` |
+| `Compleasm Genes track` | `Genes` |
+
+### Related species selection
+
+Choose related species whose genomes are evolutionarily close to the assembly under curation, so synteny is informative for spotting misassemblies. Provide them as gzipped FASTA files in a simple list collection.
+
+**Sequence names must be unique across the collection.** The workflow validates this and fails fast if duplicates are detected (e.g. two species both contain `>scaffold_1`). Prefix per-species scaffold names before uploading, for example:
+
+```bash
+zcat Species_1.fasta.gz | sed 's/^>/>Species_1_/' | gzip > Species_1_renamed.fasta.gz
+```
+
+### Scaffold name suffixes
+
+If using two haplotypes, the recommended workflow is to apply per-haplotype suffixes (e.g. `H1`/`H2`) to scaffold names *before* running this workflow, so that scaffolds from each haplotype are unambiguously identified in the JBrowse view and in synteny tracks.
+
+## Citation
+
+If you use this workflow, please cite:
+- JBrowse2 ([Diesh et al., 2023](https://doi.org/10.1186/s13059-023-02914-z))
+- minimap2 (used for related-species alignment)
+- Other tools as listed in the workflow

--- a/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/README.md
+++ b/workflows/VGP-assembly-v2/Precuration-Jbrowse-tracks-alignments/README.md
@@ -32,6 +32,19 @@ The workflow takes the assembly haplotype(s) and the precuration tracks (telomer
 4. **JBrowse2 Hap1 and hap2 with related species** [collection] - JBrowse2 instance for two haplotypes with related species alignments (when two haplotypes are used)
 5. **JBrowse2 Hap1 and hap2 with related species and gene tracks** [collection] - As above, with gene annotation tracks included
 
+### Additional outputs
+
+These JBrowse2 instances are produced without the related-species alignment tracks and can be useful for curators who only need the assembly-internal view.
+
+6. **JBrowse2 Single Haplotype** [collection] - JBrowse2 instance for a single haplotype with assembly tracks only (telomeres, gaps, coverage), no related-species alignments
+7. **JBrowse2 Single Haplotype with Gene Track** [collection] - As above, with gene annotation tracks included
+8. **JBrowse2 Hap1 vs Hap2** [collection] - JBrowse2 instance for two haplotypes with the hap1-vs-hap2 alignment, no related-species alignments
+9. **JBrowse2 Hap1 vs Hap2 with gene tracks** [collection] - As above, with gene annotation tracks included
+
+### Validation output
+
+10. **Fail if there are duplicated sequence names between the fasta files** [boolean] - Internal validation flag. The workflow fails fast if any sequence name appears in more than one of the related-species fastas.
+
 ## Usage Notes
 
 ### Pairing with the Hi-C contact map workflow


### PR DESCRIPTION

FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
