### PR TITLE
fastq-to-matrix-10x-v3: hardcode soloBarcodeReadLength=0 for v3 chemistry

### DIFF
--- a/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-v3-tests.yml
+++ b/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-v3-tests.yml
@@ -23,7 +23,6 @@
           - hash_function: SHA-1
             hash_value: bba127e369535d226290a74858efafd7f359168e
     reference genome: dm6
-    Barcode Size is same size of the Read: false
     gtf:
       class: File
       location: https://zenodo.org/record/6457007/files/Drosophila_melanogaster.BDGP6.32.109_UCSC.gtf.gz

--- a/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-v3.ga
+++ b/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-v3.ga
@@ -141,33 +141,6 @@
             "when": null,
             "workflow_outputs": []
         },
-        "4": {
-            "annotation": "Barcode Size is same size of the Read",
-            "content_id": null,
-            "errors": null,
-            "id": 4,
-            "input_connections": {},
-            "inputs": [
-                {
-                    "description": "Barcode Size is same size of the Read",
-                    "name": "Barcode Size is same size of the Read"
-                }
-            ],
-            "label": "Barcode Size is same size of the Read",
-            "name": "Input parameter",
-            "outputs": [],
-            "position": {
-                "left": 260.683349609375,
-                "top": 414.5
-            },
-            "tool_id": null,
-            "tool_state": "{\"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
-            "tool_version": null,
-            "type": "parameter_input",
-            "uuid": "a9d14d27-ca59-444d-9fe1-485b3354b9a7",
-            "when": null,
-            "workflow_outputs": []
-        },
         "5": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/rna_starsolo/rna_starsolo/2.7.11b+galaxy0",
@@ -186,20 +159,12 @@
                     "id": 0,
                     "output_name": "output"
                 },
-                "sc|soloBarcodeReadLength": {
-                    "id": 4,
-                    "output_name": "output"
-                },
                 "sc|soloCBwhitelist": {
                     "id": 3,
                     "output_name": "output"
                 }
             },
             "inputs": [
-                {
-                    "description": "runtime parameter for tool RNA STARSolo",
-                    "name": "sc"
-                },
                 {
                     "description": "runtime parameter for tool RNA STARSolo",
                     "name": "sc"
@@ -285,7 +250,7 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"algo\": {\"params\": {\"settingsType\": \"default\", \"__current_case__\": 0}}, \"chimOutType\": \"\", \"outWig\": {\"outWigType\": \"None\", \"__current_case__\": 0, \"outWigStrand\": \"false\"}, \"refGenomeSource\": {\"geneSource\": \"indexed\", \"__current_case__\": 0, \"GTFconditional\": {\"GTFselect\": \"without-gtf-with-gtf\", \"__current_case__\": 1, \"genomeDir\": {\"__class__\": \"ConnectedValue\"}, \"sjdbGTFfile\": {\"__class__\": \"ConnectedValue\"}, \"sjdbGTFfeatureExon\": \"exon\", \"sjdbOverhang\": \"100\"}}, \"sc\": {\"solo_type\": \"CB_UMI_Simple\", \"__current_case__\": 0, \"input_types\": {\"use\": \"list_paired\", \"__current_case__\": 1, \"input_collection\": {\"__class__\": \"ConnectedValue\"}}, \"soloCBwhitelist\": {\"__class__\": \"ConnectedValue\"}, \"params\": {\"chemistry\": \"Cv3\", \"__current_case__\": 1}, \"soloBarcodeReadLength\": {\"__class__\": \"ConnectedValue\"}, \"umidedup\": {\"soloUMIdedup\": \"1MM_CR\", \"__current_case__\": 4, \"soloUMIfiltering\": \"-\"}, \"soloCBmatchWLtype\": \"1MM_multi\"}, \"solo\": {\"soloStrand\": \"Forward\", \"soloFeatures\": \"Gene\", \"wasp_conditional\": {\"waspOutputMode\": \"\", \"__current_case__\": 1}, \"filter\": {\"filter_type\": \"no_filter\", \"__current_case__\": 3, \"output_raw\": \"true\"}, \"soloOutFormatFeaturesGeneField3\": \"Gene Expression\", \"outSAMattributes\": [\"NH\", \"HI\", \"AS\", \"nM\", \"GX\", \"GN\", \"CB\", \"UB\"], \"quantModeGene\": true, \"outSAMunmapped\": false, \"outSAMmapqUnique\": \"60\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"algo\": {\"params\": {\"settingsType\": \"default\", \"__current_case__\": 0}}, \"chimOutType\": \"\", \"outWig\": {\"outWigType\": \"None\", \"__current_case__\": 0, \"outWigStrand\": \"false\"}, \"refGenomeSource\": {\"geneSource\": \"indexed\", \"__current_case__\": 0, \"GTFconditional\": {\"GTFselect\": \"without-gtf-with-gtf\", \"__current_case__\": 1, \"genomeDir\": {\"__class__\": \"ConnectedValue\"}, \"sjdbGTFfile\": {\"__class__\": \"ConnectedValue\"}, \"sjdbGTFfeatureExon\": \"exon\", \"sjdbOverhang\": \"100\"}}, \"sc\": {\"solo_type\": \"CB_UMI_Simple\", \"__current_case__\": 0, \"input_types\": {\"use\": \"list_paired\", \"__current_case__\": 1, \"input_collection\": {\"__class__\": \"ConnectedValue\"}}, \"soloCBwhitelist\": {\"__class__\": \"ConnectedValue\"}, \"params\": {\"chemistry\": \"Cv3\", \"__current_case__\": 1}, \"soloBarcodeReadLength\": \"0\", \"umidedup\": {\"soloUMIdedup\": \"1MM_CR\", \"__current_case__\": 4, \"soloUMIfiltering\": \"-\"}, \"soloCBmatchWLtype\": \"1MM_multi\"}, \"solo\": {\"soloStrand\": \"Forward\", \"soloFeatures\": \"Gene\", \"wasp_conditional\": {\"waspOutputMode\": \"\", \"__current_case__\": 1}, \"filter\": {\"filter_type\": \"no_filter\", \"__current_case__\": 3, \"output_raw\": \"true\"}, \"soloOutFormatFeaturesGeneField3\": \"Gene Expression\", \"outSAMattributes\": [\"NH\", \"HI\", \"AS\", \"nM\", \"GX\", \"GN\", \"CB\", \"UB\"], \"quantModeGene\": true, \"outSAMunmapped\": false, \"outSAMmapqUnique\": \"60\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "2.7.11b+galaxy0",
             "type": "tool",


### PR DESCRIPTION
## Problem

The `fastq-to-matrix-10x-v3` workflow exposes `soloBarcodeReadLength` as a user-facing boolean parameter (step 4, "Barcode Size is same size of the Read"). For all standard 10x v3 libraries the barcode does not occupy the full read length, so this must always be `0` (disabled).

In practice the `ConnectedValue` routing does not reliably deliver the user's selection to STARsolo. During testing, both `true` and `false` UI settings produced identical, incorrect output: STARsolo log showed `Solo: CB 17bp` instead of `Solo: CB 16bp`, meaning barcode detection was wrong regardless of what the user selected. Direct STARsolo tool runs with `soloBarcodeReadLength=0` produced correct output.

The test YAML explicitly passes `Barcode Size is same size of the Read: false`, which is why CI passes, but interactive users reliably hit the bug.

## Fix

- Remove the `parameter_input` step entirely (step 4)
- Remove the `sc|soloBarcodeReadLength` connection from the STARsolo step
- Hardcode `"soloBarcodeReadLength": "0"` directly in the STARsolo `tool_state`
- Remove the now-nonexistent parameter from the test YAML

This approach is unambiguous: `soloBarcodeReadLength` is always `0` for v3 chemistry and there is no reason to expose it as a user-adjustable parameter in a workflow named for v3.

## Evidence

Reanalysis of Wang et al. 2024 (*Aedes aegypti* midgut scRNA-seq, GEO GSE246612) on usegalaxy.org. Workflow invocations `a9a0b6a0f307171b` (step 4 = true) and `983ee63c0b6a234a` (step 4 = false) both failed identically with `Solo: CB 17bp`.

## Testing

Existing test YAML updated to remove the deleted parameter. Test assertions are unchanged; expected outputs are unchanged since the correct value (`0`) was already being passed in the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)