### PR TITLE
Enable testing against external instances

### DIFF
--- a/.github/workflows/test_workflows.yml
+++ b/.github/workflows/test_workflows.yml
@@ -66,6 +66,9 @@ jobs:
         ports:
           - 5432:5432
     steps:
+    - name: Debug environment
+      run: |
+          echo "${{ inputs.galaxy-user-key-environment }}"
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1

--- a/.github/workflows/test_workflows.yml
+++ b/.github/workflows/test_workflows.yml
@@ -41,6 +41,11 @@ on:
         default: false
         required: false
         type: boolean
+      galaxy-user-key:
+        description: Galaxy user key
+        default: ''
+        required: false
+        type: string
 jobs:
   test:
     name: Test workflows
@@ -86,6 +91,7 @@ jobs:
         galaxy-branch: ${{ inputs.galaxy-branch }}
         chunk: ${{ matrix.chunk }}
         chunk-count: ${{ inputs.chunk-count }}
+        galaxy-user-key: ${{ inputs.galaxy-user-key }}
     - uses: actions/upload-artifact@v4
       with:
         name: 'Workflow test output ${{ matrix.chunk }}'

--- a/.github/workflows/test_workflows.yml
+++ b/.github/workflows/test_workflows.yml
@@ -41,8 +41,8 @@ on:
         default: false
         required: false
         type: boolean
-      galaxy-user-key:
-        description: Galaxy user key
+      galaxy-user-key-environment:
+        description: 'name of the protected environment holding GALAXY_USER_KEY (empty = none)'
         default: ''
         required: false
         type: string
@@ -50,6 +50,7 @@ jobs:
   test:
     name: Test workflows
     runs-on: ubuntu-latest
+    environment: ${{ inputs.galaxy-user-key-environment }}
     strategy:
       fail-fast: false
       matrix:
@@ -91,7 +92,7 @@ jobs:
         galaxy-branch: ${{ inputs.galaxy-branch }}
         chunk: ${{ matrix.chunk }}
         chunk-count: ${{ inputs.chunk-count }}
-        galaxy-user-key: ${{ inputs.galaxy-user-key }}
+        galaxy-user-key: ${{ secrets.GALAXY_USER_KEY }}
     - uses: actions/upload-artifact@v4
       with:
         name: 'Workflow test output ${{ matrix.chunk }}'

--- a/.github/workflows/workflow_test.yml
+++ b/.github/workflows/workflow_test.yml
@@ -83,7 +83,6 @@ jobs:
     name: Test workflows (with secret)
     needs: [setup, detect_secret]
     if: ${{ needs.detect_secret.outputs.use_secret == 'true' && needs.setup.outputs.repository-list != '' }}
-    environment: secret-env   # protected environment containing GALAXY_USER_KEY
     uses: ./.github/workflows/test_workflows.yml
     with:
       galaxy-head-sha: ${{ needs.setup.outputs.galaxy-head-sha }}
@@ -94,7 +93,7 @@ jobs:
       galaxy-fork: galaxyproject
       galaxy-branch: release_25.0
       check-outputs: false
-      # galaxy-user-key: ${{ secrets.GALAXY_USER_KEY }}
+      galaxy-user-key-environment: secret-env
 
   # Test job for PRs that do not need the secret
   test_regular:

--- a/.github/workflows/workflow_test.yml
+++ b/.github/workflows/workflow_test.yml
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 1
       - id: check
         run: |
-          echo "environment=None" >> $GITHUB_OUTPUT
+          echo "environment=" >> $GITHUB_OUTPUT
           for repo in $(echo "${{ needs.setup.outputs.repository-list }}" | tr ',' '\n'); do
             if [[ -f "$repo/.wt_instance" ]]; then
               echo "Found $repo/.wt_instance"

--- a/.github/workflows/workflow_test.yml
+++ b/.github/workflows/workflow_test.yml
@@ -57,10 +57,50 @@ jobs:
         repository-list: "${{ needs.setup.outputs.repository-list }}"
         additional-planemo-options: --iwc
 
-  test:
-    name: Test workflows
+  # Detect if any changed repo contains a .wt_instance file
+  detect_secret:
+    name: Detect secret requirement
     needs: setup
-    if: needs.setup.outputs.repository-list != ''
+    runs-on: ubuntu-latest
+    outputs:
+      use_secret: ${{ steps.check.outputs.use_secret }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - id: check
+        run: |
+          echo "use_secret=false" >> $GITHUB_OUTPUT
+          for repo in $(echo "${{ needs.setup.outputs.repository-list }}" | tr ',' '\n'); do
+            if [[ -f "$repo/.wt_instance" ]]; then
+              echo "use_secret=true" >> $GITHUB_OUTPUT
+              break
+            fi
+          done
+
+  # Test job that requires the secret (runs only when .wt_instance present)
+  test_secret:
+    name: Test workflows (with secret)
+    needs: [setup, detect_secret]
+    if: ${{ needs.detect_secret.outputs.use_secret == 'true' && needs.setup.outputs.repository-list != '' }}
+    environment: secret-env   # protected environment containing GALAXY_USER_KEY
+    uses: ./.github/workflows/test_workflows.yml
+    with:
+      galaxy-head-sha: ${{ needs.setup.outputs.galaxy-head-sha }}
+      chunk-count: ${{ fromJSON(needs.setup.outputs.chunk-count) }}
+      chunk-list: ${{ needs.setup.outputs.chunk-list }}
+      python-version-list: "[\"3.11\"]"
+      repository-list: ${{ needs.setup.outputs.repository-list }}
+      galaxy-fork: galaxyproject
+      galaxy-branch: release_25.0
+      check-outputs: false
+      # galaxy-user-key: ${{ secrets.GALAXY_USER_KEY }}
+
+  # Test job for PRs that do not need the secret
+  test_regular:
+    name: Test workflows (no secret)
+    needs: [setup, detect_secret]
+    if: ${{ needs.detect_secret.outputs.use_secret != 'true' && needs.setup.outputs.repository-list != '' }}
     uses: ./.github/workflows/test_workflows.yml
     with:
       galaxy-head-sha: ${{ needs.setup.outputs.galaxy-head-sha }}
@@ -75,7 +115,8 @@ jobs:
   combine_outputs:
     # same as tool step
     name: Combine chunked test results
-    needs: [setup, test]
+    needs: [setup, test_secret, test_regular]
+    if: always()
     strategy:
       matrix:
         python-version: ['3.11']
@@ -119,7 +160,7 @@ jobs:
   # deploy workflows to organization
   deploy:
     name: Deploy
-    needs: [setup,test,combine_outputs]
+    needs: [setup,test_secret,test_regular,combine_outputs]
     strategy:
       matrix:
         python-version: ['3.11']

--- a/.github/workflows/workflow_test.yml
+++ b/.github/workflows/workflow_test.yml
@@ -58,31 +58,34 @@ jobs:
         additional-planemo-options: --iwc
 
   # Detect if any changed repo contains a .wt_instance file
-  detect_secret:
-    name: Detect secret requirement
+  # and set environment to 'secret-env' (if there is such a file)
+  # or None (otherwise) 
+  determine_env:
+    name: Determine github environment to use
     needs: setup
     runs-on: ubuntu-latest
     outputs:
-      use_secret: ${{ steps.check.outputs.use_secret }}
+      environment: ${{ steps.check.outputs.environment }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - id: check
         run: |
-          echo "use_secret=false" >> $GITHUB_OUTPUT
+          echo "environment=None" >> $GITHUB_OUTPUT
           for repo in $(echo "${{ needs.setup.outputs.repository-list }}" | tr ',' '\n'); do
             if [[ -f "$repo/.wt_instance" ]]; then
-              echo "use_secret=true" >> $GITHUB_OUTPUT
+              echo "Found $repo/.wt_instance"
+              echo "environment=secret-env" >> $GITHUB_OUTPUT
               break
             fi
           done
+          echo "Will use $(cat $GITHUB_OUTPUT)"
 
-  # Test job that requires the secret (runs only when .wt_instance present)
-  test_secret:
-    name: Test workflows (with secret)
-    needs: [setup, detect_secret]
-    if: ${{ needs.detect_secret.outputs.use_secret == 'true' && needs.setup.outputs.repository-list != '' }}
+  test:
+    name: Test workflows
+    needs: [setup, determine_env]
+    if: ${{ needs.setup.outputs.repository-list != '' }}
     uses: ./.github/workflows/test_workflows.yml
     with:
       galaxy-head-sha: ${{ needs.setup.outputs.galaxy-head-sha }}
@@ -93,29 +96,13 @@ jobs:
       galaxy-fork: galaxyproject
       galaxy-branch: release_25.0
       check-outputs: false
-      galaxy-user-key-environment: secret-env
+      galaxy-user-key-environment: ${{ needs.determine_env.outputs.environment }}
     secrets: inherit
-
-  # Test job for PRs that do not need the secret
-  test_regular:
-    name: Test workflows (no secret)
-    needs: [setup, detect_secret]
-    if: ${{ needs.detect_secret.outputs.use_secret != 'true' && needs.setup.outputs.repository-list != '' }}
-    uses: ./.github/workflows/test_workflows.yml
-    with:
-      galaxy-head-sha: ${{ needs.setup.outputs.galaxy-head-sha }}
-      chunk-count: ${{ fromJSON(needs.setup.outputs.chunk-count) }}
-      chunk-list: ${{ needs.setup.outputs.chunk-list }}
-      python-version-list: "[\"3.11\"]"
-      repository-list: ${{ needs.setup.outputs.repository-list }}
-      galaxy-fork: galaxyproject
-      galaxy-branch: release_25.1
-      check-outputs: false
 
   combine_outputs:
     # same as tool step
     name: Combine chunked test results
-    needs: [setup, test_secret, test_regular]
+    needs: [setup, test]
     if: always()
     strategy:
       matrix:
@@ -160,7 +147,7 @@ jobs:
   # deploy workflows to organization
   deploy:
     name: Deploy
-    needs: [setup,test_secret,test_regular,combine_outputs]
+    needs: [setup,test,combine_outputs]
     strategy:
       matrix:
         python-version: ['3.11']

--- a/.github/workflows/workflow_test.yml
+++ b/.github/workflows/workflow_test.yml
@@ -94,6 +94,7 @@ jobs:
       galaxy-branch: release_25.0
       check-outputs: false
       galaxy-user-key-environment: secret-env
+    secrets: inherit
 
   # Test job for PRs that do not need the secret
   test_regular:


### PR DESCRIPTION
Split testing job in the PR workflow into two parts: 

1. test against planemo instance in github actions (as before) OR
2. test against external instance (using an environment secret) if there is a `.wt_instance` with content `usegalaxy.org` (currently we test only against org)

In the 2nd case the workflow (or more precisely the test job) needs approval to access the environment by a configurable set of persons. 

Therefore we adapted:

- [test_workflows.yml](https://github.com/galaxyproject/iwc/pull/1264/changes#diff-370af6548ccb6ed6ddb40383f7891a9e1491bb027fc8734783991e468c524201) to use a secret (optionally from an environment)
- this should automatically be used in the scheduled CI jobs running in the separate workflow repos (**each needs to setup the secret**)
- The PR CI workflow_test.yml needs an extra step to check which job to run (with / without secret).


FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [x] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
