### PR TITLE
Convert duplicate-keyed asserts blocks to list form (passing subset)

### DIFF
--- a/workflows/bacterial_genomics/bacterial-quality-and-contamination-control-post-assembly/bacterial_quality_and_contamination_control_post_assembly-tests.yml
+++ b/workflows/bacterial_genomics/bacterial-quality-and-contamination-control-post-assembly/bacterial_quality_and_contamination_control_post_assembly-tests.yml
@@ -28,10 +28,10 @@
           n: 6
     Kraken2 sequence assignation:
       asserts:
-        has_text:
+        - that: has_text
           text: "contig00001"
-        has_text:
-          text: "contig00359"          
+        - that: has_text
+          text: "contig00359"
     Kraken2 tabular report:
       asserts:
         has_text:
@@ -56,9 +56,9 @@
       element_tests:
         E-coli3_S194.fasta:
           asserts:
-            has_text:
+            - that: has_text
               text: ">contig00001_1"
-            has_text:
+            - that: has_text
               text: ">contig00358_1"
     Tooldistillator summarize control:
       asserts:

--- a/workflows/genome-assembly/quality-and-contamination-control-raw-reads/quality_and_contamination_control_raw_reads-tests.yml
+++ b/workflows/genome-assembly/quality-and-contamination-control-raw-reads/quality_and_contamination_control_raw_reads-tests.yml
@@ -12,9 +12,9 @@
   outputs:
     fastp_report_json:
       asserts:
-        has_text:
+        - that: has_text
           text: "fastp_version"
-        has_text:
+        - that: has_text
           text: "read2_before_filtering"
     kraken_report_tabular:
       asserts:

--- a/workflows/microbiome/host-contamination-removal/host-contamination-removal-long-reads/host-or-contamination-removal-on-long-reads-tests.yml
+++ b/workflows/microbiome/host-contamination-removal/host-contamination-removal-long-reads/host-or-contamination-removal-on-long-reads-tests.yml
@@ -21,9 +21,9 @@
           elements:
             genome_results:
               asserts:
-                has_text:
+                - that: has_text
                   text: "Spike3bBarcode10"
-                has_text:
+                - that: has_text
                   text: "586,300,787 bp"
             coverage_across_reference:
               asserts:
@@ -45,15 +45,15 @@
                   value: 51
             duplication_rate_histogram:
               asserts:
-                has_text:
+                - that: has_text
                   text: "#Duplication rate"
-                has_text:
+                - that: has_text
                   text: "17.0"
             homopolymer_indels:
               asserts:
-                has_text:
+                - that: has_text
                   text: "#Type of indel"
-                has_text:
+                - that: has_text
                   text: "polyN"
             insert_size_across_reference:
               asserts:
@@ -65,9 +65,9 @@
                   value: 0
             mapped_reads_clipping_profile:
               asserts:
-                has_text:
+                - that: has_text
                   text: "#Read position (bp)"
-                has_text:
+                - that: has_text
                   text: "38.123"
             mapped_reads_gc-content_distribution:
               asserts:
@@ -95,9 +95,9 @@
           elements:
             genome_results:
               asserts:
-                has_text:
+                - that: has_text
                   text: "Spike3bBarcode12"
-                has_text:
+                - that: has_text
                   text: "586,300,787 bp"
             coverage_across_reference:
               asserts:
@@ -119,15 +119,15 @@
                   value: 51
             duplication_rate_histogram:
               asserts:
-                has_text:
+                - that: has_text
                   text: "#Duplication rate"
-                has_text:
+                - that: has_text
                   text: "8.0"
             homopolymer_indels:
               asserts:
-                has_text:
+                - that: has_text
                   text: "#Type of indel"
-                has_text:
+                - that: has_text
                   text: "polyN"
             insert_size_across_reference:
               asserts:
@@ -139,9 +139,9 @@
                   value: 0
             mapped_reads_clipping_profile:
               asserts:
-                has_text:
+                - that: has_text
                   text: "#Read position (bp)"
-                has_text:
+                - that: has_text
                   text: "0.03930972"
             mapped_reads_gc-content_distribution:
               asserts:
@@ -167,9 +167,9 @@
                   value: 4
     MultiQC HTML Report:
       asserts:
-        has_text:
+        - that: has_text
           text: "Spike3bBarcode10"
-        has_text:
+        - that: has_text
           text: "Spike3bBarcode12"
     Reads without Host or Contamination:
       element_tests:

--- a/workflows/read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml
+++ b/workflows/read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml
@@ -24,19 +24,19 @@
   outputs:
     MultiQC HTML report:
       asserts:
-        has_text:
+        - that: has_text
           text: "Filtered Reads"
-        has_text:
+        - that: has_text
           text: "pair"
     fastp JSON report:
       element_tests:
         pair:
           asserts:
-            has_text:
+            - that: has_text
               text: "paired end (301 cycles + 301 cycles)"
-            has_text:
+            - that: has_text
               text: "300000"
-            has_text:
+            - that: has_text
               text: "295680"
-            has_text:
+            - that: has_text
               text: "59230948"

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation-tests.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation-tests.yml
@@ -32,11 +32,11 @@
       element_tests:
         SRR11578257:
           asserts:
-            has_line:
+            - that: has_line
               line: "##fileformat=VCFv4.0"
-            has_line:
+            - that: has_line
               line: "#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO"
-            has_text_matching:
+            - that: has_text_matching
               expression: "NC_045512.2\t174\t.\tG\tC\t[0-9]*\tPASS"
-            has_text_matching:
+            - that: has_text_matching
               expression: "NC_045512.2\t20209\t.\tAGTAGAAATT\tA\t[0-9]*\tPASS\tDP=[0-9]*;AF=0.9[0-9]*;SB=24;DP4=[0-9]*,[0-9]*,[0-9]*,[0-9]*;INDEL;HRUN=1;EFF=CODON_CHANGE_PLUS_CODON_DELETION\\(MODERATE||agtagaaattta/ata|SRNL6649I|7096|ORF1ab|protein_coding|CODING|GU280_gp01|2|A\\),CODON_CHANGE_PLUS_CODON_DELETION\\(MODERATE||agtagaaattta/ata|SRNL197I|345|ORF1ab|protein_coding|CODING|YP_009725310.1|1|A|WARNING_TRANSCRIPT_NO_START_CODON\\)"

--- a/workflows/variant-calling/ploidy-aware-genotype-calling/genotype-variant-calling-wgs-pe-test.yml
+++ b/workflows/variant-calling/ploidy-aware-genotype-calling/genotype-variant-calling-wgs-pe-test.yml
@@ -40,18 +40,18 @@
 
     SnpEff variants:
       asserts:
-        has_text:
+        - that: has_text
           text: "##fileformat=VCFv4.2"
-        has_text:
+        - that: has_text
           text: "##contig=<ID=chr1,length=2000>"
-        has_n_lines:
+        - that: has_n_lines
           n: 71
 
     SnpEff eff reports:
       asserts:
-        has_text:
+        - that: has_text
           text: "<td valign=top> <b> Number of variants processed <br> (i.e. after filter and non-variants) </b> </td>"
-        has_text:
+        - that: has_text
           text: "<td> 2 </td>"
 
     Annotated Variants:


### PR DESCRIPTION
> _Opened by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally._

## Summary

YAML silently collapses duplicate mapping keys, so `asserts:` blocks that repeat an assertion type (`has_text:`, `has_line:`, `has_text_matching:`) only ran the **last** assertion per type — every earlier assertion was silently dropped by the loader and never executed. This converts the affected workflow-tests files to list form so every assertion runs:

```yaml
# Before — second has_text: overwrites first, "gene" assertion never ran
asserts:
  has_text:
    text: "gene"
  has_text:
    text: "BUSTED"

# After — both run
asserts:
  - that: has_text
    text: "gene"
  - that: has_text
    text: "BUSTED"
```

Successor to closed #1217, reduced to the files whose tests are **genuinely green** with this change. Files whose tests fail/error are split into their own PRs.

## Files (6)

- `bacterial_quality_and_contamination_control_post_assembly-tests.yml`
- `quality_and_contamination_control_raw_reads-tests.yml`
- `host-or-contamination-removal-on-long-reads-tests.yml`
- `short-read-quality-control-and-trimming-tests.yml`
- `pe-artic-variation-tests.yml`
- `genotype-variant-calling-wgs-pe-test.yml`

## Split out

- **#1276** — bacterial-genome-assembly (a resurrected assertion was wrong; fixed there)
- **#1277** — se-wgs-variation: removed from this set because it currently errors on a pre-existing `bcftools concat` SIGSEGV (unrelated to the assertion conversion). IWC only tests changed workflows, so touching that file merely surfaced the crash.

## How this was found

Galaxy's new `gxwf validate-tests` validator swept IWC workflow-tests against the Pydantic `Tests` model; `ordered_load` raises on duplicate mapping keys (per YAML 1.2), surfacing these authoring bugs.

FOR CONTRIBUTOR:
* [x] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [x] License permits unrestricted use (educational + commercial)
