### PR TITLE
bacterial-genome-assembly: convert asserts to list form and fix resurrected assertion

### DIFF
--- a/workflows/genome-assembly/bacterial-genome-assembly/bacterial_genome_assembly-tests.yml
+++ b/workflows/genome-assembly/bacterial-genome-assembly/bacterial_genome_assembly-tests.yml
@@ -29,7 +29,7 @@
           n: 2
     tooldistillator_summarize_assembly:
       asserts:
-        has_text:
+        - that: has_text
           text: "\"Assembly\": \"shovill_contigs_fasta\""
-        has_text:
+        - that: has_text
           text: "contig00146"

--- a/workflows/genome-assembly/bacterial-genome-assembly/bacterial_genome_assembly-tests.yml
+++ b/workflows/genome-assembly/bacterial-genome-assembly/bacterial_genome_assembly-tests.yml
@@ -30,6 +30,6 @@
     tooldistillator_summarize_assembly:
       asserts:
         - that: has_text
-          text: "\"Assembly\": \"shovill_contigs_fasta\""
+          text: "\"analysis_software_name\": \"shovill\""
         - that: has_text
           text: "contig00146"


### PR DESCRIPTION
> _Opened by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally._

## Summary

Convert the `tooldistillator_summarize_assembly` `asserts:` block to list form **and** fix the assertion that this exposed.

The `"Assembly": "shovill_contigs_fasta"` assertion never actually ran: it was authored (wf 1.1.9, `0925cf747`) as a duplicate `has_text:` mapping key stacked above `has_text: contig00146`. YAML collapses duplicate mapping keys (last wins), so only `contig00146` was ever evaluated — the Assembly assertion was dead from the day it was written and never validated. Converting to list form ran it for the first time and it failed: tooldistillator's JSON has no `Assembly` key and no `shovill_contigs_fasta` value.

**Fix:** replace it with a substring that is actually present and preserves the intent (confirm the summary is of the shovill assembly): `"analysis_software_name": "shovill"`. `contig00146` is genuinely in the output and is kept.

## Caveat / possible follow-up

`has_text` substring matching over a serialized JSON document is a fragile way to validate structured output — it silently depends on key ordering and whitespace and asserts nothing structural. A follow-up could migrate these to a proper JSON-property assertion.

Split from the passing-subset PR; belongs on its own because it changes an assertion's meaning, not just its form.
