### PR TITLE
capheine-core-and-compare: convert asserts to list form + relocate misplaced MEME assert

### DIFF
--- a/workflows/comparative_genomics/hyphy/capheine-core-and-compare-tests.yml
+++ b/workflows/comparative_genomics/hyphy/capheine-core-and-compare-tests.yml
@@ -35,17 +35,17 @@
   outputs:
     combined_summary:
       asserts:
-        has_text:
+        - that: has_text
           text: "gene"
-        has_text:
+        - that: has_text
           text: "BUSTED"
-        has_text:
+        - that: has_text
           text: "MEME"
-        has_text:
+        - that: has_text
           text: "pval"
-        has_text:
+        - that: has_text
           text: "omega"
-        has_n_columns:
+        - that: has_n_columns
           n: 9
 
 - doc: Test CAPHEINE with reference CDS, unaligned sequences, and regex (no foreground list)
@@ -86,29 +86,29 @@
   outputs:
     combined_summary:
       asserts:
-        has_text:
+        - that: has_text
           text: "gene"
-        has_text:
+        - that: has_text
           text: "BUSTED"
-        has_text:
+        - that: has_text
           text: "MEME"
-        has_text:
+        - that: has_text
           text: "RELAX"
-        has_text:
+        - that: has_text
           text: "pval"
-        has_n_columns:
+        - that: has_n_columns
           n: 12
     combined_comparison_summary:
       asserts:
-        has_text:
+        - that: has_text
           text: "gene"
-        has_text:
+        - that: has_text
           text: "comparison_group"
-        has_text:
+        - that: has_text
           text: "Foreground"
-        has_text:
+        - that: has_text
           text: "Reference"
-        has_n_columns:
+        - that: has_n_columns
           n: 6
 
 - doc: Test CAPHEINE with reference CDS, unaligned sequences, and foreground list (no regex)
@@ -153,29 +153,29 @@
   outputs:
     combined_summary:
       asserts:
-        has_text:
+        - that: has_text
           text: "gene"
-        has_text:
+        - that: has_text
           text: "BUSTED"
-        has_text:
+        - that: has_text
           text: "MEME"
-        has_text:
+        - that: has_text
           text: "RELAX"
-        has_text:
+        - that: has_text
           text: "pval"
-        has_n_columns:
+        - that: has_n_columns
           n: 12
     combined_comparison_summary:
       asserts:
-        has_text:
+        - that: has_text
           text: "gene"
-        has_text:
+        - that: has_text
           text: "comparison_group"
-        has_text:
+        - that: has_text
           text: "Foreground"
-        has_text:
+        - that: has_text
           text: "Reference"
-        has_n_columns:
+        - that: has_n_columns
           n: 6
 
 - doc: Test CAPHEINE with all inputs (reference CDS, unaligned sequences, regex, and foreground list)
@@ -232,27 +232,27 @@
   outputs:
     combined_summary:
       asserts:
-        has_text:
+        - that: has_text
           text: "gene"
-        has_text:
+        - that: has_text
           text: "BUSTED"
-        has_text:
+        - that: has_text
           text: "MEME"
-        has_text:
+        - that: has_text
           text: "RELAX"
-        has_text:
+        - that: has_text
           text: "pval"
-        has_n_columns:
+        - that: has_n_columns
           n: 12
     combined_comparison_summary:
       asserts:
-        has_text:
+        - that: has_text
           text: "gene"
-        has_text:
+        - that: has_text
           text: "comparison_group"
-        has_text:
+        - that: has_text
           text: "Foreground"
-        has_text:
+        - that: has_text
           text: "Reference"
-        has_n_columns:
+        - that: has_n_columns
           n: 6

--- a/workflows/comparative_genomics/hyphy/capheine-core-and-compare-tests.yml
+++ b/workflows/comparative_genomics/hyphy/capheine-core-and-compare-tests.yml
@@ -40,13 +40,15 @@
         - that: has_text
           text: "BUSTED"
         - that: has_text
-          text: "MEME"
-        - that: has_text
           text: "pval"
         - that: has_text
           text: "omega"
         - that: has_n_columns
           n: 9
+    combined_sites:
+      asserts:
+        - that: has_text
+          text: "meme_marker"
 
 - doc: Test CAPHEINE with reference CDS, unaligned sequences, and regex (no foreground list)
   job:
@@ -91,13 +93,15 @@
         - that: has_text
           text: "BUSTED"
         - that: has_text
-          text: "MEME"
-        - that: has_text
           text: "RELAX"
         - that: has_text
           text: "pval"
         - that: has_n_columns
           n: 12
+    combined_sites:
+      asserts:
+        - that: has_text
+          text: "meme_marker"
     combined_comparison_summary:
       asserts:
         - that: has_text
@@ -158,13 +162,15 @@
         - that: has_text
           text: "BUSTED"
         - that: has_text
-          text: "MEME"
-        - that: has_text
           text: "RELAX"
         - that: has_text
           text: "pval"
         - that: has_n_columns
           n: 12
+    combined_sites:
+      asserts:
+        - that: has_text
+          text: "meme_marker"
     combined_comparison_summary:
       asserts:
         - that: has_text
@@ -237,13 +243,15 @@
         - that: has_text
           text: "BUSTED"
         - that: has_text
-          text: "MEME"
-        - that: has_text
           text: "RELAX"
         - that: has_text
           text: "pval"
         - that: has_n_columns
           n: 12
+    combined_sites:
+      asserts:
+        - that: has_text
+          text: "meme_marker"
     combined_comparison_summary:
       asserts:
         - that: has_text


### PR DESCRIPTION
> _Opened by Claude (AI assistant) on behalf of @jmchilton — not authored by them personally._

## Summary

Two commits, now **green** in CI:

1. **Convert `asserts:` to list form** — the repeated `has_text:` / `has_n_columns:` keys silently collapsed to the **last** one under YAML, so only one assertion per output was validated.
2. **Relocate the resurfaced `MEME` assertion** — see below.

## The MEME fix

Converting to list form revived a `has_text: "MEME"` assertion on `combined_summary` that never actually ran before. It failed because **MEME genuinely isn't in that output** — and it never should be:

- `combined_summary` (produced by DRHIP) is **gene-level**: `gene`, `BUSTED`, `RELAX`, `pval`, `omega`. The [drhip tool's own tests](https://github.com/galaxyproject/tools-iuc/blob/main/tools/drhip/drhip.xml) assert exactly those and **never** MEME.
- MEME is a **site-level** selection test; DRHIP puts its results in `combined_sites`, in a column the tool spells **`meme_marker`** (lowercase). A case-sensitive `has_text: "MEME"` could never match.

So the assertion was dead code that the duplicate-key collapse happened to hide. Fix: drop it from `combined_summary` and add `combined_sites: has_text: meme_marker` (matching DRHIP's own convention) so the check actually verifies MEME contributed.

✅ CI is green.
