### PR TITLE
tests: declare class:Collection / collection_type (epigenetics, data-fetching, chem, read-prep)

### DIFF
--- a/workflows/computational-chemistry/gromacs-dctmd/gromacs-dctmd-tests.yml
+++ b/workflows/computational-chemistry/gromacs-dctmd/gromacs-dctmd-tests.yml
@@ -25,6 +25,7 @@
     Salt concentration: 0.1
   outputs:
     XTC files:
+      class: Collection
       element_tests:
         split_file_000000.txt:
           assert:

--- a/workflows/data-fetching/metadata-and-sequences-from-bioproject-ids/metadata-and-sequences-from-bioproject-ids-tests.yml
+++ b/workflows/data-fetching/metadata-and-sequences-from-bioproject-ids/metadata-and-sequences-from-bioproject-ids-tests.yml
@@ -10,10 +10,12 @@
     Expand sample attributes in metadata: false
   outputs:
     SRA metadata table:
+      class: Collection
       element_tests:
         PRJNA1417618:
           path: test-data/test1_metadata_file_split_file_000000.txt.tsv
     Paired End Reads:
+      class: Collection
       element_tests:
         SRR37073390:
           forward:
@@ -37,6 +39,7 @@
     Expand sample attributes in metadata: false
   outputs:
     SRA metadata table:
+      class: Collection
       element_tests:
         PRJNA1425250:
           path: test-data/test2_metadata_file_split_file_000000.txt.tsv
@@ -45,6 +48,7 @@
           path: test-data/test2_metadata_file_split_file_000001.txt.tsv
           compare: contains
     Paired End Reads:
+      class: Collection
       element_tests:
         SRR37273408:
           forward:
@@ -65,6 +69,7 @@
             decompress: true
             compare: contains
     Single End Reads:
+      class: Collection
       element_tests:
         SRR37273407:
           path: test-data/test2_SRR37273407_forward.fastq
@@ -83,10 +88,12 @@
     Expand sample attributes in metadata: true
   outputs:
     SRA metadata table:
+      class: Collection
       element_tests:
         PRJNA1417618:
           path: test-data/test3_metadata.tsv
     Paired End Reads:
+      class: Collection
       element_tests:
         SRR37073390:
           forward:

--- a/workflows/data-fetching/parallel-accession-download/parallel-accession-download-tests.yml
+++ b/workflows/data-fetching/parallel-accession-download/parallel-accession-download-tests.yml
@@ -8,6 +8,7 @@
         hash_value: 82f7d1a023352b8d99bdf262ccbc0c87723b754b
   outputs:
     Single End Reads:
+      class: Collection
       element_tests:
         SRR044777:
           file: test-data/SRR044777_head.fastq
@@ -24,8 +25,10 @@
         hash_value: cc855f075b8473f89364415d7f30fada8182a40a
   outputs:
     Paired End Reads:
+      class: Collection
       element_tests:
         SRR11953971:
+          class: Collection
           elements:
             forward:
               file: test-data/SRR11953971_1_head.fastq

--- a/workflows/data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs-tests.yml
+++ b/workflows/data-fetching/sra-manifest-to-concatenated-fastqs/sra-manifest-to-concatenated-fastqs-tests.yml
@@ -10,8 +10,10 @@
     Column number with final identifier: 22
   outputs:
     paired_output:
+      class: Collection
       element_tests:
         GSM461177-:
+          class: Collection
           element_tests:
             forward:
               asserts:
@@ -24,6 +26,7 @@
                   value: 307000000
                   delta: 30000000
         GSM461178___a:
+          class: Collection
           element_tests:
             forward:
               asserts:
@@ -36,6 +39,7 @@
                   value: 205000000
                   delta: 20000000
     single_output:
+      class: Collection
       element_tests:
         GSM461176.-:
           asserts:

--- a/workflows/epigenetics/atacseq/atacseq-tests.yml
+++ b/workflows/epigenetics/atacseq/atacseq-tests.yml
@@ -5,7 +5,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: SRR891268_chr22_enriched
         elements:
         - identifier: forward
@@ -28,6 +28,7 @@
     Bin size: 1000
   outputs:
     mapping stats:
+      class: Collection
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
@@ -38,12 +39,14 @@
           - that: "has_text"
             text: "119723 (42.32%) aligned concordantly >1 times"
     MarkDuplicates metrics:
+      class: Collection
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
             has_text:
               text: "0.02"
     BAM filtered rmDup:
+      class: Collection
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
@@ -51,6 +54,7 @@
               value: 15810403
               delta: 1000000
     histogram of fragment length:
+      class: Collection
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
@@ -58,12 +62,14 @@
               value: 47718
               delta: 4000
     MACS2 narrowPeak:
+      class: Collection
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
             has_n_lines:
               n: 237
     MACS2 report:
+      class: Collection
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
@@ -72,6 +78,7 @@
           - that: "has_text"
             text: "# total tags in treatment: 261890"
     Coverage from MACS2 (bigwig):
+      class: Collection
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
@@ -79,18 +86,21 @@
               value: 2892925
               delta: 200000
     1kb around summits:
+      class: Collection
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
             has_n_lines:
               n: 220
     Nb of reads in summits +-500bp:
+      class: Collection
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
             has_line:
               line: "9522"
     bigwig_norm:
+      class: Collection
       element_tests:
         SRR891268_chr22_enriched:
           asserts:
@@ -98,6 +108,7 @@
               value: 1253177
               delta: 100000
     bigwig_norm2:
+      class: Collection
       element_tests:
         SRR891268_chr22_enriched:
           asserts:

--- a/workflows/epigenetics/average-bigwig-between-replicates/average-bigwig-between-replicates-tests.yml
+++ b/workflows/epigenetics/average-bigwig-between-replicates/average-bigwig-between-replicates-tests.yml
@@ -35,6 +35,7 @@
     bin_size: 50
   outputs:
     average_bigwigs:
+      class: Collection
       attributes:
         collection_type: list
       element_tests:

--- a/workflows/epigenetics/chipseq-pe/chipseq-pe-tests.yml
+++ b/workflows/epigenetics/chipseq-pe/chipseq-pe-tests.yml
@@ -5,7 +5,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: wt_H3K4me3
         elements:
         - identifier: forward
@@ -42,6 +42,7 @@
         has_text_matching:
           expression: "wt_H3K4me3\t20[12].0\t0.0\t13\t98.[0-9]*\t93.[0-9]*\t4.5[0-9]*\t0.095[0-9]*\t57.[0-9]*\t95.[0-9]*\t95.[0-9]*\t0.19[0-9]*\t51.0\t51.0"
     filtered BAM:
+      class: Collection
       element_tests:
         wt_H3K4me3:
           asserts:
@@ -49,12 +50,14 @@
               value: 5311841
               delta: 500000
     MACS2 summits:
+      class: Collection
       element_tests:
         wt_H3K4me3:
           asserts:
             has_n_lines:
               n: 13
     MACS2 peaks:
+      class: Collection
       element_tests:
         wt_H3K4me3:
           asserts:
@@ -65,12 +68,14 @@
           - that: "has_text"
             text: "# fragments after filtering in treatment: 42745"
     MACS2 narrowPeak:
+      class: Collection
       element_tests:
         wt_H3K4me3:
           asserts:
             has_n_lines:
               n: 13
     MACS2 report:
+      class: Collection
       element_tests:
         wt_H3K4me3:
           asserts:
@@ -81,6 +86,7 @@
           - that: "has_text"
             text: "# fragments after filtering in treatment: 42745"
     coverage from MACS2:
+      class: Collection
       element_tests:
         wt_H3K4me3:
           asserts:
@@ -88,6 +94,7 @@
               value: 568174
               delta: 50000
     mapping stats:
+      class: Collection
       element_tests:
         wt_H3K4me3:
           asserts:

--- a/workflows/epigenetics/chipseq-sr/chipseq-sr-tests.yml
+++ b/workflows/epigenetics/chipseq-sr/chipseq-sr-tests.yml
@@ -32,6 +32,7 @@
         has_text_matching:
           expression: "wt_H3K4me3\t200.0\t0.0\t9\t98.[0-9]*\t93.[0-9]*\t2.3[0-9]*\t0.049[0-9]*\t57.[0-9]*\t99.[0-9]*\t99.[0-9]*\t0.12[0-9]*\t51.0"
     filtered BAM:
+      class: Collection
       element_tests:
         wt_H3K4me3:
           asserts:
@@ -39,12 +40,14 @@
               value: 2587182
               delta: 200000
     MACS2 summits:
+      class: Collection
       element_tests:
         wt_H3K4me3:
           asserts:
             has_n_lines:
               n: 9
     MACS2 peaks:
+      class: Collection
       element_tests:
         wt_H3K4me3:
           asserts:
@@ -55,12 +58,14 @@
           - that: "has_text"
             text: "# tags after filtering in treatment: 44528"
     MACS2 narrowPeak:
+      class: Collection
       element_tests:
         wt_H3K4me3:
           asserts:
             has_n_lines:
               n: 9
     MACS2 report:
+      class: Collection
       element_tests:
         wt_H3K4me3:
           asserts:
@@ -71,6 +76,7 @@
           - that: "has_text"
             text: "# tags after filtering in treatment: 44528"
     coverage from MACS2:
+      class: Collection
       element_tests:
         wt_H3K4me3:
           asserts:
@@ -78,6 +84,7 @@
               value: 563563
               delta: 10000
     mapping stats:
+      class: Collection
       element_tests:
         wt_H3K4me3:
           asserts:

--- a/workflows/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun-tests.yml
+++ b/workflows/epigenetics/consensus-peaks/consensus-peaks-atac-cutandrun-tests.yml
@@ -30,6 +30,7 @@
     bin_size: 50
   outputs:
     individual_macs2_narrowPeaks:
+      class: Collection
       element_tests:
         rep1:
           asserts:

--- a/workflows/epigenetics/consensus-peaks/consensus-peaks-chip-pe-tests.yml
+++ b/workflows/epigenetics/consensus-peaks/consensus-peaks-chip-pe-tests.yml
@@ -30,6 +30,7 @@
     bin_size: 50
   outputs:
     individual_macs2_narrowPeaks:
+      class: Collection
       element_tests:
         rep1:
           asserts:

--- a/workflows/epigenetics/consensus-peaks/consensus-peaks-chip-sr-tests.yml
+++ b/workflows/epigenetics/consensus-peaks/consensus-peaks-chip-sr-tests.yml
@@ -30,6 +30,7 @@
     bin_size: 50
   outputs:
     individual_macs2_narrowPeaks:
+      class: Collection
       element_tests:
         rep1:
           asserts:

--- a/workflows/read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml
+++ b/workflows/read-preprocessing/short-read-qc-trimming/short-read-quality-control-and-trimming-tests.yml
@@ -5,7 +5,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: pair
         elements:
         - class: File
@@ -29,6 +29,7 @@
         - that: has_text
           text: "pair"
     fastp JSON report:
+      class: Collection
       element_tests:
         pair:
           asserts:


### PR DESCRIPTION
Schema regularization of workflow test files for epigenetics, data-fetching, computational chemistry, and read preprocessing. 10 workflow directories, all green in #1286's CI.

## What this is

Split out of #1286, which bundled 55 workflow directories into one PR and could not complete CI (the PR test job caps at 4 chunks, so ~14 Galaxy test runs landed in each and chunk 0 was cancelled at GitHub's 6h job limit).

The change is purely mechanical schema regularization of workflow test files, in two patterns:

- `class: Collection` added to outputs that already carried `element_tests:` / `elements:` / collection-only `attributes:` — a declarative annotation of things already known to be collections.
- `type:` renamed to `collection_type:` on nested collection elements in job inputs.

No `.ga` workflow files and no expected test data are touched.

## Why this one is expected green

Every workflow in this PR **passed** its planemo test run on the #1286 branch (CI run [29268785765](https://github.com/galaxyproject/iwc/actions/runs/29268785765)), and all directories linted clean. This PR carries only those workflows, in a small enough set that CI can actually finish.

Workflows in #1286 that failed did so for pre-existing reasons unrelated to this schema change (a broken `compleasm` tool, tool revisions missing from the Toolshed, stale expected VCFs, flaky asserts). Those are held back in separate branches behind their underlying fixes.

## Workflows

atacseq, average-bigwig-between-replicates, chipseq-pe, chipseq-sr, consensus-peaks, gromacs-dctmd, metadata-and-sequences-from-bioproject-ids, parallel-accession-download, sra-manifest-to-concatenated-fastqs, short-read-qc-trimming
