### PR TITLE
tests: declare class:Collection / collection_type (amplicon, bacterial, microbiome)

### DIFF
--- a/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete-tests.yml
+++ b/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-complete/mgnify-amplicon-pipeline-v5-complete-tests.yml
@@ -28,6 +28,7 @@
       - that: has_text
         text: "DRR010481_trimming"
     Single-end post quality control FASTA files:
+      class: Collection
       element_tests:
         DRR010481:
           location: https://zenodo.org/records/13710235/files/DRR010481_SE.fasta
@@ -56,15 +57,18 @@
     Paired-end MultiQC statistics:
       location: https://zenodo.org/records/14746033/files/general_stats_PE.tabular
     Paired-end post quality control FASTA files:
+      class: Collection
       element_tests:
         ERR2715528:
           location: https://zenodo.org/records/13710235/files/ERR2715528_PE.fasta
     LSU FASTA files:
+      class: Collection
       element_tests:
         DRR010481:
           location: https://zenodo.org/records/13710235/files/DRR010481_LSU.fasta
           compare: contains
     SSU taxonomic classifications using SILVA DB:
+      class: Collection
       element_tests:
         ERR2715528:
           asserts:
@@ -76,6 +80,7 @@
             comment: "#"
             n: 15
     SSU OTU tables (SILVA DB):
+      class: Collection
       element_tests:
         ERR2715528:
           asserts:
@@ -93,6 +98,7 @@
             comment: "#"
             n: 4
     LSU OTU tables (SILVA DB):
+      class: Collection
       element_tests:
         DRR010481:
           asserts:
@@ -110,6 +116,7 @@
             comment: "#"
             n: 4
     SSU OTU tables in HDF5 format (SILVA DB):
+      class: Collection
       element_tests:
         ERR2715528:
           asserts:
@@ -117,6 +124,7 @@
             value: 37000
             delta: 10000
     SSU OTU tables in JSON format (SILVA DB):
+      class: Collection
       element_tests:
         ERR2715528:
           asserts:
@@ -127,6 +135,7 @@
       - that: has_text
         text: "ERR2715528"
     LSU OTU tables in HDF5 format (SILVA DB):
+      class: Collection
       element_tests:
         DRR010481:
           asserts:
@@ -134,6 +143,7 @@
             value: 37000
             delta: 10000
     LSU OTU tables in JSON format (SILVA DB):
+      class: Collection
       element_tests:
         DRR010481:
           asserts:
@@ -144,6 +154,7 @@
       - that: has_text
         text: "DRR010481"
     LSU taxonomic classifications using SILVA DB:
+      class: Collection
       element_tests:
         DRR010481:
           asserts:
@@ -155,17 +166,20 @@
             comment: "#"
             n: 15
     SSU FASTA files:
+      class: Collection
       element_tests:
         ERR2715528:
           location: https://zenodo.org/records/13710235/files/ERR2715528_SSU.fasta
           compare: contains
     LSU and SSU BED regions:
+      class: Collection
       element_tests:
         DRR010481:
           location: https://zenodo.org/records/13710235/files/DRR010481.bed
         ERR2715528:
           location: https://zenodo.org/records/13710235/files/ERR2715528.bed
     ITS taxonomic classifications using ITSoneDB:
+      class: Collection
       element_tests:
         DRR010481:
           asserts:
@@ -186,6 +200,7 @@
             comment: "#"
             n: 15
     ITS FASTA files:
+      class: Collection
       element_tests:
         DRR010481:
           location: https://zenodo.org/records/13710235/files/DRR010481_ITS.fasta
@@ -194,6 +209,7 @@
           location: https://zenodo.org/records/13710235/files/ERR2715528_ITS.fasta
           compare: contains
     ITS OTU tables in JSON format (UNITE DB):
+      class: Collection
       element_tests:
         DRR010481:
           asserts:
@@ -210,6 +226,7 @@
       - that: has_text
         text: "ERR2715528"
     ITS OTU tables in HDF5 format (UNITE DB):
+      class: Collection
       element_tests:
         DRR010481:
           asserts:
@@ -228,6 +245,7 @@
       - that: has_text
         text: "ERR2715528"
     ITS OTU tables in JSON format (ITSoneDB):
+      class: Collection
       element_tests:
         DRR010481:
           asserts:
@@ -238,6 +256,7 @@
           - that: has_text
             text: "\"type\": \"OTU table\""
     ITS OTU tables in HDF5 format (ITSoneDB):
+      class: Collection
       element_tests:
         DRR010481:
           asserts:
@@ -250,6 +269,7 @@
             value: 72000
             delta: 10000
     ITS taxonomic classifications using UNITE DB:
+      class: Collection
       element_tests:
         DRR010481:
           asserts:
@@ -270,6 +290,7 @@
             comment: "#"
             n: 15
     ITS OTU tables (UNITE DB):
+      class: Collection
       element_tests:
         DRR010481:
           asserts:
@@ -302,6 +323,7 @@
             comment: "#"
             n: 4
     ITS OTU tables (ITSoneDB):
+      class: Collection
       element_tests:
         DRR010481:
           asserts:

--- a/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-paired-end/mgnify-amplicon-pipeline-v5-quality-control-paired-end-tests.yml
+++ b/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-paired-end/mgnify-amplicon-pipeline-v5-quality-control-paired-end-tests.yml
@@ -5,7 +5,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: ERR2715528
         elements:
         - identifier: forward
@@ -22,6 +22,7 @@
             hash_value: 38ca7f72b64c1b27367b61084e95797c4c97bfd5
   outputs:
     Paired-end post quality control FASTA files:
+      class: Collection
       element_tests:
         ERR2715528:
           location: https://zenodo.org/records/13710235/files/ERR2715528_PE.fasta

--- a/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-single-end/mgnify-amplicon-pipeline-v5-quality-control-single-end-tests.yml
+++ b/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-quality-control-single-end/mgnify-amplicon-pipeline-v5-quality-control-single-end-tests.yml
@@ -42,6 +42,7 @@
       - that: has_text
         text: "DRR010481_trimming"
     Single-end post quality control FASTA files:
+      class: Collection
       element_tests:
         DRR010481:
           location: https://zenodo.org/records/13710235/files/DRR010481_SE.fasta

--- a/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction-tests.yml
+++ b/workflows/amplicon/amplicon-mgnify/mgnify-amplicon-pipeline-v5-rrna-prediction/mgnify-amplicon-pipeline-v5-rrna-prediction-tests.yml
@@ -24,22 +24,26 @@
         hash_value: ac1d31c511c0726873c0fd7cad5ab207fed3228c
   outputs:
     LSU and SSU BED regions:
+      class: Collection
       element_tests:
         DRR010481_FASTQ.fasta:
           location: https://zenodo.org/records/13710235/files/DRR010481.bed
         ERR2715528_MERGED_FASTQ.fasta:
           location: https://zenodo.org/records/13710235/files/ERR2715528.bed
     SSU FASTA files:
+      class: Collection
       element_tests:
         ERR2715528_MERGED_FASTQ.fasta:
           location: https://zenodo.org/records/13710235/files/ERR2715528_SSU.fasta
           compare: contains
     LSU FASTA files:
+      class: Collection
       element_tests:
         DRR010481_FASTQ.fasta:
           location: https://zenodo.org/records/13710235/files/DRR010481_LSU.fasta
           compare: contains
     SSU taxonomic classifications using SILVA DB:
+      class: Collection
       element_tests:
         ERR2715528_MERGED_FASTQ.fasta:
           asserts:
@@ -51,6 +55,7 @@
             comment: "#"
             n: 15
     SSU OTU tables (SILVA DB):
+      class: Collection
       element_tests:
         ERR2715528_MERGED_FASTQ.fasta:
           asserts:
@@ -68,6 +73,7 @@
             comment: "#"
             n: 4
     LSU OTU tables (SILVA DB):
+      class: Collection
       element_tests:
         DRR010481_FASTQ.fasta:
           asserts:
@@ -85,6 +91,7 @@
             comment: "#"
             n: 4
     LSU taxonomic classifications using SILVA DB:
+      class: Collection
       element_tests:
         DRR010481_FASTQ.fasta:
           asserts:
@@ -96,6 +103,7 @@
             comment: "#"
             n: 15
     SSU OTU tables in HDF5 format (SILVA DB):
+      class: Collection
       element_tests:
         ERR2715528_MERGED_FASTQ.fasta:
           asserts:
@@ -103,6 +111,7 @@
             value: 37000
             delta: 10000
     SSU OTU tables in JSON format (SILVA DB):
+      class: Collection
       element_tests:
         ERR2715528_MERGED_FASTQ.fasta:
           asserts:
@@ -113,6 +122,7 @@
       - that: has_text
         text: "ERR2715528_MERGED_FASTQ_fasta"
     LSU OTU tables in HDF5 format (SILVA DB):
+      class: Collection
       element_tests:
         DRR010481_FASTQ.fasta:
           asserts:
@@ -120,6 +130,7 @@
             value: 37000
             delta: 10000
     LSU OTU tables in JSON format (SILVA DB):
+      class: Collection
       element_tests:
         DRR010481_FASTQ.fasta:
           asserts:

--- a/workflows/amplicon/dada2/dada2_paired-tests.yml
+++ b/workflows/amplicon/dada2/dada2_paired-tests.yml
@@ -5,7 +5,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: F3D0
         elements:
         - class: File
@@ -21,7 +21,7 @@
           - hash_function: SHA-1
             hash_value: af06e2cfbe8bd6415023dd8aa49cc8c44541ec0c
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: F3D5
         elements:
         - class: File
@@ -37,7 +37,7 @@
           - hash_function: SHA-1
             hash_value: 3233317bde4fd33c640d28d3982afb8f32065b61
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: F3D145
         elements:
         - class: File
@@ -53,7 +53,7 @@
           - hash_function: SHA-1
             hash_value: 5007557c8f03c5ee7952293b9f39d7eabb538e01
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: F3D150
         elements:
         - class: File
@@ -69,7 +69,7 @@
           - hash_function: SHA-1
             hash_value: dde2d7b349bd24d298f5f21bf1103ad3cf4e0a2e
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: Mock
         elements:
         - class: File

--- a/workflows/amplicon/qiime2/qiime2-III-VI-downsteam/QIIME2-VI-diversity-metrics-and-estimations-tests.yml
+++ b/workflows/amplicon/qiime2/qiime2-III-VI-downsteam/QIIME2-VI-diversity-metrics-and-estimations-tests.yml
@@ -106,6 +106,7 @@
           path: "^[^/]*/data/[^/]*\\.pdf"
           n: 6
     Emperor plot collection:
+      class: Collection
       element_tests:
         'unweighted_unifrac':
           ftype: qzv
@@ -116,6 +117,7 @@
         'bray_curtis':
           ftype: qzv
     Distance matrix collection:
+      class: Collection
       element_tests:
         'unweighted_unifrac':
           ftype: qzv
@@ -126,6 +128,7 @@
         'bray_curtis':
           ftype: qzv
     PCoA collection:
+      class: Collection
       element_tests:
         'unweighted_unifrac':
           ftype: qzv
@@ -136,6 +139,7 @@
         'bray_curtis':
           ftype: qzv
     Richness and evenness collection:
+      class: Collection
       element_tests:
         'rarefied_table':
           ftype: qzv

--- a/workflows/bacterial_genomics/bacterial-quality-and-contamination-control-post-assembly/bacterial_quality_and_contamination_control_post_assembly-tests.yml
+++ b/workflows/bacterial_genomics/bacterial-quality-and-contamination-control-post-assembly/bacterial_quality_and_contamination_control_post_assembly-tests.yml
@@ -45,6 +45,7 @@
         has_n_columns:
           n: 15
     Checkm2 diamond files:
+      class: Collection
       element_tests:
         DIAMOND_RESULTS:
           asserts:
@@ -53,6 +54,7 @@
             has_n_columns:
               n: 12
     Checkm2 protein files:
+      class: Collection
       element_tests:
         E-coli3_S194.fasta:
           asserts:

--- a/workflows/microbiome/binning-evaluation/MAGs-binning-evaluation-tests.yml
+++ b/workflows/microbiome/binning-evaluation/MAGs-binning-evaluation-tests.yml
@@ -19,7 +19,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: _trimmed
         elements:
         - class: File

--- a/workflows/microbiome/host-contamination-removal/host-contamination-removal-long-reads/host-or-contamination-removal-on-long-reads-tests.yml
+++ b/workflows/microbiome/host-contamination-removal/host-contamination-removal-long-reads/host-or-contamination-removal-on-long-reads-tests.yml
@@ -16,8 +16,10 @@
     Profile of preset options for the mapping (long-read): map-pb
   outputs:
     QualiMap Statistics:
+      class: Collection
       element_tests:
         Spike3bBarcode10:
+          class: Collection
           elements:
             genome_results:
               asserts:
@@ -92,6 +94,7 @@
                 has_n_lines:
                   value: 13
         Spike3bBarcode12:
+          class: Collection
           elements:
             genome_results:
               asserts:
@@ -172,6 +175,7 @@
         - that: has_text
           text: "Spike3bBarcode12"
     Reads without Host or Contamination:
+      class: Collection
       element_tests:
         Spike3bBarcode10:
           asserts:

--- a/workflows/microbiome/host-contamination-removal/host-contamination-removal-short-reads/host-or-contamination-removal-on-short-reads-tests.yml
+++ b/workflows/microbiome/host-contamination-removal/host-contamination-removal-short-reads/host-or-contamination-removal-on-short-reads-tests.yml
@@ -5,7 +5,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: pair
         elements:
         - class: File
@@ -27,6 +27,7 @@
         - has_text:
             text: "Bowtie"
     Bowtie2 Mapping Statistics from Local Index:
+      class: Collection
       element_tests:
         pair:
           asserts:
@@ -45,7 +46,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: pair
         elements:
         - class: File
@@ -66,6 +67,7 @@
         - has_text:
             text: "Paired-end"
     Bowtie2 Mapping Statistics from Reference Input:
+      class: Collection
       element_tests:
         pair:
           asserts:

--- a/workflows/microbiome/mags-building/MAGs-generation-tests.yml
+++ b/workflows/microbiome/mags-building/MAGs-generation-tests.yml
@@ -5,7 +5,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: test_minigut
         elements:
           - class: File
@@ -19,7 +19,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: test_minigut
         elements:
           - class: File
@@ -50,6 +50,7 @@
       - that: has_text
         text: "CheckM"
     Assembly Report:
+      class: Collection
       element_tests:
         test_minigut:
           asserts:
@@ -72,6 +73,7 @@
       - that: has_text
         text: "test_minigut_binette_bin5"
     Dereplicated Bins:
+      class: Collection
       element_tests:
         test_minigut_binette_bin1.fasta:
           asserts:
@@ -97,7 +99,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: test_minigut
         elements:
           - class: File
@@ -111,7 +113,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: test_minigut
         elements:
           - class: File
@@ -150,6 +152,7 @@
       - that: has_text
         text: "CheckM"
     Assembly Report:
+      class: Collection
       element_tests:
         minigut_reads:
           asserts:
@@ -159,6 +162,7 @@
             value: 361400
             delta: 50000
     metaSPAdes Contigs:
+      class: Collection
       element_tests:
         minigut_reads:
           asserts:
@@ -179,6 +183,7 @@
       - that: has_text
         text: "minigut_reads_binette_bin2.fasta"
     Dereplicated Bins:
+      class: Collection
       element_tests:
         minigut_reads_binette_bin1.fasta:
           asserts:

--- a/workflows/microbiome/mags-taxonomy-annotation/MAGs-taxonomy-annotation-tests.yml
+++ b/workflows/microbiome/mags-taxonomy-annotation/MAGs-taxonomy-annotation-tests.yml
@@ -28,6 +28,7 @@
         - that: has_text
           text: "Unclassified"
       GTDB-Tk summary files:
+        class: Collection
         element_tests:
           gtdbtk.bac120.summary:
             asserts:
@@ -38,6 +39,7 @@
               - that: has_text
                 text: "95.0"
       GTDB-NCBI mapping:
+        class: Collection
         element_tests:
           gtdbtk.bac120.summary:
             asserts:
@@ -48,6 +50,7 @@
               - that: has_text
                 text: "species"
       NCBI names to taxIDs mapping:
+        class: Collection
         element_tests:
           gtdbtk.bac120.summary:
             asserts:
@@ -58,6 +61,7 @@
               - that: has_text
                 text: "12908"
       full GTDB to NCBI mapping:
+        class: Collection
         element_tests:
           gtdbtk.bac120.summary:
             asserts:

--- a/workflows/microbiome/metagenomic-raw-reads-amr-analysis/metagenomic-raw-reads-amr-analysis-tests.yml
+++ b/workflows/microbiome/metagenomic-raw-reads-amr-analysis/metagenomic-raw-reads-amr-analysis-tests.yml
@@ -5,7 +5,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: raw_reads_metag_test
         elements:
           - class: File
@@ -24,6 +24,7 @@
     Coverage Threshold for Groot to Report an ARG: '0.6'
   outputs:
     Sylph Taxonomy Profiling:
+      class: Collection
       element_tests:
         raw_reads_metag_test:
           has_text:
@@ -31,6 +32,7 @@
           has_n_columns:
             n: 15
     Sylph Merge Taxonomy:
+      class: Collection
       element_tests:
         raw_reads_metag_test:
           has_text:
@@ -38,6 +40,7 @@
           has_n_columns:
             n: 2
     DeepARG Mapping ARG (>min probability):
+      class: Collection
       element_tests:
         raw_reads_metag_test:
           has_text:
@@ -45,6 +48,7 @@
           has_n_columns:
             n: 4
     Groot Report:
+      class: Collection
       element_tests:
         raw_reads_metag_test:
           asserts:
@@ -53,6 +57,7 @@
             has_n_columns:
               n: 4
     argNorm Groot Report:
+      class: Collection
       element_tests:
         raw_reads_metag_test:
           asserts:
@@ -61,6 +66,7 @@
             has_n_columns:
               n: 1
     argNorm DeepARG Report:
+      class: Collection
       element_tests:
         raw_reads_metag_test:
           has_text:
@@ -68,6 +74,7 @@
           has_n_columns:
             n: 4
     Tooldistillator Summarize:
+      class: Collection
       element_tests:
         raw_reads_metag_test:
           asserts:

--- a/workflows/microbiome/pathogen-identification/nanopore-pre-processing/Nanopore-Pre-Processing-tests.yml
+++ b/workflows/microbiome/pathogen-identification/nanopore-pre-processing/Nanopore-Pre-Processing-tests.yml
@@ -22,6 +22,7 @@
     host_reference_genome: apiMel3
   outputs:
     nanoplot_qc_on_reads_after_preprocessing_nanostats:
+      class: Collection
       attributes: {}
       element_tests:
         collection_of_all_samples_Spike3bBarcode12:

--- a/workflows/microbiome/pathogen-identification/taxonomy-profiling-and-visualization-with-krona/Taxonomy-Profiling-and-Visualization-with-Krona-tests.yml
+++ b/workflows/microbiome/pathogen-identification/taxonomy-profiling-and-visualization-with-krona/Taxonomy-Profiling-and-Visualization-with-Krona-tests.yml
@@ -21,6 +21,7 @@
     kraken_database: k2_minusb_20210517
   outputs:
     converted_kraken_report:
+      class: Collection
       attributes: {}
       element_tests:
         nanopore_preprocessed_collection_of_all_samples_Spike3bBarcode12:


### PR DESCRIPTION
Schema regularization of workflow test files for amplicon, bacterial genomics, and microbiome workflows. 15 workflow directories, all green in #1286's CI.

## What this is

Split out of #1286, which bundled 55 workflow directories into one PR and could not complete CI (the PR test job caps at 4 chunks, so ~14 Galaxy test runs landed in each and chunk 0 was cancelled at GitHub's 6h job limit).

The change is purely mechanical schema regularization of workflow test files, in two patterns:

- `class: Collection` added to outputs that already carried `element_tests:` / `elements:` / collection-only `attributes:` — a declarative annotation of things already known to be collections.
- `type:` renamed to `collection_type:` on nested collection elements in job inputs.

No `.ga` workflow files and no expected test data are touched.

## Why this one is expected green

Every workflow in this PR **passed** its planemo test run on the #1286 branch (CI run [29268785765](https://github.com/galaxyproject/iwc/actions/runs/29268785765)), and all directories linted clean. This PR carries only those workflows, in a small enough set that CI can actually finish.

Workflows in #1286 that failed did so for pre-existing reasons unrelated to this schema change (a broken `compleasm` tool, tool revisions missing from the Toolshed, stale expected VCFs, flaky asserts). Those are held back in separate branches behind their underlying fixes.

## Workflows

mgnify-amplicon-pipeline-v5 (complete, qc paired-end, qc single-end, rrna-prediction), dada2, qiime2-III-VI-downsteam, bacterial-quality-and-contamination-control-post-assembly, binning-evaluation, host-contamination-removal (long + short reads), mags-building, mags-taxonomy-annotation, metagenomic-raw-reads-amr-analysis, nanopore-pre-processing, taxonomy-profiling-and-visualization-with-krona
