### PR TITLE
tests: declare class:Collection / collection_type (variant calling, omics, imaging)

### DIFF
--- a/workflows/VGP-assembly-v2/Plot-Nx-Size/Generate-Nx-and-Size-plots-for-multiple-assemblies-tests.yml
+++ b/workflows/VGP-assembly-v2/Plot-Nx-Size/Generate-Nx-and-Size-plots-for-multiple-assemblies-tests.yml
@@ -28,6 +28,7 @@
           value: 89000
           delta: 2000
     gfastats data for plotting:
+      class: Collection
       element_tests:
         Primary:
           path: test-data/primary_head.tabular

--- a/workflows/imaging/tissue-microarray-analysis/tissue-microarray-analysis/tissue-micro-array-analysis-tests.yml
+++ b/workflows/imaging/tissue-microarray-analysis/tissue-microarray-analysis/tissue-micro-array-analysis-tests.yml
@@ -64,6 +64,7 @@
       has_image_channels:
         channels: 1
     DFP images:
+      class: Collection
       element_tests:
         exemplar-001-cycle-04:
           has_image_channels:
@@ -81,6 +82,7 @@
           has_image_channels:
             channels: 1
     FFP images:
+      class: Collection
       element_tests:
         exemplar-001-cycle-04:
           has_image_channels:
@@ -98,44 +100,53 @@
           has_image_channels:
             channels: 1
     Dearray images:
+      class: Collection
       element_tests:
         '1':
           has_image_channels:
             channels: 1
     Dearray masks:
+      class: Collection
       element_tests:
         '1':
           has_image_channels:
             channels: 1
     Nuclear mask:
+      class: Collection
       element_tests:
         '1':
           has_image_channels:
             channels: 1
     Converted image:
+      class: Collection
       element_tests:
         '1':
           has_image_channels:
             channels: 1
     Primary Mask Quantification:
+      class: Collection
       element_tests:
         '1':
           has_image_channels:
             channels: 1
     Renamed image:
+      class: Collection
       element_tests:
         '1':
           has_image_channels:
             channels: 1
     Anndata feature table:
+      class: Collection
       element_tests:
         '1':
           has_h5_keys: obs/Area,obs/CellID,obs/Eccentricity,obs/Extent,obs/MajorAxisLength,obs/MinorAxisLength,obs/Orientation,obs/Solidity,obs/X_centroid,obs/Y_centroid,obs/imageid,obs/imageid/categories,obs/imageid/codes
     Phenotyped feature table:
+      class: Collection
       element_tests:
         '1':
           has_h5_keys: obs/Area,obs/CellID,obs/Eccentricity,obs/Extent,obs/MajorAxisLength,obs/MinorAxisLength,obs/Orientation,obs/Solidity,obs/X_centroid,obs/Y_centroid,obs/imageid,obs/imageid/categories,obs/imageid/codes
     Vitessce Dashboard Config:
+      class: Collection
       element_tests:
         '1':
           has_json_property_with_text:

--- a/workflows/metabolomics/mfassignr/mfassignr-tests.yml
+++ b/workflows/metabolomics/mfassignr/mfassignr-tests.yml
@@ -27,6 +27,7 @@
     Unambig:
       path: test-data/Unambig.tabular
     plots (CHO):
+      class: Collection
       element_tests:
         MSgroups:
           has_size:
@@ -45,6 +46,7 @@
             size: 121K
             delta: 1K
     plots:
+      class: Collection
       element_tests:
         MSgroups:
           has_size:

--- a/workflows/proteomics/openms-metaprosip/metaprosip-tests.yml
+++ b/workflows/proteomics/openms-metaprosip/metaprosip-tests.yml
@@ -24,6 +24,7 @@
     Labeled element: C
   outputs:
     Peptide centric result:
+      class: Collection
       element_tests:
         Zeitz_SIP_13-II_020_picked.mzML:
           asserts:
@@ -34,6 +35,7 @@
           - that: has_text
             text: AATGTPSPAGSPPPIVPAPK
     Feature fitting result:
+      class: Collection
       element_tests:
         Zeitz_SIP_13-II_020_picked.mzML:
           asserts:

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-ivar-analysis/pe-wgs-ivar-analysis-test.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-ivar-analysis/pe-wgs-ivar-analysis-test.yml
@@ -19,7 +19,7 @@
       collection_type: 'list:paired'
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: ERR4970105
         elements:
         - identifier: forward

--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation-tests.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-pe-illumina-artic-variant-calling/pe-artic-variation-tests.yml
@@ -17,7 +17,7 @@
       collection_type: 'list:paired'
       elements:
         - class: Collection
-          type: paired
+          collection_type: paired
           identifier: SRR11578257
           elements:
           - identifier: forward
@@ -28,6 +28,7 @@
             location: "https://zenodo.org/records/10174466/files/SRR11578257_R2.fastq.gz?download=1"
   outputs:
     annotated_softfiltered_variants:
+      class: Collection
       attributes: {}
       element_tests:
         SRR11578257:

--- a/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml
+++ b/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-cellplex-tests.yml
@@ -5,7 +5,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: subsample
         elements:
         - identifier: forward
@@ -44,7 +44,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: subsample
         elements:
         - identifier: forward
@@ -80,9 +80,11 @@
           expression: |-
             <span class="val">33.[0-9]<span class=['"]mqc_small_space['"]>
     Seurat input for gene expression (filtered):
+      class: Collection
       attributes: {collection_type: list:list}
       element_tests:
         subsample:
+          class: Collection
           elements:
             matrix:
               asserts:
@@ -97,6 +99,7 @@
                 has_line:
                   line: "FBgn0250732\tgfzf"
     CITE-seq-Count report:
+      class: Collection
       attributes: {collection_type: list}
       element_tests:
         subsample:
@@ -110,9 +113,11 @@
           - that: "has_line"
             line: "Percentage unmapped: 1"
     Seurat input for CMO (UMI):
+      class: Collection
       attributes: {collection_type: list:list}
       element_tests:
         subsample:
+          class: Collection
           elements:
             matrix:
               asserts:

--- a/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-v3-tests.yml
+++ b/workflows/scRNAseq/fastq-to-matrix-10x/scrna-seq-fastq-to-matrix-10x-v3-tests.yml
@@ -5,7 +5,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: subsample
         elements:
         - identifier: forward
@@ -46,9 +46,11 @@
           expression: |-
             <span class="val">33.[0-9]<span class=['"]mqc_small_space['"]>
     Seurat input for gene expression (filtered):
+      class: Collection
       attributes: {collection_type: list:list}
       element_tests:
         subsample:
+          class: Collection
           elements:
             matrix:
               asserts:

--- a/workflows/scRNAseq/velocyto/Velocyto-on10X-filtered-barcodes-tests.yml
+++ b/workflows/scRNAseq/velocyto/Velocyto-on10X-filtered-barcodes-tests.yml
@@ -32,6 +32,7 @@
           hash_value: 332a0a5ac99b06315b2c946faa333c4684423b0b
   outputs:
     velocyto loom:
+      class: Collection
       element_tests:
         subsample:
           asserts:

--- a/workflows/scRNAseq/velocyto/Velocyto-on10X-from-bundled-tests.yml
+++ b/workflows/scRNAseq/velocyto/Velocyto-on10X-from-bundled-tests.yml
@@ -24,7 +24,7 @@
       collection_type: list:list
       elements:
       - class: Collection
-        type: list
+        collection_type: list
         identifier: subsample
         elements:
         - class: File
@@ -50,6 +50,7 @@
             hash_value: c84cc0a02031b55acbbb944a0f865af39aa3448d
   outputs:
     velocyto loom:
+      class: Collection
       element_tests:
         subsample:
           asserts:

--- a/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml
+++ b/workflows/transcriptomics/rnaseq-pe/rnaseq-pe-tests.yml
@@ -12,7 +12,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: SRR5085167
         elements:
         - class: File
@@ -46,6 +46,7 @@
       - that: "has_text_matching"
         expression: "SRR5085167_reverse\t*27.[0-9]*\t45.8\t75.0\t75\t45.45[0-9]*\t0.39[0-9]*"
     Stranded Coverage:
+      class: Collection
       element_tests:
         SRR5085167_forward:
           asserts:
@@ -58,12 +59,14 @@
               value: 618578
               delta: 30000
     Gene Abundance Estimates from StringTie:
+      class: Collection
       element_tests:
         SRR5085167:
           asserts:
             has_text_matching:
               expression: "YAL038W\tCDC19\tchrI\t\\+\t71786\t73288\t92.5[0-9]*\t3273.[0-9]*\t3975.[0-9]*"
     Unstranded Coverage:
+      class: Collection
       element_tests:
         SRR5085167:
           asserts:
@@ -71,6 +74,7 @@
               value: 1140004
               delta: 50000
     Mapped Reads:
+      class: Collection
       element_tests:
         SRR5085167:
           asserts:
@@ -78,18 +82,21 @@
               value: 56913572
               delta: 2500000
     Genes Expression from Cufflinks:
+      class: Collection
       element_tests:
         SRR5085167:
           asserts:
             has_text_matching:
               expression: "YAL038W\t-\t-\tYAL038W\tCDC19\t-\tchrI:71785-73288\t-\t-\t3437.[0-9]*\t3211.[0-9]*\t3662.[0-9]*\tOK"
     Transcripts Expression from Cufflinks:
+      class: Collection
       element_tests:
         SRR5085167:
           asserts:
             has_text_matching:
               expression: "YAL038W_mRNA\t-\t-\tYAL038W\tCDC19\t-\tchrI:71785-73288\t1503\t102.8[0-9]*\t3437.[0-9]*\t3211.[0-9]*\t3662.[0-9]*\tOK"
     Counts Table:
+      class: Collection
       element_tests:
         SRR5085167:
           asserts:

--- a/workflows/variant-calling/haploid-variant-calling-wgs-pe/WGS-PE-variant-calling-in-haploid-system-tests.yml
+++ b/workflows/variant-calling/haploid-variant-calling-wgs-pe/WGS-PE-variant-calling-in-haploid-system-tests.yml
@@ -19,7 +19,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: ERR018930
         elements:
         - class: File
@@ -35,7 +35,7 @@
           - hash_function: SHA-1
             hash_value: 693dfe7dad64030b72b59ffe07e7e711ae11606d
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: ERR1035492
         elements:
         - class: File
@@ -54,6 +54,7 @@
     Annotated Variants:
       path: test-data/Annotated Variants.tabular
     SnpEff variants:
+      class: Collection
       element_tests:
         ERR018930:
           asserts:

--- a/workflows/variant-calling/ploidy-aware-genotype-calling/genotype-variant-calling-wgs-pe-test.yml
+++ b/workflows/variant-calling/ploidy-aware-genotype-calling/genotype-variant-calling-wgs-pe-test.yml
@@ -5,7 +5,7 @@
       collection_type: list:paired
       elements:
         - class: Collection
-          type: paired
+          collection_type: paired
           identifier: sample1
           elements:
             - class: File
@@ -27,6 +27,7 @@
     Set Ploidy for FreeBayes Variant Calling: 2
   outputs:
     fastp HTML report:
+      class: Collection
       element_tests:
         sample1:
           asserts:

--- a/workflows/variant-calling/variation-reporting/Generic-variation-analysis-reporting-tests.yml
+++ b/workflows/variant-calling/variation-reporting/Generic-variation-analysis-reporting-tests.yml
@@ -15,6 +15,7 @@
           hash_value: 2e8678ff28911100ad231d536a508937250176c9
   outputs:
     af_recalculated:
+      class: Collection
       element_tests:
         filtered variants ERR3485802:
           path: test-data/af_recalculated.tabular

--- a/workflows/virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml
+++ b/workflows/virology/pox-virus-amplicon/pox-virus-half-genome-tests.yml
@@ -19,7 +19,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: 20L70   # SRR15145276
         elements:
         - identifier: forward
@@ -41,7 +41,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: 20L70   # SRX11452708
         elements:
         - identifier: forward


### PR DESCRIPTION
Schema regularization of workflow test files for variant calling, transcriptomics, scRNA-seq, imaging, proteomics, and metabolomics. 13 workflow directories, all green in #1286's CI.

## What this is

Split out of #1286, which bundled 55 workflow directories into one PR and could not complete CI (the PR test job caps at 4 chunks, so ~14 Galaxy test runs landed in each and chunk 0 was cancelled at GitHub's 6h job limit).

The change is purely mechanical schema regularization of workflow test files, in two patterns:

- `class: Collection` added to outputs that already carried `element_tests:` / `elements:` / collection-only `attributes:` — a declarative annotation of things already known to be collections.
- `type:` renamed to `collection_type:` on nested collection elements in job inputs.

No `.ga` workflow files and no expected test data are touched.

## Why this one is expected green

Every workflow in this PR **passed** its planemo test run on the #1286 branch (CI run [29268785765](https://github.com/galaxyproject/iwc/actions/runs/29268785765)), and all directories linted clean. This PR carries only those workflows, in a small enough set that CI can actually finish.

Workflows in #1286 that failed did so for pre-existing reasons unrelated to this schema change (a broken `compleasm` tool, tool revisions missing from the Toolshed, stale expected VCFs, flaky asserts). Those are held back in separate branches behind their underlying fixes.

## Workflows

Plot-Nx-Size, tissue-microarray-analysis, mfassignr, openms-metaprosip, sars-cov-2-pe-illumina-artic-ivar-analysis, sars-cov-2-pe-illumina-artic-variant-calling, fastq-to-matrix-10x, velocyto, rnaseq-pe, haploid-variant-calling-wgs-pe, ploidy-aware-genotype-calling, variation-reporting, pox-virus-amplicon
