### PR TITLE
PathoGFAIR: fix unresolvable fasttree pin + test schema regularization

### DIFF
--- a/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/CHANGELOG.md
+++ b/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## [0.1.1] - 2026-07-14
+## [0.2] - 2026-07-15
 
 ### Changed
 - Update fasttree from 2.1.10+galaxy1 to 2.1.10+galaxy3
+
+### Added
+- Expose the "Pathogeneic Genes Per Samples" heatmap PNG resolution as a workflow parameter (`heatmap_png_dpi`, default 1000); width/height unchanged. Lets the DPI be lowered for testing or memory-constrained runs without shrinking the vector PDF.
 
 ## [0.1] - 2024-04-24
 

--- a/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/CHANGELOG.md
+++ b/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.1] - 2026-07-14
+
+### Changed
+- Update fasttree from 2.1.10+galaxy1 to 2.1.10+galaxy3
+
 ## [0.1] - 2024-04-24
 
 First release.

--- a/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/CHANGELOG.md
+++ b/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Update fasttree from 2.1.10+galaxy1 to 2.1.10+galaxy3
 
 ### Added
-- Expose the "Pathogeneic Genes Per Samples" heatmap PNG resolution as a workflow parameter (`heatmap_png_dpi`, default 1000); width/height unchanged. Lets the DPI be lowered for testing or memory-constrained runs without shrinking the vector PDF.
+- Expose the "Pathogeneic Genes Per Samples" heatmap PNG resolution as a workflow parameter (`heatmap_png_dpi`, default 150); width/height unchanged. The previous hard-coded 1000 dpi produced a ~27.5k px square raster that could exhaust memory; the vector PDF output remains full resolution for high-detail zooming.
 
 ## [0.1] - 2024-04-24
 

--- a/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation-tests.yml
+++ b/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation-tests.yml
@@ -109,7 +109,6 @@
         - hash_function: SHA-1
           hash_value: 918299a8e0bb26fc024b8715b91460638cfc68c8
     metadata:
-    heatmap_png_dpi: 150
   outputs:
     adjusted_abricate_vfs_tabular_part1:
       class: Collection

--- a/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation-tests.yml
+++ b/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation-tests.yml
@@ -111,6 +111,7 @@
     metadata:
   outputs:
     adjusted_abricate_vfs_tabular_part1:
+      class: Collection
       attributes: {}
       element_tests:
         YP_001006764:

--- a/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation-tests.yml
+++ b/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation-tests.yml
@@ -109,6 +109,7 @@
         - hash_function: SHA-1
           hash_value: 918299a8e0bb26fc024b8715b91460638cfc68c8
     metadata:
+    heatmap_png_dpi: 150
   outputs:
     adjusted_abricate_vfs_tabular_part1:
       class: Collection

--- a/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.ga
+++ b/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.ga
@@ -3101,7 +3101,7 @@
                 "top": 900.0
             },
             "tool_id": null,
-            "tool_state": "{\"default\": 1000.0, \"validators\": [{\"min\": 1, \"max\": null, \"negate\": false, \"type\": \"in_range\"}], \"parameter_type\": \"float\", \"optional\": false}",
+            "tool_state": "{\"default\": 150.0, \"validators\": [{\"min\": 1, \"max\": null, \"negate\": false, \"type\": \"in_range\"}], \"parameter_type\": \"float\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
             "uuid": "d91f0a4e-7c3b-4a1e-9f2d-000000000070",
@@ -3116,5 +3116,5 @@
         "name:IWC"
     ],
     "uuid": "cb26018e-9d2f-4513-a372-122474df703e",
-    "version": 59
+    "version": 60
 }

--- a/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.ga
+++ b/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.ga
@@ -202,7 +202,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.1.1",
+    "release": "0.2",
     "name": "Pathogen Detection PathoGFAIR Samples Aggregation and Visualisation",
     "report": {
         "markdown": "# Pathogen Detection - PathoGFAIR Samples Aggregation and Visualisation Workflow Report\nBelow are the results for the PathoGFAIR Samples Aggregation and Visualisation Workflow\n\nThis workflow was run on:\n\n```galaxy\ngenerate_time()\n```\n\nWith Galaxy version:\n\n```galaxy\ngenerate_galaxy_version()\n```\n\n## Workflow Inputs\nTabular files and a FASTA file from the Gene-based Pathogen Identification workflow, four other tabular files from Nanopore Preprocessing and Nanopore - Allele-based Pathogen Identification workflow, and an optional Metadata tabular file with more sample information:\n\nFrom Gene-based Pathogenic Identification workflow: \n- contigs, FASTA file\n- VFs, Tabular file\n- vfs_of_genes_identified_by_vfdb, Tabular file\n- AMRs, Tabular file\n- amr_identified_by_ncbi, Tabular file\n\nFrom Nanopore - Allele bases Pathogen Identification workflow: \n- number_of_variants_per_sample, Tabular file\n- mapping_mean_depth_per_sample, Tabular file\n- mapping_coverage_percentage_per_sample, Tabular file\n\nFrom Nanopore Preprocessing: \n- removed_hosts_percentage_tabular, Tabular file\n\n## Some of the Workflow Outputs\n\n1- All Samples VFs Heatmap\n\n```galaxy\nhistory_dataset_as_image(output=\"heatmap_png\")\n```\n\n2- All samples phylogenetic tree VFs based\n\n```galaxy\nhistory_dataset_as_image(output=\"all_samples_phylogenetic_tree_based_vfs\")\n```\n\n3- All samples Phylogenetic tree AMR based \n\n```galaxy\nhistory_dataset_as_image(output=\"all_samples_phylogenetic_tree_based_amrs\")\n```\n\n4- Bar-plot for the Number of reads before host sequences removal and Number of found host reads per sample, performed in the Nanopore - Preprocessing workflow\n\n\n5- Barplot for the total number of removed host sequences per sample\n\n \n6- Barplot for the Mapping mean depth of coverage per sample\n\n\n6- Barplot for the Mapping breadth of coverage percentage per sample\n\n\n7- Barplot for the total number of complex variants and SNPs identified per sample\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"
@@ -1973,6 +1973,10 @@
                 "input1": {
                     "id": 41,
                     "output_name": "out_file1"
+                },
+                "out|dpi_output_dim": {
+                    "id": 70,
+                    "output_name": "output"
                 }
             },
             "inputs": [],
@@ -2029,7 +2033,7 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"adv\": {\"transform\": \"none\", \"cluster\": true, \"colorscheme\": \"whrd\"}, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"inputdata\": {\"input_type\": \"with_header_rownames\", \"__current_case__\": 2, \"header\": \"TRUE\", \"row_names_index\": \"1\", \"sample_name_orientation\": \"FALSE\"}, \"out\": {\"unit_output_dim\": \"cm\", \"width_output_dim\": \"70.0\", \"height_output_dim\": \"70.0\", \"dpi_output_dim\": \"1000.0\", \"additional_output_format\": \"pdf\"}, \"title\": \"Pathogeneic Genes Per Samples\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"adv\": {\"transform\": \"none\", \"cluster\": true, \"colorscheme\": \"whrd\"}, \"input1\": {\"__class__\": \"ConnectedValue\"}, \"inputdata\": {\"input_type\": \"with_header_rownames\", \"__current_case__\": 2, \"header\": \"TRUE\", \"row_names_index\": \"1\", \"sample_name_orientation\": \"FALSE\"}, \"out\": {\"unit_output_dim\": \"cm\", \"width_output_dim\": \"70.0\", \"height_output_dim\": \"70.0\", \"dpi_output_dim\": {\"__class__\": \"ConnectedValue\"}, \"additional_output_format\": \"pdf\"}, \"title\": \"Pathogeneic Genes Per Samples\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "3.4.0+galaxy0",
             "type": "tool",
             "uuid": "14c05908-0f84-44a6-bc2e-1c4cd9d73fae",
@@ -3076,6 +3080,33 @@
                     "uuid": "6bb4b32b-7cca-4e04-8120-be9f64ccba39"
                 }
             ]
+        },
+        "70": {
+            "annotation": "Resolution in dots-per-inch for the rasterized PNG of the 'Pathogeneic Genes Per Samples' heatmap. Lower it for large sample numbers or memory-constrained servers; the vector PDF output is unaffected.",
+            "content_id": null,
+            "errors": null,
+            "id": 70,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "Resolution in dots-per-inch for the rasterized PNG of the 'Pathogeneic Genes Per Samples' heatmap. Lower it for large sample numbers or memory-constrained servers; the vector PDF output is unaffected.",
+                    "name": "heatmap_png_dpi"
+                }
+            ],
+            "label": "heatmap_png_dpi",
+            "name": "Input parameter",
+            "outputs": [],
+            "position": {
+                "left": 1400.0,
+                "top": 900.0
+            },
+            "tool_id": null,
+            "tool_state": "{\"default\": 1000.0, \"validators\": [{\"min\": 1, \"max\": null, \"negate\": false, \"type\": \"in_range\"}], \"parameter_type\": \"float\", \"optional\": false}",
+            "tool_version": null,
+            "type": "parameter_input",
+            "uuid": "d91f0a4e-7c3b-4a1e-9f2d-000000000070",
+            "when": null,
+            "workflow_outputs": []
         }
     },
     "tags": [
@@ -3085,5 +3116,5 @@
         "name:IWC"
     ],
     "uuid": "cb26018e-9d2f-4513-a372-122474df703e",
-    "version": 58
+    "version": 59
 }

--- a/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.ga
+++ b/workflows/microbiome/pathogen-identification/pathogen-detection-pathogfair-samples-aggregation-and-visualisation/Pathogen-Detection-PathoGFAIR-Samples-Aggregation-and-Visualisation.ga
@@ -202,7 +202,7 @@
     ],
     "format-version": "0.1",
     "license": "MIT",
-    "release": "0.1",
+    "release": "0.1.1",
     "name": "Pathogen Detection PathoGFAIR Samples Aggregation and Visualisation",
     "report": {
         "markdown": "# Pathogen Detection - PathoGFAIR Samples Aggregation and Visualisation Workflow Report\nBelow are the results for the PathoGFAIR Samples Aggregation and Visualisation Workflow\n\nThis workflow was run on:\n\n```galaxy\ngenerate_time()\n```\n\nWith Galaxy version:\n\n```galaxy\ngenerate_galaxy_version()\n```\n\n## Workflow Inputs\nTabular files and a FASTA file from the Gene-based Pathogen Identification workflow, four other tabular files from Nanopore Preprocessing and Nanopore - Allele-based Pathogen Identification workflow, and an optional Metadata tabular file with more sample information:\n\nFrom Gene-based Pathogenic Identification workflow: \n- contigs, FASTA file\n- VFs, Tabular file\n- vfs_of_genes_identified_by_vfdb, Tabular file\n- AMRs, Tabular file\n- amr_identified_by_ncbi, Tabular file\n\nFrom Nanopore - Allele bases Pathogen Identification workflow: \n- number_of_variants_per_sample, Tabular file\n- mapping_mean_depth_per_sample, Tabular file\n- mapping_coverage_percentage_per_sample, Tabular file\n\nFrom Nanopore Preprocessing: \n- removed_hosts_percentage_tabular, Tabular file\n\n## Some of the Workflow Outputs\n\n1- All Samples VFs Heatmap\n\n```galaxy\nhistory_dataset_as_image(output=\"heatmap_png\")\n```\n\n2- All samples phylogenetic tree VFs based\n\n```galaxy\nhistory_dataset_as_image(output=\"all_samples_phylogenetic_tree_based_vfs\")\n```\n\n3- All samples Phylogenetic tree AMR based \n\n```galaxy\nhistory_dataset_as_image(output=\"all_samples_phylogenetic_tree_based_amrs\")\n```\n\n4- Bar-plot for the Number of reads before host sequences removal and Number of found host reads per sample, performed in the Nanopore - Preprocessing workflow\n\n\n5- Barplot for the total number of removed host sequences per sample\n\n \n6- Barplot for the Mapping mean depth of coverage per sample\n\n\n6- Barplot for the Mapping breadth of coverage percentage per sample\n\n\n7- Barplot for the total number of complex variants and SNPs identified per sample\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"
@@ -2402,7 +2402,7 @@
         },
         "55": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy3",
             "errors": null,
             "id": 55,
             "input_connections": {
@@ -2438,15 +2438,15 @@
                     "output_name": "output"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "e005e659ae21",
+                "changeset_revision": "bc939965ce41",
                 "name": "fasttree",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"advanced_selector\": {\"maximize\": \"min\", \"__current_case__\": 0}, \"input_selector\": {\"select_format\": \"fasta\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}, \"quote\": false, \"intree_selector\": {\"intree_format\": \"none\", \"__current_case__\": 0}}, \"model_selector\": {\"format\": \"-nt\", \"__current_case__\": 0, \"model\": \"-gtr\"}, \"save_logfile\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.1.10+galaxy1",
+            "tool_version": "2.1.10+galaxy3",
             "type": "tool",
             "uuid": "4faa1735-bea7-4e71-9961-9928bbba13d3",
             "when": null,
@@ -2871,7 +2871,7 @@
         },
         "66": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy3",
             "errors": null,
             "id": 66,
             "input_connections": {
@@ -2899,15 +2899,15 @@
                 "top": 1184.9745890557185
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "e005e659ae21",
+                "changeset_revision": "bc939965ce41",
                 "name": "fasttree",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"advanced_selector\": {\"maximize\": \"min\", \"__current_case__\": 0}, \"input_selector\": {\"select_format\": \"fasta\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}, \"quote\": false, \"intree_selector\": {\"intree_format\": \"none\", \"__current_case__\": 0}}, \"model_selector\": {\"format\": \"-nt\", \"__current_case__\": 0, \"model\": \"-gtr\"}, \"save_logfile\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.1.10+galaxy1",
+            "tool_version": "2.1.10+galaxy3",
             "type": "tool",
             "uuid": "38119133-c15d-472e-9df2-38ea8519f795",
             "when": null,
@@ -2915,7 +2915,7 @@
         },
         "67": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy1",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy3",
             "errors": null,
             "id": 67,
             "input_connections": {
@@ -2943,15 +2943,15 @@
                 "top": 1852.0079752861873
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy1",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/fasttree/fasttree/2.1.10+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "e005e659ae21",
+                "changeset_revision": "bc939965ce41",
                 "name": "fasttree",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"advanced_selector\": {\"maximize\": \"min\", \"__current_case__\": 0}, \"input_selector\": {\"select_format\": \"fasta\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}, \"quote\": false, \"intree_selector\": {\"intree_format\": \"none\", \"__current_case__\": 0}}, \"model_selector\": {\"format\": \"-nt\", \"__current_case__\": 0, \"model\": \"-gtr\"}, \"save_logfile\": false, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
-            "tool_version": "2.1.10+galaxy1",
+            "tool_version": "2.1.10+galaxy3",
             "type": "tool",
             "uuid": "02345d58-0ef8-49dd-ab98-ee74a5e69adc",
             "when": null,


### PR DESCRIPTION
Supersedes #1162. Unblocks the PathoGFAIR aggregation workflow and carries its share of the test-schema regularization split out of #1286.

## The fasttree pin

The workflow pinned `fasttree 2.1.10+galaxy1`, which is no longer installable — the Toolshed's only installable revisions are `2.1.10` (`c7e73acfa3eb`) and `2.1.10+galaxy3` (`bc939965ce41`). This produced two distinct failures:

- **Lint:** `ERROR: The tool ...fasttree/2.1.10+galaxy1 is not in the toolshed (may have been tagged as invalid).` This was the *only* lint error across all 55 workflow directories in #1286.
- **Test:** `Workflow was not invoked; the following required tools are not installed: ...fasttree/2.1.10+galaxy1`. Reproduces identically on `main` in the weekly runs of [2026-07-06](https://github.com/galaxyproject/iwc/actions/runs/28760707797) and [2026-07-13](https://github.com/galaxyproject/iwc/actions/runs/29215707224), so it is long-standing and not introduced here.

This bumps all three fasttree steps to `2.1.10+galaxy3`. `planemo workflow_lint --iwc` now exits 0.

### What #1162 missed

#1162 updated `content_id`, `tool_id`, and `changeset_revision`, but left `tool_version` at `2.1.10+galaxy1` in all three fasttree steps. That inconsistency is fixed here.

## The heatmap OOM (revealed once fasttree was fixed)

With the pin fixed, the workflow ran for the first time ever — **616 jobs succeeded, one errored**: the `ggplot2_heatmap` step titled "Pathogeneic Genes Per Samples". It died in ~33s with empty stderr and no exit code — the signature of a container kill, not a clean R error.

Cause: the step is hard-coded to render at **70×70 cm @ 1000 dpi** = a **27,559 × 27,559 px** raster ≈ **~3 GB** for the bitmap alone, on top of Galaxy + Postgres + docker on a ~7 GB runner. Near-certain OOM. This is pre-existing — it never surfaced before (in PRs *or* weeklies) because the fasttree pin blocked the workflow from ever reaching this step.

**Fix:** the physical size is legitimate (readable labels for many samples) and the vector PDF output already gives unlimited zoom for free, so the 1000-dpi *raster* is the only wasteful part. This exposes the PNG resolution as a workflow input `heatmap_png_dpi` (float), wired to the heatmap's `dpi_output_dim`. Width/height are untouched, so the vector PDF is unaffected.

Per review, the parameter **defaults to 150 dpi** (≈ 4,134 px², ~68 MB raster) so a plain run is memory-safe by default rather than relying on a test-only override; users who want a high-resolution raster can raise it, and the full-resolution vector PDF is always emitted regardless.

## Test schema

Adds the `class: Collection` / `collection_type` annotations for this workflow's test file — the same mechanical change as #1290/#1291/#1292, held back from those because this workflow could not run at all.

## Release

Folded into **release 0.2** (fasttree update + the dpi parameter), since #1162's intermediate 0.1.1 never reached `main`.
