### PR TITLE
tests: declare class:Collection / collection_type (rnaseq-sr)

### DIFF
--- a/workflows/transcriptomics/rnaseq-sr/rnaseq-sr-tests.yml
+++ b/workflows/transcriptomics/rnaseq-sr/rnaseq-sr-tests.yml
@@ -31,12 +31,14 @@
         has_text_matching:
           expression: "SRR5085167\t0.11[0-9]*\t18.3[0-9]*\t69.6[0-9]*\t0.3[0-9]*\t0.3[0-9]*\t94.62\t0.12[0-9]*\t34.43\t0.2[0-9]*\t90.[0-9]*\t16.[0-9]*\t0.3[0-9]*\t43.[0-9]*\t91.[0-9]*\t61.[0-9]*\t70.[0-9]*\t75.0\t27.[0-9]*\t46.1\t75.0\t75\t27.[0-9]*\t0.39[0-9]*"
     Counts Table:
+      class: Collection
       element_tests:
         SRR5085167:
           asserts:
             has_line:
               line: "YAL038W\t1775"
     Mapped Reads:
+      class: Collection
       element_tests:
         SRR5085167:
           asserts:
@@ -44,24 +46,28 @@
               value: 31570787
               delta: 3000000
     Gene Abundance Estimates from StringTie:
+      class: Collection
       element_tests:
         SRR5085167:
           asserts:
             has_text_matching:
               expression: "YAL038W\tCDC19\tchrI\t\\+\t71786\t73288\t57.[0-9]*\t3575.[0-9]*\t2900.[0-9]*"
     Genes Expression from Cufflinks:
+      class: Collection
       element_tests:
         SRR5085167:
           asserts:
             has_text_matching:
               expression: "YAL038W\t-\t-\tYAL038W\tCDC19\t-\tchrI:71785-73288\t-\t-\t3375.8[0-9]*\t3161.3[0-9]*\t3590.3[0-9]*\tOK"
     Transcripts Expression from Cufflinks:
+      class: Collection
       element_tests:
         SRR5085167:
           asserts:
             has_text_matching:
               expression: "YAL038W_mRNA\t-\t-\tYAL038W\tCDC19\t-\tchrI:71785-73288\t1503\t57.56[0-9]*\t3375.8[0-9]*\t3161.3[0-9]*\t3590.3[0-9]*\tOK"
     Stranded Coverage:
+      class: Collection
       element_tests:
         SRR5085167_forward:
           asserts:
@@ -74,6 +80,7 @@
               value: 526952
               delta: 50000
     Unstranded Coverage:
+      class: Collection
       element_tests:
         SRR5085167:
           asserts:


### PR DESCRIPTION
Final piece of the #1286 split. Same mechanical change as #1290/#1291/#1292: `class: Collection` on outputs that already carried `element_tests:`, and `type:` -> `collection_type:` on nested collection elements. No `.ga` files or expected data touched.

## Why this is standalone

`rnaseq-sr` was held back from #1292 because it errors in CI with:

```
Workflow was not invoked; the following required tools are not installed:
.../featurecounts/featurecounts/2.1.1+galaxy1
```

That is **not** a tool or workflow problem — it is the CI harness bug filed as #1294. The shed-installed data-table config does not survive Galaxy restarts, so the *second and later* consumer of featurecounts within a chunk cannot load it. `rnaseq-pe` runs first, installs featurecounts, and passes; `rnaseq-sr` inherits it and fails.

As the **only** featurecounts consumer in this PR's CI run, `rnaseq-sr` installs the tool fresh and registers the data tables — so it should pass here. (`rnaseq-pe` went out separately in #1292.)

This PR therefore doubles as the empirical check on #1294's diagnosis: if it goes green, the harness bug is confirmed and `rnaseq-sr` itself is fine.
