### PR TITLE
tests: declare class:Collection / collection_type (baredSC)

### DIFF
--- a/workflows/scRNAseq/baredsc/baredSC-1d-logNorm-tests.yml
+++ b/workflows/scRNAseq/baredsc/baredSC-1d-logNorm-tests.yml
@@ -12,6 +12,7 @@
     Maximum number of Gaussians to study: '4'
   outputs:
     baredsc_numpy:
+      class: Collection
       element_tests:
         split_file_000000.tabular:
           asserts:
@@ -34,8 +35,10 @@
               value: 28234812
               delta: 2000000
     baredsc_qc_plots:
+      class: Collection
       element_tests:
         split_file_000000.tabular:
+          class: Collection
           element_tests:
             convergence:
               asserts:
@@ -53,6 +56,7 @@
                   value: 45302
                   delta: 4000
         split_file_000001.tabular:
+          class: Collection
           element_tests:
             convergence:
               asserts:
@@ -70,6 +74,7 @@
                   value: 97623
                   delta: 90000
         split_file_000002.tabular:
+          class: Collection
           element_tests:
             convergence:
               asserts:
@@ -87,6 +92,7 @@
                   value: 159797
                   delta: 10000
         split_file_000003.tabular:
+          class: Collection
           element_tests:
             convergence:
               asserts:
@@ -104,6 +110,7 @@
                   value: 175774
                   delta: 10000
     baredsc_neff:
+      class: Collection
       element_tests:
         split_file_000000.tabular:
           asserts:
@@ -130,6 +137,7 @@
             has_line_matching:
               expression: "[7-9][0-9][0-9].[0-9]*"
     combined_other_outputs:
+      class: Collection
       element_tests:
         individuals:
           asserts:


### PR DESCRIPTION
Part of the #1286 split. Same mechanical change as #1290/#1291/#1292: `class: Collection` on outputs that already carried `element_tests:`. No `.ga` files or expected data touched, and **no assertions modified**.

## Why this is standalone

`baredSC-1d-logNorm` failed once in #1286 on a PNG file-size assert (`108407 +- 10000`, saw `119622`). It **passes on `main`** in the weeklies of [2026-07-06](https://github.com/galaxyproject/iwc/actions/runs/28760707797) and [2026-07-13](https://github.com/galaxyproject/iwc/actions/runs/29215707224), so that failure was not caused by this schema change.

baredSC is an MCMC sampler, so plot output varies run to run and the `+- 10000` delta is tight enough to catch it occasionally. Sending this on its own so a flake here cannot drag an otherwise-green batch red.

Worth a separate look: widening that delta would stop this recurring. Deliberately not done here, since it means loosening an assertion.
