### PR TITLE
tests: declare class:Collection / collection_type (workflows CI never reached in #1286)

### DIFF
--- a/workflows/comparative_genomics/hyphy/hyphy-compare-tests.yml
+++ b/workflows/comparative_genomics/hyphy/hyphy-compare-tests.yml
@@ -30,6 +30,7 @@
       filetype: txt
   outputs:
     cfel_output:
+      class: Collection
       element_tests:
         "NC_001477.1|capsid_protein_C|95-394_DENV1":
           asserts:
@@ -40,6 +41,7 @@
             has_text:
               text: "{"
     relax_output:
+      class: Collection
       element_tests:
         "NC_001477.1|capsid_protein_C|95-394_DENV1":
           asserts:

--- a/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml
+++ b/workflows/comparative_genomics/hyphy/hyphy-core-tests.yml
@@ -34,6 +34,7 @@
         filetype: fasta
   outputs:
     meme_output:
+      class: Collection
       element_tests:
         "capsid_protein_C":
           asserts:
@@ -44,6 +45,7 @@
             has_text:
               text: "{"
     prime_output:
+      class: Collection
       element_tests:
         "capsid_protein_C":
           asserts:
@@ -54,6 +56,7 @@
             has_text:
               text: "{"
     busted_output:
+      class: Collection
       element_tests:
         "capsid_protein_C":
           asserts:
@@ -64,6 +67,7 @@
             has_text:
               text: "{"
     fel_output:
+      class: Collection
       element_tests:
         "capsid_protein_C":
           asserts:

--- a/workflows/comparative_genomics/hyphy/hyphy-preprocessing-tests.yml
+++ b/workflows/comparative_genomics/hyphy/hyphy-preprocessing-tests.yml
@@ -170,6 +170,7 @@
         filetype: fasta
   outputs:
     output_file:
+      class: Collection
       element_tests:
         "capsid_protein_C":
           asserts:
@@ -180,6 +181,7 @@
             has_text:
               text: ">"
     treefile:
+      class: Collection
       element_tests:
         "capsid_protein_C":
           asserts:

--- a/workflows/epigenetics/cutandrun/cutandrun-tests.yml
+++ b/workflows/epigenetics/cutandrun/cutandrun-tests.yml
@@ -5,7 +5,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: Rep1
         elements:
         - identifier: forward
@@ -29,6 +29,7 @@
     normalize_profile: false
   outputs:
     Mapping stats:
+      class: Collection
       element_tests:
         Rep1:
           asserts:
@@ -37,6 +38,7 @@
             has_text_matching:
               expression: "99.39% overall alignment rate"
     BAM filtered rmDup:
+      class: Collection
       element_tests:
         Rep1:
           asserts:
@@ -44,24 +46,28 @@
               value: 8661584
               delta: 800000
     MarkDuplicates metrics:
+      class: Collection
       element_tests:
         Rep1:
           asserts:
             has_text:
               text: "0.33"
     MACS2 summits:
+      class: Collection
       element_tests:
         Rep1:
           asserts:
             has_n_lines:
               n: 5870
     MACS2 narrowPeak:
+      class: Collection
       element_tests:
         Rep1:
           asserts:
             has_n_lines:
               n: 5870
     MACS2 peaks xls:
+      class: Collection
       element_tests:
         Rep1:
           asserts:
@@ -76,7 +82,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: Rep1
         elements:
         - identifier: forward
@@ -100,6 +106,7 @@
     normalize_profile: true
   outputs:
     Mapping stats:
+      class: Collection
       element_tests:
         Rep1:
           asserts:
@@ -108,6 +115,7 @@
             has_text_matching:
               expression: "98.17% overall alignment rate"
     BAM filtered rmDup:
+      class: Collection
       element_tests:
         Rep1:
           asserts:
@@ -115,24 +123,28 @@
               value: 18246620
               delta: 1000000
     MarkDuplicates metrics:
+      class: Collection
       element_tests:
         Rep1:
           asserts:
             has_text:
               text: "0.001269"
     MACS2 summits:
+      class: Collection
       element_tests:
         Rep1:
           asserts:
             has_n_lines:
               n: 3231
     MACS2 narrowPeak:
+      class: Collection
       element_tests:
         Rep1:
           asserts:
             has_n_lines:
               n: 3231
     MACS2 peaks xls:
+      class: Collection
       element_tests:
         Rep1:
           asserts:
@@ -141,6 +153,7 @@
             has_text_matching:
               expression: "# total tags in treatment: 489716"
     Coverage from MACS2 (bigwig):
+      class: Collection
       element_tests:
         Rep1:
           asserts:

--- a/workflows/epigenetics/hic-hicup-cooler/chic-fastq-to-cool-hicup-cooler-tests.yml
+++ b/workflows/epigenetics/hic-hicup-cooler/chic-fastq-to-cool-hicup-cooler-tests.yml
@@ -5,7 +5,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: test_dataset
         elements:
         - class: File
@@ -33,6 +33,7 @@
     capture region (end): 180000000
   outputs:
     HiCUP report (html):
+      class: Collection
       element_tests:
         test_dataset:
           asserts:
@@ -40,12 +41,14 @@
               value: 4602173
               delta: 4000000
     HiCUP report (txt):
+      class: Collection
       element_tests:
         test_dataset:
           asserts:
             has_text:
               text: "\t99742\t99742\t92512\t92628\t7230\t7114\t22.45\t22.63\t2658\t2476\t73431\t72142\t17767\t18475\t5886\t6649\t57671\t57671\t39966\t1652\t17997\t20317\t17705\t481\t2432\t13452\t1340\t0\t0\t39962\t1652\t17996\t20314\t57.82\t69.30\t99.99\t50.83\t40.07"
     valid pairs in juicebox format:
+      class: Collection
       element_tests:
         test_dataset:
           asserts:
@@ -56,6 +59,7 @@
           - that: "has_line"
             line: "3\t0\tchr10\t100127492\t28094\t1\tchr10\t50864290\t13489\t0\t42"
     valid pairs in juicebox format MAPQ filtered:
+      class: Collection
       element_tests:
         test_dataset:
           asserts:
@@ -66,6 +70,7 @@
           - that: "not_has_text"
             text: "3\t0\tchr10\t100127492\t28094\t1\tchr10\t50864290\t13489\t0\t42"
     valid pairs filtered and sorted:
+      class: Collection
       element_tests:
         test_dataset:
           asserts:
@@ -73,6 +78,7 @@
               value: 807
               delta: 80
     matrix with raw values:
+      class: Collection
       element_tests:
         test_dataset:
           asserts:
@@ -80,6 +86,7 @@
               value: 42118
               delta: 4000
     matrix with iced values:
+      class: Collection
       element_tests:
         test_dataset:
           asserts:

--- a/workflows/epigenetics/hic-hicup-cooler/hic-fastq-to-cool-hicup-cooler-tests.yml
+++ b/workflows/epigenetics/hic-hicup-cooler/hic-fastq-to-cool-hicup-cooler-tests.yml
@@ -5,7 +5,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: test_dataset
         elements:
         - class: File
@@ -31,6 +31,7 @@
     region for matrix plotting: chr2:175,689,620-178,604,461
   outputs:
     HiCUP report (html):
+      class: Collection
       element_tests:
         test_dataset:
           asserts:
@@ -38,12 +39,14 @@
               value: 4602173
               delta: 4000000
     HiCUP report (txt):
+      class: Collection
       element_tests:
         test_dataset:
           asserts:
             has_text:
               text: "\t99742\t99742\t92512\t92628\t7230\t7114\t22.45\t22.63\t2658\t2476\t73431\t72142\t17767\t18475\t5886\t6649\t57671\t57671\t39966\t1652\t17997\t20317\t17705\t481\t2432\t13452\t1340\t0\t0\t39962\t1652\t17996\t20314\t57.82\t69.30\t99.99\t50.83\t40.07"
     valid pairs in juicebox format:
+      class: Collection
       element_tests:
         test_dataset:
           asserts:
@@ -54,6 +57,7 @@
           - that: "has_line"
             line: "3\t0\tchr10\t100127492\t28094\t1\tchr10\t50864290\t13489\t0\t42"
     valid pairs in juicebox format MAPQ filtered:
+      class: Collection
       element_tests:
         test_dataset:
           asserts:
@@ -64,6 +68,7 @@
           - that: "not_has_text"
             text: "3\t0\tchr10\t100127492\t28094\t1\tchr10\t50864290\t13489\t0\t42"
     valid pairs filtered and sorted:
+      class: Collection
       element_tests:
         test_dataset:
           asserts:
@@ -71,6 +76,7 @@
               value: 735227
               delta: 70000
     matrix with raw values:
+      class: Collection
       element_tests:
         test_dataset:
           asserts:
@@ -78,6 +84,7 @@
               value: 117588
               delta: 10000
     matrix with iced values:
+      class: Collection
       element_tests:
         test_dataset:
           asserts:

--- a/workflows/epigenetics/hic-hicup-cooler/hic-fastq-to-pairs-hicup-tests.yml
+++ b/workflows/epigenetics/hic-hicup-cooler/hic-fastq-to-pairs-hicup-tests.yml
@@ -5,7 +5,7 @@
       collection_type: list:paired
       elements:
       - class: Collection
-        type: paired
+        collection_type: paired
         identifier: test_dataset
         elements:
         - class: File
@@ -28,6 +28,7 @@
     minimum MAPQ: 30
   outputs:
     HiCUP report (HTML):
+      class: Collection
       element_tests:
         test_dataset:
           asserts:
@@ -35,12 +36,14 @@
               value: 4602173
               delta: 4000000
     HiCUP report (tabular):
+      class: Collection
       element_tests:
         test_dataset:
           asserts:
             has_text:
               text: "\t99742\t99742\t92512\t92628\t7230\t7114\t22.45\t22.63\t2658\t2476\t73431\t72142\t17767\t18475\t5886\t6649\t57671\t57671\t39966\t1652\t17997\t20317\t17705\t481\t2432\t13452\t1340\t0\t0\t39962\t1652\t17996\t20314\t57.82\t69.30\t99.99\t50.83\t40.07"
     valid pairs in juicebox format:
+      class: Collection
       element_tests:
         test_dataset:
           asserts:
@@ -51,6 +54,7 @@
           - that: "has_line"
             line: "3\t0\tchr10\t100127492\t28094\t1\tchr10\t50864290\t13489\t0\t42"
     valid pairs in juicebox format MAPQ filtered:
+      class: Collection
       element_tests:
         test_dataset:
           asserts:

--- a/workflows/epigenetics/hic-hicup-cooler/hic-juicermediumtabix-to-cool-cooler-tests.yml
+++ b/workflows/epigenetics/hic-hicup-cooler/hic-juicermediumtabix-to-cool-cooler-tests.yml
@@ -16,6 +16,7 @@
     Interactions to consider to calculate weights in normalization step: --cis-only
   outputs:
     matrix with raw values:
+      class: Collection
       element_tests:
         test_dataset:
           asserts:
@@ -23,6 +24,7 @@
               value: 42118
               delta: 4000
     matrix with iced values:
+      class: Collection
       element_tests:
         test_dataset:
           asserts:

--- a/workflows/genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences-tests.yml
+++ b/workflows/genome_annotation/functional-annotation/functional-annotation-of-sequences/Functional_annotation_of_sequences-tests.yml
@@ -17,12 +17,14 @@
     InterProScan mode select: Protein
   outputs:
     interproscan xml:
+      class: Collection
       element_tests:
         test-sequence:
           location: https://zenodo.org/records/13951790/files/interProScan.xml?download=1&preview=1
           compare: sim_size
           delta: 7000000
     interproscan tabular:
+      class: Collection
       element_tests:
         test-sequence:
           location: https://zenodo.org/records/13951790/files/interProScan.tabular?download=1&preview=1
@@ -86,12 +88,14 @@
     InterProScan mode select: Protein
   outputs:
     interproscan xml:
+      class: Collection
       element_tests:
         test-sequence:
           location: https://zenodo.org/records/13951790/files/interProScan.xml?download=1&preview=1
           compare: sim_size
           delta: 7000000
     interproscan tabular:
+      class: Collection
       element_tests:
         test-sequence:
           location: https://zenodo.org/records/13951790/files/interProScan.tabular?download=1&preview=1

--- a/workflows/imaging/histological-staining-area-quantification/histological-staining-area-quantification-tests.yml
+++ b/workflows/imaging/histological-staining-area-quantification/histological-staining-area-quantification-tests.yml
@@ -60,6 +60,7 @@
         - has_text_matching:
             expression: 'treatment_3\t255\t0\.001441[0-9]+\t5156\.0\t5156\.0\t360000\t1\.432[0-9]+'
     Selected Stain Channel:
+      class: Collection
       element_tests:
         control_1:
           asserts:
@@ -86,6 +87,7 @@
             has_size:
               min: 1
     'Collection of Tabular: Staining Quantification Results':
+      class: Collection
       element_tests:
         control_1:
           asserts:
@@ -140,8 +142,10 @@
             has_text_matching:
               expression: '255\t0\.001[0-9]+\t5156\.0\t5156\.0'
     'Collection: Individual Deconvolved Channels':
+      class: Collection
       element_tests:
         control_1:
+          class: Collection
           elements:
             1.tiff:
               asserts:
@@ -156,6 +160,7 @@
                 has_size:
                   min: 1
         control_2:
+          class: Collection
           elements:
             1.tiff:
               asserts:
@@ -170,6 +175,7 @@
                 has_size:
                   min: 1
         control_3:
+          class: Collection
           elements:
             1.tiff:
               asserts:
@@ -184,6 +190,7 @@
                 has_size:
                   min: 1
         treatment_1:
+          class: Collection
           elements:
             1.tiff:
               asserts:
@@ -198,6 +205,7 @@
                 has_size:
                   min: 1
         treatment_2:
+          class: Collection
           elements:
             1.tiff:
               asserts:
@@ -212,6 +220,7 @@
                 has_size:
                   min: 1
         treatment_3:
+          class: Collection
           elements:
             1.tiff:
               asserts:
@@ -226,6 +235,7 @@
                 has_size:
                   min: 1
     Deconvolved Image:
+      class: Collection
       element_tests:
         control_1:
           asserts:
@@ -252,6 +262,7 @@
             has_size:
               min: 1
     Selected Stain Channel Thresholded:
+      class: Collection
       element_tests:
         control_1:
           asserts:

--- a/workflows/imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml
+++ b/workflows/imaging/tissue-microarray-analysis/multiplex-tissue-microarray-analysis/multiplex-tma-tests.yml
@@ -53,12 +53,14 @@
           size: 60K
           delta: 30K
     Background subtracted images:
+      class: Collection
       element_tests:
         image:
           asserts:
           - has_image_channels:
               channels: 7
     Background subtracted markers:
+      class: Collection
       element_tests:
         image:
           asserts:
@@ -67,24 +69,28 @@
           - has_line:
               line: DNA_7,,
     Primary Mask Quantification:
+      class: Collection
       element_tests:
         image:
           asserts:
           - has_line:
               line: CellID,DNA_7,CD11B,SMA,CD16,ECAD,FOXP3,NCAM,X_centroid,Y_centroid,Area,MajorAxisLength,MinorAxisLength,Eccentricity,Solidity,Extent,Orientation
     Segmented Multiplexed Mask:
+      class: Collection
       element_tests:
         image:
           asserts:
           - has_image_channels:
               channels: 1
     phenotyped adata:
+      class: Collection
       element_tests:
         image:
           asserts:
           - has_h5_keys:
               keys: obs/Area,obs/CellID,obs/Eccentricity,obs/Extent,obs/MajorAxisLength,obs/MinorAxisLength,obs/Orientation,obs/Solidity,obs/X_centroid,obs/Y_centroid,obs/imageid,obs/imageid/categories,obs/imageid/codes
     Interaction Matrix Plot:
+      class: Collection
       element_tests:
         image:
           asserts:
@@ -92,12 +98,14 @@
               size: 43K
               delta: 20K
     Interaction Matrix Anndata:
+      class: Collection
       element_tests:
         image:
           asserts:
           - has_h5_keys:
               keys: obs/Area,obs/CellID,obs/Eccentricity,obs/Extent,obs/MajorAxisLength,obs/MinorAxisLength,obs/Orientation,obs/Solidity,obs/X_centroid,obs/Y_centroid,obs/imageid,obs/imageid/categories,obs/imageid/codes
     Squidpy Spatial Scatterplots:
+      class: Collection
       element_tests:
         image:
           asserts:
@@ -105,6 +113,7 @@
               size: 181K
               delta: 50K
     Vitessce Dashboard:
+      class: Collection
       element_tests:
         image:
           asserts:


### PR DESCRIPTION
Part of the #1286 split. Same mechanical change as #1290/#1291/#1292: `class: Collection` on outputs that already carried `element_tests:` / `elements:`, and `type:` -> `collection_type:` on nested collection elements. No `.ga` files or expected data touched.

## Why these were held back

These six workflow directories got **no CI verdict at all** in #1286. That PR bundled 55 directories against a 4-chunk cap, so chunk 0 was cancelled at GitHub's 6h job limit and chunk 1's job died outright — these never ran.

All six pass on `main` in the [2026-07-13 weekly](https://github.com/galaxyproject/iwc/actions/runs/29215707224), so they are expected green here:

hyphy (compare / core / preprocessing), cutandrun, hic-hicup-cooler (all four), functional-annotation-of-sequences, histological-staining-area-quantification, multiplex-tissue-microarray-analysis

`planemo workflow_lint --iwc` passes locally on all six.
