### PR TITLE
ont-artic: repoint consistently-broken NCBI SRA read URL at ENA + test schema regularization

### DIFF
--- a/workflows/sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation-tests.yml
+++ b/workflows/sars-cov-2-variant-calling/sars-cov-2-ont-artic-variant-calling/ont-artic-variation-tests.yml
@@ -19,12 +19,13 @@
       - identifier: SRR12447380
         class: File
         filetype: fastqsanger.gz
-        location: "https://www.be-md.ncbi.nlm.nih.gov/Traces/sra-reads-be/fastq?acc=SRR12447380"
+        location: "https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR124/080/SRR12447380/SRR12447380_1.fastq.gz"
         hashes:
         - hash_function: SHA-1
-          hash_value: e26a9711e1d1201ed49cd3e98bbc0837f4c90533
+          hash_value: cd93c6dcbcf46b795d7cc2f41a81c9d87f8601d6
   outputs:
     annotated_softfiltered_variants:
+      class: Collection
       attributes: {}
       element_tests:
         SRR12447380:


### PR DESCRIPTION
Unblocks `ont-artic-variation` and carries its share of the test-schema regularization split out of #1286.

## The read URL is consistently broken, not flaky

The test fetched its ONT reads from:

```
https://www.be-md.ncbi.nlm.nih.gov/Traces/sra-reads-be/fastq?acc=SRR12447380
```

`be-md.ncbi.nlm.nih.gov` is an NCBI **backend** host, not a public data endpoint. It no longer serves this accession, and it fails in the nastiest possible way: it returns **HTTP 200 with an HTML page** titled *"NCBI - WWW Error Diagnostic"* (3713 bytes) instead of a FASTQ.

Because the status code is 200, Galaxy downloads it happily, then the content fails to decompress as `fastqsanger.gz` and the declared SHA-1 does not match — so the upload job errors and the workflow is never invoked:

```
Upload job produced output [3: fastq?acc=SRR12447380] in state [error]
```

**This has failed in every run I can find** — identical accession, identical error:

| run | result |
|---|---|
| weekly [2026-06-29](https://github.com/galaxyproject/iwc/actions/runs/28341986477) | ERROR |
| weekly [2026-07-06](https://github.com/galaxyproject/iwc/actions/runs/28760707797) | ERROR |
| weekly [2026-07-13](https://github.com/galaxyproject/iwc/actions/runs/29215707224) | ERROR |
| PR [#1286](https://github.com/galaxyproject/iwc/pull/1286) | ERROR |

It is not a transient SRA outage and no amount of retrying will fix it. It reads like a network flake, which is probably why it has survived this long.

## The fix

Repointed at ENA, which serves the same accession from a stable, public, versioned path:

```
https://ftp.sra.ebi.ac.uk/vol1/fastq/SRR124/080/SRR12447380/SRR12447380_1.fastq.gz
```

The declared SHA-1 is re-derived from the actual file, since the old hash described whatever the dead endpoint used to serve. The download was verified before hashing:

- **md5 `c68b7c19b4ee19d668a927e55c9e4d78`** — matches ENA's independently published md5 for this run exactly
- gzip integrity check passes
- read headers confirm the accession (`@SRR12447380.1 1/1`)
- new SHA-1: `cd93c6dcbcf46b795d7cc2f41a81c9d87f8601d6`

## Test schema

Also adds the `class: Collection` / `collection_type` annotations for this workflow — same mechanical change as #1290/#1291/#1292, held back from those because this workflow could not run at all.

## Expectations

`planemo workflow_lint --iwc` passes locally. The workflow test has **never successfully executed** on CI — it has been dying at upload — so this run is the first real signal. If something downstream fails (e.g. the variant-call comparison, which allows `lines_diff: 6`), that is a pre-existing problem this PR merely reveals, and can be handled separately.
