### PR TITLE
Update metagenomic genes catalogue to 1.3

### DIFF
--- a/workflows/microbiome/metagenomic-genes-catalogue/CHANGELOG.md
+++ b/workflows/microbiome/metagenomic-genes-catalogue/CHANGELOG.md
@@ -9,7 +9,6 @@
 ### Deprecated
 - The updated versions of these two tools are available only on galaxy.org
 - `toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.3.0` was deprecated to `toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.2.0`
-- `toolshed.g2.bx.psu.edu/repos/iuc/coverm_contig/coverm_contig/0.8.0+galaxy0` was deprecated to `toolshed.g2.bx.psu.edu/repos/iuc/coverm_contig/coverm_contig/0.7.0+galaxy0`
 
 
 ## [1.2.2] - 2026-07-13

--- a/workflows/microbiome/metagenomic-genes-catalogue/CHANGELOG.md
+++ b/workflows/microbiome/metagenomic-genes-catalogue/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.3] - 2026-07-16
+
+### Changed
+
+- Concatenation used to be performed directly after assembly, but following steps (Prodigal and AMRFinderPlus) could take too long depending on the number of samples and their size. Concatenation is now performed later in the workflow, which speeds up the process when dealing with multiple samples, without affecting the results.
+
+### Deprecated
+- The updated versions of these two tools are available only on galaxy.org
+- `toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.3.0` was deprecated to `toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.2.0`
+- `toolshed.g2.bx.psu.edu/repos/iuc/coverm_contig/coverm_contig/0.8.0+galaxy0` was deprecated to `toolshed.g2.bx.psu.edu/repos/iuc/coverm_contig/coverm_contig/0.7.0+galaxy0`
+
+
 ## [1.2.2] - 2026-07-13
 
 ### Automatic update

--- a/workflows/microbiome/metagenomic-genes-catalogue/CHANGELOG.md
+++ b/workflows/microbiome/metagenomic-genes-catalogue/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 - Concatenation used to be performed directly after assembly, but following steps (Prodigal and AMRFinderPlus) could take too long depending on the number of samples and their size. Concatenation is now performed later in the workflow, which speeds up the process when dealing with multiple samples, without affecting the results.
 
-### Deprecated
-- The updated versions of these two tools are available only on galaxy.org
-- `toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.3.0` was deprecated to `toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.2.0`
-
 
 ## [1.2.2] - 2026-07-13
 

--- a/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue-tests.yml
+++ b/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue-tests.yml
@@ -16,7 +16,7 @@
             location: https://zenodo.org/records/17348100/files/genes_catalogue_R2.fastqsanger.gz
     eggNOG database: 5.0.2
     mmseqs2 taxonomy DB: UniRef50-15.6f452-21102025
-    starAMR database: staramr_downloaded_27022025_resfinder_d1e607b_pointfinder_694919f_plasmidfinder_3e77502
+    starAMR database: staramr_downloaded_07042025_resfinder_d1e607b_pointfinder_694919f_plasmidfinder_3e77502
     Virulence genes detection database: resfinder
     AMR genes detection database: amrfinderplus_V3.12_2024-05-02.2
     Full genes catalogue: false

--- a/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue-tests.yml
+++ b/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue-tests.yml
@@ -15,7 +15,7 @@
             identifier: reverse
             location: https://zenodo.org/records/17348100/files/genes_catalogue_R2.fastqsanger.gz
     eggNOG database: 5.0.2
-    mmseqs2 taxonomy DB: UniRef50-15.6f452-21102025
+    mmseqs2 taxonomy DB: UniRef50-17-b804f-07112025
     starAMR database: staramr_downloaded_07042025_resfinder_d1e607b_pointfinder_694919f_plasmidfinder_3e77502
     Virulence genes detection database: resfinder
     AMR genes detection database: amrfinderplus_V3.12_2024-05-02.2

--- a/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue-tests.yml
+++ b/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue-tests.yml
@@ -15,8 +15,8 @@
             identifier: reverse
             location: https://zenodo.org/records/17348100/files/genes_catalogue_R2.fastqsanger.gz
     eggNOG database: 5.0.2
-    mmseqs2 taxonomy DB: UniRef50-17-b804f-07112025
-    starAMR database: staramr_downloaded_07042025_resfinder_d1e607b_pointfinder_694919f_plasmidfinder_3e77502
+    mmseqs2 taxonomy DB: UniRef50-15.6f452-21102025
+    starAMR database: staramr_downloaded_27022025_resfinder_d1e607b_pointfinder_694919f_plasmidfinder_3e77502
     Virulence genes detection database: resfinder
     AMR genes detection database: amrfinderplus_V3.12_2024-05-02.2
     Full genes catalogue: false
@@ -39,7 +39,7 @@
           text: "cellular root"
         has_n_columns:
           n: 6
-    Argnorm AMRfinderplus Report:
+    Argnorm AMRfinderplus Concatenated Reports:
       asserts:
         has_text:
           text: "Protein identifier"
@@ -55,7 +55,7 @@
           text: "Isolate ID"
         has_n_columns:
           n: 13
-    Abricate Virulence Report:
+    ABRicate Virulence Concatenated Reports:
       asserts:
         has_text:
           text: "#FILE"

--- a/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.ga
+++ b/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.ga
@@ -4,38 +4,13 @@
     "comments": [
         {
             "child_steps": [
-                25,
-                40,
-                22,
-                23,
-                26,
-                29,
-                35
-            ],
-            "color": "black",
-            "data": {
-                "title": "MultiQC"
-            },
-            "id": 4,
-            "position": [
-                4596.9,
-                898.5
-            ],
-            "size": [
-                890,
-                769
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                7,
-                9,
-                10,
                 12,
-                13,
+                9,
+                15,
                 14,
-                15
+                13,
+                10,
+                7
             ],
             "color": "turquoise",
             "data": {
@@ -44,7 +19,7 @@
             "id": 0,
             "position": [
                 670.6814223676528,
-                1667.772463199814
+                1463.8724631998139
             ],
             "size": [
                 1385,
@@ -54,33 +29,11 @@
         },
         {
             "child_steps": [
-                18,
-                19,
-                20,
-                21
-            ],
-            "color": "red",
-            "data": {
-                "title": "ARG annotation"
-            },
-            "id": 1,
-            "position": [
-                2163.9,
-                651.3803319554148
-            ],
-            "size": [
-                622,
-                1082
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                33,
-                36,
-                38,
+                32,
                 16,
-                30
+                40,
+                38,
+                35
             ],
             "color": "yellow",
             "data": {
@@ -89,7 +42,7 @@
             "id": 2,
             "position": [
                 3488.9,
-                203.9
+                0
             ],
             "size": [
                 992.4,
@@ -99,12 +52,62 @@
         },
         {
             "child_steps": [
+                27,
+                24,
+                22,
+                21,
+                20,
+                19,
+                18
+            ],
+            "color": "red",
+            "data": {
+                "title": "ARG annotation"
+            },
+            "id": 1,
+            "position": [
+                2245.5,
+                452.6
+            ],
+            "size": [
+                1110,
+                1070
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                36,
+                28,
+                26,
+                25,
+                23,
+                42
+            ],
+            "color": "black",
+            "data": {
+                "title": "MultiQC"
+            },
+            "id": 4,
+            "position": [
+                4596.9,
+                694.6
+            ],
+            "size": [
+                890,
+                769
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
                 31,
-                32,
-                34,
-                37,
+                30,
+                41,
                 39,
-                28
+                37,
+                34,
+                33
             ],
             "color": "green",
             "data": {
@@ -113,7 +116,7 @@
             "id": 3,
             "position": [
                 3317.6,
-                1746.9
+                1543
             ],
             "size": [
                 1281,
@@ -142,7 +145,7 @@
     ],
     "format-version": "0.1",
     "license": "GPL-3.0-or-later",
-    "name": "Metagenomic Genes Catalogue Analysis",
+    "name": "Metagenomic Genes Catalogue Analysis (concatenate later)",
     "report": {
         "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
     },
@@ -164,13 +167,13 @@
             "outputs": [],
             "position": {
                 "left": 0,
-                "top": 1467.439162418564
+                "top": 1263.5391624185638
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false, \"format\": [\"fastq\", \"fastq.gz\", \"fastqsanger\", \"fastqsanger.gz\"], \"tag\": null, \"collection_type\": \"list:paired\", \"fields\": null, \"column_definitions\": null}",
             "tool_version": null,
             "type": "data_collection_input",
-            "uuid": "f5324bed-5b58-4257-aa3f-750cdd50820e",
+            "uuid": "2e93b54f-1f59-4248-951d-a61b295b6566",
             "when": null,
             "workflow_outputs": []
         },
@@ -191,13 +194,13 @@
             "outputs": [],
             "position": {
                 "left": 15.399050635630108,
-                "top": 1913.7115099384337
+                "top": 1709.8115099384336
             },
             "tool_id": null,
             "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "6dc23ebc-8b3c-4d69-8080-c22714ea7538",
+            "uuid": "129b9a62-2c6a-4b98-a011-827404c6f7f4",
             "when": null,
             "workflow_outputs": []
         },
@@ -218,13 +221,13 @@
             "outputs": [],
             "position": {
                 "left": 1403.3740168282284,
-                "top": 1349.239061776434
+                "top": 1145.339061776434
             },
             "tool_id": null,
             "tool_state": "{\"default\": false, \"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "9478f044-1568-4d58-b0e3-507d13eb377e",
+            "uuid": "d113adc2-aff0-452c-adc1-8414b083b207",
             "when": null,
             "workflow_outputs": []
         },
@@ -245,13 +248,13 @@
             "outputs": [],
             "position": {
                 "left": 24.81191671531622,
-                "top": 2062.973286962767
+                "top": 1859.0732869627668
             },
             "tool_id": null,
             "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "8946c9cf-6462-4ecb-bfb5-53e04b8e6ab5",
+            "uuid": "3abf087d-71a8-40f7-b83c-19645564a65f",
             "when": null,
             "workflow_outputs": []
         },
@@ -272,13 +275,13 @@
             "outputs": [],
             "position": {
                 "left": 28.161894269887082,
-                "top": 2210.1029067508402
+                "top": 2006.2029067508402
             },
             "tool_id": null,
             "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "c2953d78-aa58-4f26-b7e0-b1cd4d09e22b",
+            "uuid": "1a6b9d68-55bb-4ab9-9ab5-277c08e16b95",
             "when": null,
             "workflow_outputs": []
         },
@@ -299,13 +302,13 @@
             "outputs": [],
             "position": {
                 "left": 35.74544588141396,
-                "top": 2329.2443452184816
+                "top": 2125.3443452184815
             },
             "tool_id": null,
             "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "4e6bb427-0b7c-49ea-9955-acce33b56980",
+            "uuid": "0ce51ebc-2e9c-4790-8e57-5a7bfd176bc2",
             "when": null,
             "workflow_outputs": []
         },
@@ -326,13 +329,13 @@
             "outputs": [],
             "position": {
                 "left": 32.735609612839866,
-                "top": 2455.5482659375934
+                "top": 2251.6482659375934
             },
             "tool_id": null,
             "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "7cdf1440-f518-4f1b-9e12-d2cae91e666c",
+            "uuid": "6e82db4e-ed10-4c07-875f-15dc1de4247e",
             "when": null,
             "workflow_outputs": []
         },
@@ -362,7 +365,7 @@
             ],
             "position": {
                 "left": 704.0514740558186,
-                "top": 1710.1503530749274
+                "top": 1506.2503530749273
             },
             "post_job_actions": {
                 "HideDatasetActionlog_output": {
@@ -410,13 +413,13 @@
             "tool_uuid": null,
             "tool_version": "1.2.9+galaxy2",
             "type": "tool",
-            "uuid": "ff4e0fc6-de47-4fcc-bc10-98494741712a",
+            "uuid": "25f93957-6015-4e8c-bd13-0cceaed2fa94",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Megahit Contigs Output",
                     "output_name": "output",
-                    "uuid": "291628a5-b5cc-40e6-9cc4-903edd81f44a"
+                    "uuid": "dc917ccb-5087-4747-ae20-295c9e664b85"
                 }
             ]
         },
@@ -442,7 +445,7 @@
             ],
             "position": {
                 "left": 1893.4994812563964,
-                "top": 532.3960481700308
+                "top": 328.4960481700308
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
@@ -456,7 +459,7 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "b2998a59-fd2d-47eb-83ce-b13f9f39ea80",
+            "uuid": "f8f88eea-0202-4dc7-b746-dd4b6b6a7ad8",
             "when": "$(inputs.when)",
             "workflow_outputs": []
         },
@@ -482,15 +485,9 @@
             ],
             "position": {
                 "left": 961.5618135797032,
-                "top": 1810.693390546621
+                "top": 1606.793390546621
             },
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output"
-                }
-            },
+            "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.1",
             "tool_shed_repository": {
                 "changeset_revision": "e7ed3c310b74",
@@ -502,7 +499,7 @@
             "tool_uuid": null,
             "tool_version": "1.1.1",
             "type": "tool",
-            "uuid": "9de5ef5b-d300-49d4-ab58-a6d2cc7cbe0c",
+            "uuid": "fa135585-8d48-4b50-92fe-6965b6190fec",
             "when": null,
             "workflow_outputs": []
         },
@@ -548,7 +545,7 @@
             ],
             "position": {
                 "left": 741,
-                "top": 2024.072463199814
+                "top": 1820.1724631998138
             },
             "post_job_actions": {
                 "HideDatasetActionmetrics_pdf": {
@@ -587,18 +584,18 @@
             "tool_uuid": null,
             "tool_version": "5.3.0+galaxy1",
             "type": "tool",
-            "uuid": "bda52053-e7b0-4683-bcc1-6abaaf18d4a7",
+            "uuid": "fe7cf1a6-77ad-4f34-adb4-dbbe8c700eef",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Report Tabular Meta",
                     "output_name": "report_tabular_meta",
-                    "uuid": "f7d68b96-75dd-4eaf-85e9-b7e7f8b3abbd"
+                    "uuid": "b483b9c8-8eb5-4409-8bf0-a82f66501565"
                 },
                 {
                     "label": "Report HTML Meta",
                     "output_name": "report_html_meta",
-                    "uuid": "9575142c-00f9-4590-8633-a703eb341fb6"
+                    "uuid": "74772fcc-963c-4eb8-b7a4-950d798fb7fe"
                 }
             ]
         },
@@ -623,8 +620,8 @@
                 }
             ],
             "position": {
-                "left": 2816.367304179116,
-                "top": 0
+                "left": 2731.317840191383,
+                "top": 40.26836104596575
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
@@ -638,13 +635,13 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "07b92411-e28b-483c-9c90-df17d6e195dd",
+            "uuid": "bb1d12f6-9b5d-4896-a581-4f9fed3394ae",
             "when": null,
             "workflow_outputs": []
         },
         "12": {
             "annotation": "Adds the sample name to the column corresponding to the initial ID. Allows you to create a unique ID for each sample.",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.3.0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.2.0",
             "errors": null,
             "id": 12,
             "input_connections": {
@@ -653,7 +650,12 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Add input name as column",
+                    "name": "input"
+                }
+            ],
             "label": null,
             "name": "Add input name as column",
             "outputs": [
@@ -664,27 +666,21 @@
             ],
             "position": {
                 "left": 1020.2674300607999,
-                "top": 2064.5201311287324
+                "top": 1860.6201311287323
             },
-            "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
-                    "output_name": "output"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.3.0",
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.2.0",
             "tool_shed_repository": {
                 "changeset_revision": "8a19efbd2178",
                 "name": "add_input_name_as_column",
                 "owner": "mvdbeek",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"header\": {\"contains_header\": \"no\", \"__current_case__\": 1}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"prepend\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"header\": {\"contains_header\": \"no\", \"__current_case__\": 1}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"prepend\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
-            "tool_version": "0.3.0",
+            "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "1a63545e-f06a-4667-bbff-cc0e6455f9b5",
+            "uuid": "079e46d4-46ac-419e-86cf-6afae9dbeb44",
             "when": null,
             "workflow_outputs": []
         },
@@ -710,12 +706,14 @@
             ],
             "position": {
                 "left": 1269.5,
-                "top": 2070.872512027939
+                "top": 1866.972512027939
             },
             "post_job_actions": {
-                "HideDatasetActionoutput": {
-                    "action_arguments": {},
-                    "action_type": "HideDatasetAction",
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "Megahit output with sample name in ID"
+                    },
+                    "action_type": "RenameDatasetAction",
                     "output_name": "output"
                 }
             },
@@ -730,87 +728,25 @@
             "tool_uuid": null,
             "tool_version": "1.1.1",
             "type": "tool",
-            "uuid": "32ece0be-c4ef-4da7-8002-67139bfc8086",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "14": {
-            "annotation": "Concatenate contigs from each sample",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy3",
-            "errors": null,
-            "id": 14,
-            "input_connections": {
-                "inputs": {
-                    "id": 13,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Concatenate datasets",
-            "outputs": [
-                {
-                    "name": "out_file1",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 1281.5272387173352,
-                "top": 1809.0177281033089
-            },
-            "post_job_actions": {
-                "ChangeDatatypeActionout_file1": {
-                    "action_arguments": {
-                        "newtype": "fasta"
-                    },
-                    "action_type": "ChangeDatatypeAction",
-                    "output_name": "out_file1"
-                },
-                "RenameDatasetActionout_file1": {
-                    "action_arguments": {
-                        "newname": "Concatenate Datasets"
-                    },
-                    "action_type": "RenameDatasetAction",
-                    "output_name": "out_file1"
-                },
-                "TagDatasetActionout_file1": {
-                    "action_arguments": {
-                        "tags": "fasta"
-                    },
-                    "action_type": "TagDatasetAction",
-                    "output_name": "out_file1"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy3",
-            "tool_shed_repository": {
-                "changeset_revision": "ab83aa685821",
-                "name": "text_processing",
-                "owner": "bgruening",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"inputs\": {\"__class__\": \"ConnectedValue\"}, \"queries\": [], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_uuid": null,
-            "tool_version": "9.5+galaxy3",
-            "type": "tool",
-            "uuid": "8bee23f7-b544-4159-8075-76bf1ae9f7ba",
+            "uuid": "14cea5ab-cdfe-4e24-9a20-88c334a8b30c",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Concatenate Datasets",
-                    "output_name": "out_file1",
-                    "uuid": "5976257e-e698-4c8a-b292-6dd8bf70e1a9"
+                    "label": "Megahit output with sample name in ID",
+                    "output_name": "output",
+                    "uuid": "1bfca289-deea-40a1-8100-c008713248a4"
                 }
             ]
         },
-        "15": {
+        "14": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/prodigal/prodigal/2.6.3+galaxy0",
             "errors": null,
-            "id": 15,
+            "id": 14,
             "input_connections": {
                 "input_fa": {
-                    "id": 14,
-                    "output_name": "out_file1"
+                    "id": 13,
+                    "output_name": "output"
                 }
             },
             "inputs": [
@@ -840,8 +776,8 @@
                 }
             ],
             "position": {
-                "left": 1583.2999877929688,
-                "top": 1814.6404387857513
+                "left": 1541.968038214129,
+                "top": 1610.7704659495164
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -880,22 +816,85 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"closed\": false, \"force_nonsd\": false, \"input_fa\": {\"__class__\": \"ConnectedValue\"}, \"input_train\": {\"__class__\": \"RuntimeValue\"}, \"masked_seq\": false, \"out_format\": \"gff\", \"procedure\": \"meta\", \"trans_table\": \"11\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"closed\": false, \"force_nonsd\": false, \"input_fa\": {\"__class__\": \"ConnectedValue\"}, \"input_train\": {\"__class__\": \"RuntimeValue\"}, \"masked_seq\": false, \"out_format\": \"gbk\", \"procedure\": \"meta\", \"trans_table\": \"11\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "2.6.3+galaxy0",
             "type": "tool",
-            "uuid": "06f072c7-1a9e-4ea6-9078-b304e6352672",
+            "uuid": "bfd85a6d-9fc3-46ee-b4c9-f0744fee1dbd",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Prodigal Genes Sequences",
                     "output_name": "output_fnn",
-                    "uuid": "5b73d4c2-e5e8-4e03-9306-ae534b95790f"
-                },
+                    "uuid": "173fd024-6aff-496a-be61-bec910ba3ce5"
+                }
+            ]
+        },
+        "15": {
+            "annotation": "Concatenate contigs from each sample",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy3",
+            "errors": null,
+            "id": 15,
+            "input_connections": {
+                "inputs": {
+                    "id": 14,
+                    "output_name": "output_fnn"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Concatenate datasets",
+            "outputs": [
                 {
-                    "label": "Prodigal Genes Translation",
-                    "output_name": "output_faa",
-                    "uuid": "e67ea780-0a11-4191-ae06-78f0923c8ab4"
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1840.434173553685,
+                "top": 1714.427320241335
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionout_file1": {
+                    "action_arguments": {
+                        "newtype": "fasta"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "out_file1"
+                },
+                "RenameDatasetActionout_file1": {
+                    "action_arguments": {
+                        "newname": "Concatenate Datasets"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out_file1"
+                },
+                "TagDatasetActionout_file1": {
+                    "action_arguments": {
+                        "tags": "fasta"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy3",
+            "tool_shed_repository": {
+                "changeset_revision": "c41d78ae5fee",
+                "name": "text_processing",
+                "owner": "bgruening",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"inputs\": {\"__class__\": \"ConnectedValue\"}, \"queries\": [], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "9.5+galaxy3",
+            "type": "tool",
+            "uuid": "dac7aa53-0c0a-4908-94b9-52d516a05577",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Concatenate Datasets",
+                    "output_name": "out_file1",
+                    "uuid": "f4646839-ef35-4b77-8a77-373b48bd22e4"
                 }
             ]
         },
@@ -907,14 +906,19 @@
             "input_connections": {
                 "input_fasta": {
                     "id": 15,
-                    "output_name": "output_fnn"
+                    "output_name": "out_file1"
                 },
                 "when": {
                     "id": 2,
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool MMseqs2 easy-linclust",
+                    "name": "input_fasta"
+                }
+            ],
             "label": "MMseqs2 full catalogue Sequence Clustering",
             "name": "MMseqs2 easy-linclust",
             "outputs": [
@@ -933,7 +937,7 @@
             ],
             "position": {
                 "left": 3556.6777379335003,
-                "top": 598.9588926396602
+                "top": 395.05889263966026
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/mmseqs2_easy_linclust_clustering/mmseqs2_easy_linclust_clustering/17-b804f+galaxy1",
@@ -943,11 +947,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"align\": {\"convertalis\": false, \"alignment_output_mode\": \"0\", \"wrapped_scoring\": false, \"min_aln_len\": \"0\", \"seq_id_mode\": \"0\", \"alt_ali\": \"0\", \"score_bias\": \"0.0\", \"realign\": false, \"realign_score_bias\": \"-0.2\", \"realign_max_seqs\": \"2147483647\", \"corr_score_weight\": \"0.0\", \"alignment_mode\": \"0\", \"evalue\": \"0.001\", \"max_rejected\": \"2147483647\", \"max_accept\": \"2147483647\"}, \"alph_type\": {\"dbtype\": \"0\", \"__current_case__\": 0}, \"cluster\": {\"cluster_mode\": \"0\", \"max_iterations\": \"1000\", \"similarity_type\": \"2\"}, \"common\": {\"max_seq_len\": \"65535\"}, \"cov\": \"0.8\", \"cov_mode\": \"0\", \"expert\": {\"filter_hits\": false, \"sort_results\": \"0\"}, \"input_fasta\": {\"__class__\": \"ConnectedValue\"}, \"kmermatcher\": {\"cluster_weight_threshold\": \"0.9\", \"kmer_per_seq\": \"21\", \"hash_shift\": \"67\", \"include_only_extendable\": false, \"ignore_multi_kmer\": false}, \"min_seq_id\": \"0.95\", \"misc\": {\"rescore_mode\": \"0\", \"shuffle\": true, \"id_offset\": \"0\"}, \"output_files\": {\"output_selection\": [\"file_rep_seq\", \"file_all_seq\", \"file_cluster_tsv\"]}, \"prefilter\": {\"add_self_matches\": false, \"kmer_length\": \"0\", \"mask\": \"1\", \"mask_prob\": \"0.9\", \"mask_lower_case\": \"0\", \"mask_n_repeat\": \"0\", \"spaced_kmer_mode\": \"0\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"align\": {\"convertalis\": false, \"alignment_output_mode\": \"0\", \"wrapped_scoring\": false, \"min_aln_len\": \"0\", \"seq_id_mode\": \"0\", \"alt_ali\": \"0\", \"score_bias\": \"0.0\", \"realign\": false, \"realign_score_bias\": \"-0.2\", \"realign_max_seqs\": \"2147483647\", \"corr_score_weight\": \"0.0\", \"alignment_mode\": \"0\", \"evalue\": \"0.001\", \"max_rejected\": \"2147483647\", \"max_accept\": \"2147483647\"}, \"alph_type\": {\"dbtype\": \"0\", \"__current_case__\": 0}, \"cluster\": {\"cluster_mode\": \"0\", \"max_iterations\": \"1000\", \"similarity_type\": \"2\"}, \"common\": {\"max_seq_len\": \"65535\"}, \"cov\": \"0.8\", \"cov_mode\": \"0\", \"expert\": {\"filter_hits\": false, \"sort_results\": \"0\"}, \"input_fasta\": {\"__class__\": \"RuntimeValue\"}, \"kmermatcher\": {\"cluster_weight_threshold\": \"0.9\", \"kmer_per_seq\": \"21\", \"hash_shift\": \"67\", \"include_only_extendable\": false, \"ignore_multi_kmer\": false}, \"min_seq_id\": \"0.95\", \"misc\": {\"rescore_mode\": \"0\", \"shuffle\": true, \"id_offset\": \"0\"}, \"output_files\": {\"output_selection\": [\"file_rep_seq\", \"file_all_seq\", \"file_cluster_tsv\"]}, \"prefilter\": {\"add_self_matches\": false, \"kmer_length\": \"0\", \"mask\": \"1\", \"mask_prob\": \"0.9\", \"mask_lower_case\": \"0\", \"mask_n_repeat\": \"0\", \"spaced_kmer_mode\": \"0\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "17-b804f+galaxy1",
             "type": "tool",
-            "uuid": "08f0c03f-55cc-4bad-9552-714ce261a9a2",
+            "uuid": "a36905e6-cb48-460f-9ece-0805a16733e5",
             "when": "$(inputs.when)",
             "workflow_outputs": []
         },
@@ -958,7 +962,7 @@
             "id": 17,
             "input_connections": {
                 "style_cond|type_cond|default_value": {
-                    "id": 15,
+                    "id": 14,
                     "output_name": "output_fnn"
                 },
                 "style_cond|type_cond|pick_from_0|value": {
@@ -977,7 +981,7 @@
             ],
             "position": {
                 "left": 1857.8199064478258,
-                "top": 1225.9827559014673
+                "top": 1022.0827559014673
             },
             "post_job_actions": {
                 "HideDatasetActiondata_param": {
@@ -997,7 +1001,7 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "4c95ed32-517c-4fc5-945a-1b56c95d1d7f",
+            "uuid": "823dfaf1-5fac-4153-889f-ae4265a5face",
             "when": null,
             "workflow_outputs": []
         },
@@ -1036,7 +1040,7 @@
             ],
             "position": {
                 "left": 2267.3867379148996,
-                "top": 696.5086905244358
+                "top": 492.6086905244358
             },
             "post_job_actions": {
                 "RenameDatasetActionamrfinderplus_report": {
@@ -1056,21 +1060,22 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/amrfinderplus/amrfinderplus/3.12.8+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "7844dbe4f8e2",
+                "changeset_revision": "573cfe217474",
                 "name": "amrfinderplus",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"input_option\": {\"amrfinder_db_select\": {\"__class__\": \"ConnectedValue\"}, \"input_mode\": {\"input_select\": \"nucleotide\", \"__current_case__\": 0, \"nucleotide_input\": {\"__class__\": \"ConnectedValue\"}, \"nucleotide_flank5_size\": \"0\"}}, \"options\": {\"ident_min\": \"-1.0\", \"coverage_min\": \"0.5\", \"translation_table\": \"11\", \"plus\": false, \"report_all_equal\": false, \"print_node\": false, \"name\": null}, \"organism_options\": {\"organism_conditionnal\": {\"organism_select\": \"\", \"__current_case__\": 1}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
             "tool_version": "3.12.8+galaxy0",
             "type": "tool",
-            "uuid": "f98e779d-eeed-4b91-9156-531c4f4c1bd0",
+            "uuid": "a64e36b2-8d96-487b-bf90-cf5136b188a9",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "AMRFinderplus Report",
                     "output_name": "amrfinderplus_report",
-                    "uuid": "c8890358-b75a-4b1c-9ca0-ecc970b0fd7b"
+                    "uuid": "ebe6806e-6a38-4a26-87af-8792fa58e78a"
                 }
             ]
         },
@@ -1093,6 +1098,10 @@
                 {
                     "description": "runtime parameter for tool ABRicate",
                     "name": "adv"
+                },
+                {
+                    "description": "runtime parameter for tool ABRicate",
+                    "name": "file_input"
                 }
             ],
             "label": null,
@@ -1105,7 +1114,7 @@
             ],
             "position": {
                 "left": 2277.6662666154916,
-                "top": 1040.835551418423
+                "top": 836.935551418423
             },
             "post_job_actions": {
                 "RenameDatasetActionreport": {
@@ -1123,17 +1132,17 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"adv\": {\"db\": {\"__class__\": \"ConnectedValue\"}, \"no_header\": false, \"min_dna_id\": \"80.0\", \"min_cov\": \"80.0\"}, \"file_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"adv\": {\"db\": {\"__class__\": \"ConnectedValue\"}, \"no_header\": false, \"min_dna_id\": \"80.0\", \"min_cov\": \"80.0\"}, \"file_input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "1.4.0",
             "type": "tool",
-            "uuid": "89f6edb4-98e8-4640-b7fe-7c82412c1996",
+            "uuid": "ad065f5c-aa8a-4910-bec4-ddda0af1dca6",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Abricate Virulence Report",
                     "output_name": "report",
-                    "uuid": "38f48071-defa-4175-800c-f73525e79967"
+                    "uuid": "19618920-0780-45cf-8e61-22a9d23050f9"
                 }
             ]
         },
@@ -1156,6 +1165,10 @@
                 {
                     "description": "runtime parameter for tool staramr",
                     "name": "advanced"
+                },
+                {
+                    "description": "runtime parameter for tool staramr",
+                    "name": "genomes"
                 }
             ],
             "label": null,
@@ -1188,13 +1201,18 @@
             ],
             "position": {
                 "left": 2265.4516712779136,
-                "top": 1324.7173077128004
+                "top": 1120.8173077128004
             },
             "post_job_actions": {
                 "HideDatasetActionmlst": {
                     "action_arguments": {},
                     "action_type": "HideDatasetAction",
                     "output_name": "mlst"
+                },
+                "HideDatasetActionpointfinder": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "pointfinder"
                 },
                 "RenameDatasetActionblast_hits": {
                     "action_arguments": {
@@ -1253,123 +1271,151 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"advanced\": {\"pid_threshold\": \"98.0\", \"percent_length_overlap_resfinder\": \"60.0\", \"percent_length_overlap_pointfinder\": \"95.0\", \"percent_length_overlap_plasmidfinder\": \"60.0\", \"genome_size_lower_bound\": \"4000000\", \"genome_size_upper_bound\": \"6000000\", \"minimum_N50_value\": \"10000\", \"minimum_contig_length\": \"300\", \"unacceptable_number_contigs\": \"1000\", \"report_all_blast\": false, \"exclude_negatives\": false, \"exclude_resistance_phenotypes\": false, \"mlst_scheme\": \"auto\", \"exclude_genes\": {\"exclude_genes_condition\": \"default\", \"__current_case__\": 0}, \"complex_mutations_file\": {\"__class__\": \"RuntimeValue\"}, \"plasmidfinder_type\": \"include_all\"}, \"genomes\": {\"__class__\": \"ConnectedValue\"}, \"hide_db_build\": \"\", \"output_files\": {\"output_selection\": [\"mlst_table\", \"summary_table\", \"detailed_summary_table\", \"resfinder_table\", \"plasmidfinder_table\", \"pointfinder_table\"]}, \"pointfinder_organism\": \"disabled\", \"staramr_db_select\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"advanced\": {\"pid_threshold\": \"98.0\", \"percent_length_overlap_resfinder\": \"60.0\", \"percent_length_overlap_pointfinder\": \"95.0\", \"percent_length_overlap_plasmidfinder\": \"60.0\", \"genome_size_lower_bound\": \"4000000\", \"genome_size_upper_bound\": \"6000000\", \"minimum_N50_value\": \"10000\", \"minimum_contig_length\": \"300\", \"unacceptable_number_contigs\": \"1000\", \"report_all_blast\": false, \"exclude_negatives\": false, \"exclude_resistance_phenotypes\": false, \"mlst_scheme\": \"auto\", \"exclude_genes\": {\"exclude_genes_condition\": \"default\", \"__current_case__\": 0}, \"complex_mutations_file\": {\"__class__\": \"RuntimeValue\"}, \"plasmidfinder_type\": \"include_all\"}, \"genomes\": {\"__class__\": \"RuntimeValue\"}, \"hide_db_build\": \"\", \"output_files\": {\"output_selection\": [\"mlst_table\", \"summary_table\", \"detailed_summary_table\", \"resfinder_table\", \"plasmidfinder_table\", \"pointfinder_table\"]}, \"pointfinder_organism\": \"disabled\", \"staramr_db_select\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "0.12.3+galaxy0",
             "type": "tool",
-            "uuid": "35f3f5f1-db8c-4437-b64a-8dfab4031705",
+            "uuid": "1f9e38db-f209-4f44-83aa-02292382c9eb",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Detailed Summary",
-                    "output_name": "detailed_summary",
-                    "uuid": "48806989-fead-472f-92fe-601d8ae8c87f"
-                },
-                {
                     "label": "Plasmidfinder",
                     "output_name": "plasmidfinder",
-                    "uuid": "6830b124-1d27-4aa5-b2ea-6dd4b023f25e"
+                    "uuid": "fbe752a4-24ee-4cd0-b123-b7bafdf7d3e8"
+                },
+                {
+                    "label": "Detailed Summary",
+                    "output_name": "detailed_summary",
+                    "uuid": "4d1b8aec-f819-456b-9b05-f75354f360d4"
                 },
                 {
                     "label": "Resfinder",
                     "output_name": "resfinder",
-                    "uuid": "95f19e5e-0081-45e8-a904-61f0b92459e3"
+                    "uuid": "8cf293a1-7118-4926-95cd-6d6da8a6f670"
                 }
             ]
         },
         "21": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/argnorm/argnorm/1.0.0+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
             "errors": null,
             "id": 21,
             "input_connections": {
-                "input": {
+                "input_list": {
                     "id": 18,
                     "output_name": "amrfinderplus_report"
                 }
             },
             "inputs": [],
             "label": null,
-            "name": "argNorm",
+            "name": "Collapse Collection",
             "outputs": [
                 {
                     "name": "output",
-                    "type": "tsv"
+                    "type": "input"
                 }
             ],
             "position": {
-                "left": 2561.6505505022333,
-                "top": 771.816795260264
+                "left": 2599.666748046875,
+                "top": 548.7666320800781
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
                     "action_arguments": {
-                        "newname": "Argnorm AMRfinderplus Report"
+                        "newname": "AMRfinderplus Concatenated Reports"
                     },
                     "action_type": "RenameDatasetAction",
                     "output_name": "output"
+                },
+                "TagDatasetActionoutput": {
+                    "action_arguments": {
+                        "tags": "AMRFinderplusConcatenated"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "output"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/argnorm/argnorm/1.0.0+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
             "tool_shed_repository": {
-                "changeset_revision": "d8e95a03321a",
-                "name": "argnorm",
-                "owner": "iuc",
+                "changeset_revision": "90981f86000f",
+                "name": "collapse_collections",
+                "owner": "nml",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"__input_ext\": \"input\", \"choose_tool\": {\"tool\": \"amrfinderplus\", \"__current_case__\": 4}, \"chromInfo\": \"/shared/ifbstor1/galaxy/mutable-config/tool-data/shared/ucsc/chrom/?.len\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"filename\": {\"add_name\": false, \"__current_case__\": 1}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
-            "tool_version": "1.0.0+galaxy0",
+            "tool_version": "5.1.0",
             "type": "tool",
-            "uuid": "f4d9e16b-ba44-497a-896b-40f3136ce7d6",
+            "uuid": "cb656d71-0d17-4247-8134-59aef2437251",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Argnorm AMRfinderplus Report",
+                    "label": "AMRfinderplus Concatenated Reports",
                     "output_name": "output",
-                    "uuid": "cac5b85b-d819-4237-bb17-3d37a15f4072"
+                    "uuid": "92fc2547-5e31-4107-ac8f-c1b2595386a6"
                 }
             ]
         },
         "22": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/recetox/table_pandas_rename_column/table_pandas_rename_column/3.0.2+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
             "errors": null,
             "id": 22,
             "input_connections": {
-                "input_dataset": {
+                "input_list": {
                     "id": 19,
                     "output_name": "report"
                 }
             },
             "inputs": [],
             "label": null,
-            "name": "table rename column",
+            "name": "Collapse Collection",
             "outputs": [
                 {
-                    "name": "output_dataset",
+                    "name": "output",
                     "type": "input"
                 }
             ],
             "position": {
-                "left": 4642.103682342502,
-                "top": 954.6835847382431
+                "left": 2655.3179470940436,
+                "top": 922.9076350507747
             },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/recetox/table_pandas_rename_column/table_pandas_rename_column/3.0.2+galaxy0",
+            "post_job_actions": {
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "ABRicate Virulence Concatenated Reports"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                },
+                "TagDatasetActionoutput": {
+                    "action_arguments": {
+                        "tags": "ABRicateConcatenated"
+                    },
+                    "action_type": "TagDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
             "tool_shed_repository": {
-                "changeset_revision": "761f8ab8fdb6",
-                "name": "table_pandas_rename_column",
-                "owner": "recetox",
+                "changeset_revision": "90981f86000f",
+                "name": "collapse_collections",
+                "owner": "nml",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"columns_selection\": [{\"__index__\": 0, \"column\": \"1\", \"new_name\": \"FILE\"}], \"input_dataset\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"filename\": {\"add_name\": false, \"__current_case__\": 1}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
-            "tool_version": "3.0.2+galaxy0",
+            "tool_version": "5.1.0",
             "type": "tool",
-            "uuid": "a3e7738f-5d0a-4483-af8b-7d0782dcbd5e",
+            "uuid": "deb5afbd-e3cf-4751-b5f4-131ef92ba516",
             "when": null,
-            "workflow_outputs": []
+            "workflow_outputs": [
+                {
+                    "label": "ABRicate Virulence Concatenated Reports",
+                    "output_name": "output",
+                    "uuid": "2239f73f-d3c9-45a1-903f-4e7c925a76c4"
+                }
+            ]
         },
         "23": {
             "annotation": "",
@@ -1393,7 +1439,7 @@
             ],
             "position": {
                 "left": 4763.0487513774915,
-                "top": 1296.3369415908926
+                "top": 1092.4369415908925
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/column_remove_by_header/column_remove_by_header/1.0",
@@ -1407,23 +1453,174 @@
             "tool_uuid": null,
             "tool_version": "1.0",
             "type": "tool",
-            "uuid": "804053b7-be86-40ca-92f9-e248e749eeae",
+            "uuid": "365155d2-6ea4-48c5-8338-31f1f87acc3e",
             "when": null,
             "workflow_outputs": []
         },
         "24": {
-            "annotation": "Workflow for retrieving the IDs of contigs and CDSs of antibiotic resistance genes and filtering Prodigal output to retrieve a catalogue of antibiotic resistance genes and potential genes present on the same contig as the ARG.",
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/argnorm/argnorm/1.0.0+galaxy0",
+            "errors": null,
             "id": 24,
             "input_connections": {
+                "input": {
+                    "id": 21,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "argNorm",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "tsv"
+                }
+            ],
+            "position": {
+                "left": 2877.6666259765625,
+                "top": 572.63330078125
+            },
+            "post_job_actions": {
+                "RemoveTagDatasetActionoutput": {
+                    "action_arguments": {
+                        "tags": "argNormAMRFinderPlusconcatenated"
+                    },
+                    "action_type": "RemoveTagDatasetAction",
+                    "output_name": "output"
+                },
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "Argnorm AMRfinderplus Concatenated Reports"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/argnorm/argnorm/1.0.0+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "d8e95a03321a",
+                "name": "argnorm",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"choose_tool\": {\"tool\": \"amrfinderplus\", \"__current_case__\": 4}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "1.0.0+galaxy0",
+            "type": "tool",
+            "uuid": "805a418b-e20a-4428-85c6-95b4166490ae",
+            "when": null,
+            "workflow_outputs": [
+                {
+                    "label": "Argnorm AMRfinderplus Concatenated Reports",
+                    "output_name": "output",
+                    "uuid": "fd2c1d56-ac8b-4e83-923e-fa512efb48a9"
+                }
+            ]
+        },
+        "25": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/column_remove_by_header/column_remove_by_header/1.0",
+            "errors": null,
+            "id": 25,
+            "input_connections": {
+                "input_tabular": {
+                    "id": 21,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Remove columns",
+            "outputs": [
+                {
+                    "name": "output_tabular",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 4911.048629307179,
+                "top": 932.9369415908926
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/column_remove_by_header/column_remove_by_header/1.0",
+            "tool_shed_repository": {
+                "changeset_revision": "2040e4c2750a",
+                "name": "column_remove_by_header",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"headers\": [{\"__index__\": 0, \"name\": \"Protein identifier\"}], \"input_tabular\": {\"__class__\": \"ConnectedValue\"}, \"keep_columns\": false, \"strip_characters\": \"#\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "1.0",
+            "type": "tool",
+            "uuid": "adaf0a0b-12c2-44b9-b606-9b57f8c52e63",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "26": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/recetox/table_pandas_rename_column/table_pandas_rename_column/3.0.2+galaxy0",
+            "errors": null,
+            "id": 26,
+            "input_connections": {
+                "input_dataset": {
+                    "id": 22,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool table rename column",
+                    "name": "input_dataset"
+                }
+            ],
+            "label": null,
+            "name": "table rename column",
+            "outputs": [
+                {
+                    "name": "output_dataset",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 4642.103682342502,
+                "top": 750.7835847382431
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/recetox/table_pandas_rename_column/table_pandas_rename_column/3.0.2+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "761f8ab8fdb6",
+                "name": "table_pandas_rename_column",
+                "owner": "recetox",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"columns_selection\": [{\"__index__\": 0, \"column\": \"1\", \"new_name\": \"FILE\"}], \"input_dataset\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "3.0.2+galaxy0",
+            "type": "tool",
+            "uuid": "b8b3ec82-5895-4f9c-a8a3-7b6c48b6dc8c",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "27": {
+            "annotation": "Workflow for retrieving the IDs of contigs and CDSs of antibiotic resistance genes and filtering Prodigal output to retrieve a catalogue of antibiotic resistance genes and potential genes present on the same contig as the ARG.",
+            "id": 27,
+            "input_connections": {
                 "ABRicate Tabular report": {
-                    "id": 19,
+                    "id": 22,
                     "input_subworkflow_step_id": 1,
-                    "output_name": "report"
+                    "output_name": "output"
+                },
+                "Megahit contigs": {
+                    "id": 13,
+                    "input_subworkflow_step_id": 3,
+                    "output_name": "output"
                 },
                 "Prodigal Genes Sequences": {
                     "id": 15,
-                    "input_subworkflow_step_id": 3,
-                    "output_name": "output_fnn"
+                    "input_subworkflow_step_id": 4,
+                    "output_name": "out_file1"
                 },
                 "StarAMR Tabular report": {
                     "id": 20,
@@ -1431,7 +1628,7 @@
                     "output_name": "resfinder"
                 },
                 "argNorm AMRFinderPlus Tabular report": {
-                    "id": 21,
+                    "id": 24,
                     "input_subworkflow_step_id": 0,
                     "output_name": "output"
                 },
@@ -1445,8 +1642,8 @@
             "name": "Genes catalogue AMR specific part",
             "outputs": [],
             "position": {
-                "left": 3069.771643272908,
-                "top": 870.2448945224505
+                "left": 3119.2333984375,
+                "top": 770.433349609375
             },
             "subworkflow": {
                 "a_galaxy_workflow": "true",
@@ -1495,7 +1692,7 @@
                         "outputs": [],
                         "position": {
                             "left": 0,
-                            "top": 260
+                            "top": 566.4543601883091
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"format\": [\"tsv\"], \"tag\": null}",
@@ -1521,8 +1718,8 @@
                         "name": "Input dataset",
                         "outputs": [],
                         "position": {
-                            "left": 300,
-                            "top": 450
+                            "left": 310,
+                            "top": 756.4543601883091
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"format\": [\"tabular\"], \"tag\": null}",
@@ -1549,7 +1746,7 @@
                         "outputs": [],
                         "position": {
                             "left": 0,
-                            "top": 620
+                            "top": 926.4543601883091
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"format\": [\"tabular\"], \"tag\": null}",
@@ -1568,6 +1765,33 @@
                         "inputs": [
                             {
                                 "description": "",
+                                "name": "Megahit contigs"
+                            }
+                        ],
+                        "label": "Megahit contigs",
+                        "name": "Input dataset collection",
+                        "outputs": [],
+                        "position": {
+                            "left": 931.4445699571847,
+                            "top": 50.842641921926315
+                        },
+                        "tool_id": null,
+                        "tool_state": "{\"optional\": false, \"tag\": null, \"collection_type\": \"list\", \"fields\": null, \"column_definitions\": null}",
+                        "tool_version": null,
+                        "type": "data_collection_input",
+                        "uuid": "00247760-814d-4406-b704-42fb18c33566",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "4": {
+                        "annotation": "",
+                        "content_id": null,
+                        "errors": null,
+                        "id": 4,
+                        "input_connections": {},
+                        "inputs": [
+                            {
+                                "description": "",
                                 "name": "Prodigal Genes Sequences"
                             }
                         ],
@@ -1575,8 +1799,8 @@
                         "name": "Input dataset",
                         "outputs": [],
                         "position": {
-                            "left": 900,
-                            "top": 0
+                            "left": 930,
+                            "top": 246.45436018830912
                         },
                         "tool_id": null,
                         "tool_state": "{\"optional\": false, \"format\": [\"fasta\"], \"tag\": null}",
@@ -1586,11 +1810,11 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "4": {
-                        "annotation": "Retrieves the column corresponding to the contiguous IDs of the detected antibiotic resistance genes for AMRFinderPlus.",
+                    "5": {
+                        "annotation": "",
                         "content_id": "Cut1",
                         "errors": null,
-                        "id": 4,
+                        "id": 5,
                         "input_connections": {
                             "input": {
                                 "id": 0,
@@ -1607,8 +1831,8 @@
                             }
                         ],
                         "position": {
-                            "left": 300,
-                            "top": 260
+                            "left": 310,
+                            "top": 566.4543601883091
                         },
                         "post_job_actions": {
                             "HideDatasetActionout_file1": {
@@ -1640,11 +1864,11 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "5": {
-                        "annotation": "Retrieves the column corresponding to the contiguous IDs of the detected antibiotic resistance genes for ABRicate",
+                    "6": {
+                        "annotation": "",
                         "content_id": "Cut1",
                         "errors": null,
-                        "id": 5,
+                        "id": 6,
                         "input_connections": {
                             "input": {
                                 "id": 1,
@@ -1661,8 +1885,8 @@
                             }
                         ],
                         "position": {
-                            "left": 600,
-                            "top": 430
+                            "left": 620,
+                            "top": 736.4543601883091
                         },
                         "post_job_actions": {
                             "HideDatasetActionout_file1": {
@@ -1694,11 +1918,11 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "6": {
-                        "annotation": "Retrieves the column corresponding to the contiguous IDs of the detected antibiotic resistance genes for starAMR",
+                    "7": {
+                        "annotation": "",
                         "content_id": "Cut1",
                         "errors": null,
-                        "id": 6,
+                        "id": 7,
                         "input_connections": {
                             "input": {
                                 "id": 2,
@@ -1715,8 +1939,8 @@
                             }
                         ],
                         "position": {
-                            "left": 300,
-                            "top": 620
+                            "left": 310,
+                            "top": 926.4543601883091
                         },
                         "post_job_actions": {
                             "HideDatasetActionout_file1": {
@@ -1748,14 +1972,54 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "7": {
+                    "8": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.1",
+                        "errors": null,
+                        "id": 8,
+                        "input_connections": {
+                            "input": {
+                                "id": 3,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "FASTA-to-Tabular",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "tabular"
+                            }
+                        ],
+                        "position": {
+                            "left": 1234.6846128486739,
+                            "top": 36.31617280137593
+                        },
+                        "post_job_actions": {},
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.1",
+                        "tool_shed_repository": {
+                            "changeset_revision": "e7ed3c310b74",
+                            "name": "fasta_to_tabular",
+                            "owner": "devteam",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"descr_columns\": \"3\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"keep_first\": \"0\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "1.1.1",
+                        "type": "tool",
+                        "uuid": "439e0ecc-18ad-4c61-82c6-02accd7790aa",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "9": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy3",
                         "errors": null,
-                        "id": 7,
+                        "id": 9,
                         "input_connections": {
                             "infile": {
-                                "id": 3,
+                                "id": 4,
                                 "output_name": "output"
                             }
                         },
@@ -1769,13 +2033,13 @@
                             }
                         ],
                         "position": {
-                            "left": 1200,
-                            "top": 0
+                            "left": 1240,
+                            "top": 246.45436018830912
                         },
                         "post_job_actions": {},
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy3",
                         "tool_shed_repository": {
-                            "changeset_revision": "ab83aa685821",
+                            "changeset_revision": "c41d78ae5fee",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -1788,82 +2052,82 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "8": {
-                        "annotation": "Remove header line",
-                        "content_id": "Remove beginning1",
-                        "errors": null,
-                        "id": 8,
-                        "input_connections": {
-                            "input": {
-                                "id": 4,
-                                "output_name": "out_file1"
-                            }
-                        },
-                        "inputs": [],
-                        "label": null,
-                        "name": "Remove beginning",
-                        "outputs": [
-                            {
-                                "name": "out_file1",
-                                "type": "input"
-                            }
-                        ],
-                        "position": {
-                            "left": 600,
-                            "top": 260
-                        },
-                        "post_job_actions": {},
-                        "tool_id": "Remove beginning1",
-                        "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"num_lines\": \"1\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-                        "tool_uuid": null,
-                        "tool_version": "1.0.0",
-                        "type": "tool",
-                        "uuid": "a8405573-773d-4d2f-a3c0-4fe677cfc4ce",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
-                    "9": {
-                        "annotation": "Remove header line",
-                        "content_id": "Remove beginning1",
-                        "errors": null,
-                        "id": 9,
-                        "input_connections": {
-                            "input": {
-                                "id": 6,
-                                "output_name": "out_file1"
-                            }
-                        },
-                        "inputs": [],
-                        "label": null,
-                        "name": "Remove beginning",
-                        "outputs": [
-                            {
-                                "name": "out_file1",
-                                "type": "input"
-                            }
-                        ],
-                        "position": {
-                            "left": 600,
-                            "top": 620
-                        },
-                        "post_job_actions": {},
-                        "tool_id": "Remove beginning1",
-                        "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"num_lines\": \"1\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-                        "tool_uuid": null,
-                        "tool_version": "1.0.0",
-                        "type": "tool",
-                        "uuid": "c6f99a47-5888-4699-a945-9b247372cf4a",
-                        "when": null,
-                        "workflow_outputs": []
-                    },
                     "10": {
-                        "annotation": "Convert to tabular format to make it easier to modify the contig ID.",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.1",
+                        "annotation": "",
+                        "content_id": "Remove beginning1",
                         "errors": null,
                         "id": 10,
                         "input_connections": {
                             "input": {
+                                "id": 5,
+                                "output_name": "out_file1"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Remove beginning",
+                        "outputs": [
+                            {
+                                "name": "out_file1",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 620,
+                            "top": 566.4543601883091
+                        },
+                        "post_job_actions": {},
+                        "tool_id": "Remove beginning1",
+                        "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"num_lines\": \"1\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "1.0.0",
+                        "type": "tool",
+                        "uuid": "198b9efe-4775-4bc2-ab6d-da0e8d5cd30c",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "11": {
+                        "annotation": "",
+                        "content_id": "Remove beginning1",
+                        "errors": null,
+                        "id": 11,
+                        "input_connections": {
+                            "input": {
                                 "id": 7,
+                                "output_name": "out_file1"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Remove beginning",
+                        "outputs": [
+                            {
+                                "name": "out_file1",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 620,
+                            "top": 926.4543601883091
+                        },
+                        "post_job_actions": {},
+                        "tool_id": "Remove beginning1",
+                        "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"num_lines\": \"1\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "1.0.0",
+                        "type": "tool",
+                        "uuid": "fa8666d2-e53a-43cc-a231-68915751a599",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "12": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.1",
+                        "errors": null,
+                        "id": 12,
+                        "input_connections": {
+                            "input": {
+                                "id": 9,
                                 "output_name": "outfile"
                             }
                         },
@@ -1877,8 +2141,8 @@
                             }
                         ],
                         "position": {
-                            "left": 1500,
-                            "top": 0
+                            "left": 1550,
+                            "top": 246.45436018830912
                         },
                         "post_job_actions": {},
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.1",
@@ -1896,22 +2160,22 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "11": {
+                    "13": {
                         "annotation": "",
                         "content_id": "cat1",
                         "errors": null,
-                        "id": 11,
+                        "id": 13,
                         "input_connections": {
                             "input1": {
-                                "id": 8,
+                                "id": 10,
                                 "output_name": "out_file1"
                             },
                             "queries_0|input2": {
-                                "id": 5,
+                                "id": 6,
                                 "output_name": "out_file1"
                             },
                             "queries_1|input2": {
-                                "id": 9,
+                                "id": 11,
                                 "output_name": "out_file1"
                             }
                         },
@@ -1925,8 +2189,8 @@
                             }
                         ],
                         "position": {
-                            "left": 900,
-                            "top": 410
+                            "left": 930,
+                            "top": 716.4543601883091
                         },
                         "post_job_actions": {},
                         "tool_id": "cat1",
@@ -1938,18 +2202,18 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "12": {
+                    "14": {
                         "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/filter_by_fasta_ids/filter_by_fasta_ids/2.3",
                         "errors": null,
-                        "id": 12,
+                        "id": 14,
                         "input_connections": {
                             "header_criteria|identifiers": {
-                                "id": 11,
+                                "id": 13,
                                 "output_name": "out_file1"
                             },
                             "input": {
-                                "id": 3,
+                                "id": 4,
                                 "output_name": "output"
                             }
                         },
@@ -1968,15 +2232,22 @@
                             }
                         ],
                         "position": {
-                            "left": 1200,
-                            "top": 170
+                            "left": 1240,
+                            "top": 416.4543601883091
                         },
                         "post_job_actions": {
                             "RenameDatasetActionoutput": {
                                 "action_arguments": {
-                                    "newname": "FASTA with CDS corresponding to ARGs"
+                                    "newname": "FASTA with CDS corresponding to ARGs (ARGs)"
                                 },
                                 "action_type": "RenameDatasetAction",
+                                "output_name": "output"
+                            },
+                            "TagDatasetActionoutput": {
+                                "action_arguments": {
+                                    "tags": "CDS_ARGs"
+                                },
+                                "action_type": "TagDatasetAction",
                                 "output_name": "output"
                             }
                         },
@@ -1995,20 +2266,20 @@
                         "when": null,
                         "workflow_outputs": [
                             {
-                                "label": "FASTA with CDS corresponding to ARGs",
+                                "label": "FASTA with CDS corresponding to ARGs (ARGs)",
                                 "output_name": "output",
-                                "uuid": "f21a5707-5db1-4981-8b7a-5efbaf290045"
+                                "uuid": "0c4168bf-4ea2-4d7b-bfd0-fe70e29ec920"
                             }
                         ]
                     },
-                    "13": {
-                        "annotation": "Removal of specific CDS information added to contig IDs (last underscore and following characters). This allows the initial contig IDs to be obtained in order to match all contig CDSs when cross-referencing with Eggnogmapper and MMseqs2 output.",
+                    "15": {
+                        "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_column/9.5+galaxy3",
                         "errors": null,
-                        "id": 13,
+                        "id": 15,
                         "input_connections": {
                             "infile": {
-                                "id": 11,
+                                "id": 13,
                                 "output_name": "out_file1"
                             }
                         },
@@ -2022,13 +2293,13 @@
                             }
                         ],
                         "position": {
-                            "left": 1205.783920030092,
-                            "top": 438.9388926400997
+                            "left": 1240,
+                            "top": 716.4543601883091
                         },
                         "post_job_actions": {},
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_column/9.5+galaxy3",
                         "tool_shed_repository": {
-                            "changeset_revision": "ab83aa685821",
+                            "changeset_revision": "c41d78ae5fee",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2041,14 +2312,54 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "14": {
-                        "annotation": "Unique list with contig ID where ARGs have been found",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/unique/bg_uniq/0.3",
+                    "16": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.1",
                         "errors": null,
-                        "id": 14,
+                        "id": 16,
                         "input_connections": {
                             "input": {
-                                "id": 13,
+                                "id": 14,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "FASTA-to-Tabular",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "tabular"
+                            }
+                        ],
+                        "position": {
+                            "left": 1555.0171115674193,
+                            "top": 502.80617401445556
+                        },
+                        "post_job_actions": {},
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.1",
+                        "tool_shed_repository": {
+                            "changeset_revision": "e7ed3c310b74",
+                            "name": "fasta_to_tabular",
+                            "owner": "devteam",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"descr_columns\": \"1\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"keep_first\": \"0\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "1.1.1",
+                        "type": "tool",
+                        "uuid": "99b4cc63-01af-4559-ba43-8504bac25425",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "17": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/unique/bg_uniq/0.3",
+                        "errors": null,
+                        "id": 17,
+                        "input_connections": {
+                            "input": {
+                                "id": 15,
                                 "output_name": "outfile"
                             }
                         },
@@ -2062,8 +2373,8 @@
                             }
                         ],
                         "position": {
-                            "left": 1500,
-                            "top": 410
+                            "left": 1550,
+                            "top": 716.4543601883091
                         },
                         "post_job_actions": {},
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/unique/bg_uniq/0.3",
@@ -2081,18 +2392,70 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "15": {
-                        "annotation": "Link the prodigal file with the contigs related to antibiotic resistance genes to obtain information on the genetic context of antibiotic resistance.",
+                    "18": {
+                        "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.5+galaxy3",
                         "errors": null,
-                        "id": 15,
+                        "id": 18,
                         "input_connections": {
                             "infile1": {
-                                "id": 10,
+                                "id": 8,
                                 "output_name": "output"
                             },
                             "infile2": {
-                                "id": 14,
+                                "id": 17,
+                                "output_name": "outfile"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "Join Megahit to AMR",
+                        "name": "Join",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 1534.2930384600252,
+                            "top": 14.52646912055036
+                        },
+                        "post_job_actions": {
+                            "RenameDatasetActionoutput": {
+                                "action_arguments": {
+                                    "newname": "Prodigal Filtered with AMR"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "output"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.5+galaxy3",
+                        "tool_shed_repository": {
+                            "changeset_revision": "c41d78ae5fee",
+                            "name": "text_processing",
+                            "owner": "bgruening",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"column1\": \"1\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": false, \"ignore_case\": false, \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "9.5+galaxy3",
+                        "type": "tool",
+                        "uuid": "e059c135-0412-4cce-a04a-15e73a97c1db",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "19": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.5+galaxy2",
+                        "errors": null,
+                        "id": 19,
+                        "input_connections": {
+                            "infile1": {
+                                "id": 12,
+                                "output_name": "output"
+                            },
+                            "infile2": {
+                                "id": 17,
                                 "output_name": "outfile"
                             }
                         },
@@ -2106,8 +2469,8 @@
                             }
                         ],
                         "position": {
-                            "left": 1800,
-                            "top": 0
+                            "left": 1860,
+                            "top": 246.45436018830912
                         },
                         "post_job_actions": {
                             "RenameDatasetActionoutput": {
@@ -2118,35 +2481,69 @@
                                 "output_name": "output"
                             }
                         },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.5+galaxy3",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.5+galaxy2",
                         "tool_shed_repository": {
-                            "changeset_revision": "ab83aa685821",
+                            "changeset_revision": "c41d78ae5fee",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
                         "tool_state": "{\"column1\": \"1\", \"column2\": \"1\", \"empty_string_filler\": \"0\", \"header\": false, \"ignore_case\": false, \"infile1\": {\"__class__\": \"ConnectedValue\"}, \"infile2\": {\"__class__\": \"ConnectedValue\"}, \"jointype\": \" \", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
                         "tool_uuid": null,
-                        "tool_version": "9.5+galaxy3",
+                        "tool_version": "9.5+galaxy2",
                         "type": "tool",
                         "uuid": "75d1671c-22d9-438f-8eae-f86e01cc2f8a",
                         "when": null,
-                        "workflow_outputs": [
-                            {
-                                "label": "Prodigal Filtered with AMR",
-                                "output_name": "output",
-                                "uuid": "c40300a5-bf1a-44f2-8fce-357d818ff512"
-                            }
-                        ]
+                        "workflow_outputs": []
                     },
-                    "16": {
-                        "annotation": "Return to the fasta format with unique IDs.",
+                    "20": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+                        "errors": null,
+                        "id": 20,
+                        "input_connections": {
+                            "input_list": {
+                                "id": 18,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Collapse Collection",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 1832.085655431308,
+                            "top": 0
+                        },
+                        "post_job_actions": {},
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+                        "tool_shed_repository": {
+                            "changeset_revision": "90981f86000f",
+                            "name": "collapse_collections",
+                            "owner": "nml",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"filename\": {\"add_name\": false, \"__current_case__\": 1}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": false, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "5.1.0",
+                        "type": "tool",
+                        "uuid": "2b2933d2-4d10-4767-a96c-cd1950ddecf1",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "21": {
+                        "annotation": "",
                         "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.1",
                         "errors": null,
-                        "id": 16,
+                        "id": 21,
                         "input_connections": {
                             "input": {
-                                "id": 15,
+                                "id": 19,
                                 "output_name": "output"
                             }
                         },
@@ -2160,8 +2557,8 @@
                             }
                         ],
                         "position": {
-                            "left": 2100,
-                            "top": 0
+                            "left": 2170,
+                            "top": 246.45436018830912
                         },
                         "post_job_actions": {},
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.1",
@@ -2179,19 +2576,85 @@
                         "when": null,
                         "workflow_outputs": []
                     },
-                    "17": {
-                        "annotation": "Replace text putting the CDS part back in and returning to the original Prodigal IDs",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy3",
+                    "22": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.1",
                         "errors": null,
-                        "id": 17,
+                        "id": 22,
+                        "input_connections": {
+                            "input": {
+                                "id": 20,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [
+                            {
+                                "description": "runtime parameter for tool Tabular-to-FASTA",
+                                "name": "input"
+                            }
+                        ],
+                        "label": null,
+                        "name": "Tabular-to-FASTA",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "fasta"
+                            }
+                        ],
+                        "position": {
+                            "left": 2153.483784723485,
+                            "top": 1.8158086400687807
+                        },
+                        "post_job_actions": {
+                            "RenameDatasetActionoutput": {
+                                "action_arguments": {
+                                    "newname": "FASTA with contigs related to ARGs"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "output"
+                            },
+                            "TagDatasetActionoutput": {
+                                "action_arguments": {
+                                    "tags": "contigs_ARGs"
+                                },
+                                "action_type": "TagDatasetAction",
+                                "output_name": "output"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.1",
+                        "tool_shed_repository": {
+                            "changeset_revision": "0a7799698fe5",
+                            "name": "tabular_to_fasta",
+                            "owner": "devteam",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"seq_col\": \"4\", \"title_col\": [\"1\"], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "1.1.1",
+                        "type": "tool",
+                        "uuid": "a747e674-29b1-4a69-b7a1-176cec4a5eee",
+                        "when": null,
+                        "workflow_outputs": [
+                            {
+                                "label": "FASTA with contigs related to ARGs",
+                                "output_name": "output",
+                                "uuid": "888545e6-5f82-4407-a560-f606472a8086"
+                            }
+                        ]
+                    },
+                    "23": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy2",
+                        "errors": null,
+                        "id": 23,
                         "input_connections": {
                             "infile": {
-                                "id": 16,
+                                "id": 21,
                                 "output_name": "output"
                             }
                         },
                         "inputs": [],
-                        "label": "CDSs from contigs linked to an ARG",
+                        "label": "CDSs from contigs corresponding and related to an ARG",
                         "name": "Replace Text",
                         "outputs": [
                             {
@@ -2200,99 +2663,214 @@
                             }
                         ],
                         "position": {
-                            "left": 2400,
-                            "top": 0
+                            "left": 2480.003027945328,
+                            "top": 198.8963084856413
                         },
                         "post_job_actions": {
                             "RenameDatasetActionoutfile": {
                                 "action_arguments": {
-                                    "newname": "CDSs from contigs linked to an ARG"
+                                    "newname": "FASTA with CDS corresponding and related to ARGs (ARGs and linked to)"
                                 },
                                 "action_type": "RenameDatasetAction",
                                 "output_name": "outfile"
+                            },
+                            "TagDatasetActionoutfile": {
+                                "action_arguments": {
+                                    "tags": "CDS_related_to_and_ARGs"
+                                },
+                                "action_type": "TagDatasetAction",
+                                "output_name": "outfile"
                             }
                         },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy3",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy2",
                         "tool_shed_repository": {
-                            "changeset_revision": "ab83aa685821",
+                            "changeset_revision": "c41d78ae5fee",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
                         },
                         "tool_state": "{\"infile\": {\"__class__\": \"ConnectedValue\"}, \"replacements\": [{\"__index__\": 0, \"find_pattern\": \"^>([^ ]+)_# \", \"replace_pattern\": \">\\\\1 # \", \"sed_options\": null}], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
                         "tool_uuid": null,
-                        "tool_version": "9.5+galaxy3",
+                        "tool_version": "9.5+galaxy2",
                         "type": "tool",
                         "uuid": "0db8d26f-1e31-482f-af38-c454217c3a2d",
                         "when": null,
                         "workflow_outputs": [
                             {
-                                "label": "CDSs from contigs linked to an ARG",
+                                "label": "FASTA with CDS corresponding and related to ARGs (ARGs and linked to)",
                                 "output_name": "outfile",
-                                "uuid": "c3a8160e-45b9-4290-8cde-bb8b49797680"
+                                "uuid": "d67de833-c5f3-4777-8544-cafd6f2da7ac"
+                            }
+                        ]
+                    },
+                    "24": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.1",
+                        "errors": null,
+                        "id": 24,
+                        "input_connections": {
+                            "input": {
+                                "id": 23,
+                                "output_name": "outfile"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "FASTA-to-Tabular",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "tabular"
+                            }
+                        ],
+                        "position": {
+                            "left": 2367.515400410677,
+                            "top": 464.75004807331936
+                        },
+                        "post_job_actions": {},
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/fasta_to_tabular/fasta2tab/1.1.1",
+                        "tool_shed_repository": {
+                            "changeset_revision": "e7ed3c310b74",
+                            "name": "fasta_to_tabular",
+                            "owner": "devteam",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"descr_columns\": \"1\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"keep_first\": \"0\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "1.1.1",
+                        "type": "tool",
+                        "uuid": "86f5d234-99da-4cb9-90f8-e9168cc3dc8c",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "25": {
+                        "annotation": "",
+                        "content_id": "comp1",
+                        "errors": null,
+                        "id": 25,
+                        "input_connections": {
+                            "input1": {
+                                "id": 24,
+                                "output_name": "output"
+                            },
+                            "input2": {
+                                "id": 16,
+                                "output_name": "output"
+                            }
+                        },
+                        "inputs": [],
+                        "label": null,
+                        "name": "Compare two Datasets",
+                        "outputs": [
+                            {
+                                "name": "out_file1",
+                                "type": "input"
+                            }
+                        ],
+                        "position": {
+                            "left": 2055.45516769336,
+                            "top": 634.0998085113755
+                        },
+                        "post_job_actions": {},
+                        "tool_id": "comp1",
+                        "tool_state": "{\"field1\": \"1\", \"field2\": \"1\", \"input1\": {\"__class__\": \"ConnectedValue\"}, \"input2\": {\"__class__\": \"ConnectedValue\"}, \"mode\": \"V\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "1.0.2",
+                        "type": "tool",
+                        "uuid": "02e426ca-d9b6-4602-8a2e-dac0f7887520",
+                        "when": null,
+                        "workflow_outputs": []
+                    },
+                    "26": {
+                        "annotation": "",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.1",
+                        "errors": null,
+                        "id": 26,
+                        "input_connections": {
+                            "input": {
+                                "id": 25,
+                                "output_name": "out_file1"
+                            }
+                        },
+                        "inputs": [],
+                        "label": "Keep CDSs from contigs related to an ARG",
+                        "name": "Tabular-to-FASTA",
+                        "outputs": [
+                            {
+                                "name": "output",
+                                "type": "fasta"
+                            }
+                        ],
+                        "position": {
+                            "left": 2453.1416837782335,
+                            "top": 719.7260918789319
+                        },
+                        "post_job_actions": {
+                            "RenameDatasetActionoutput": {
+                                "action_arguments": {
+                                    "newname": "FASTA with CDS related to ARGs (linked to)"
+                                },
+                                "action_type": "RenameDatasetAction",
+                                "output_name": "output"
+                            },
+                            "TagDatasetActionoutput": {
+                                "action_arguments": {
+                                    "tags": "CDS_related_to_ARGs"
+                                },
+                                "action_type": "TagDatasetAction",
+                                "output_name": "output"
+                            }
+                        },
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/tabular_to_fasta/tab2fasta/1.1.1",
+                        "tool_shed_repository": {
+                            "changeset_revision": "0a7799698fe5",
+                            "name": "tabular_to_fasta",
+                            "owner": "devteam",
+                            "tool_shed": "toolshed.g2.bx.psu.edu"
+                        },
+                        "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"seq_col\": \"2\", \"title_col\": [\"1\"], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+                        "tool_uuid": null,
+                        "tool_version": "1.1.1",
+                        "type": "tool",
+                        "uuid": "d65a7614-7e47-49af-a0b4-99a900429edb",
+                        "when": null,
+                        "workflow_outputs": [
+                            {
+                                "label": "FASTA with CDS related to ARGs (linked to)",
+                                "output_name": "output",
+                                "uuid": "9dfe1f43-4f3d-478c-b44b-39fb09debaa9"
                             }
                         ]
                     }
                 },
                 "tags": [],
-                "uuid": "d0508cbd-a87b-4b3b-9124-9fc4ca37316e"
+                "uuid": "80a15f5a-6c9c-477b-b3a5-b139a5e6c15e"
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "973d7bea-318c-4e1d-9210-8569cb16ac56",
+            "uuid": "90573785-f551-4979-89ec-39e39d5aa401",
             "when": "$(inputs.when)",
-            "workflow_outputs": []
-        },
-        "25": {
-            "annotation": "",
-            "content_id": "Remove beginning1",
-            "errors": null,
-            "id": 25,
-            "input_connections": {
-                "input": {
-                    "id": 21,
-                    "output_name": "output"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "Remove beginning",
-            "outputs": [
+            "workflow_outputs": [
                 {
-                    "name": "out_file1",
-                    "type": "input"
+                    "label": "FASTA with CDS corresponding and related to ARGs (ARGs and linked to)",
+                    "output_name": "FASTA with CDS corresponding and related to ARGs (ARGs and linked to)",
+                    "uuid": "f3209c32-1ce9-43cd-903a-f8c0d7d2cff1"
+                },
+                {
+                    "label": "FASTA with contigs related to ARGs",
+                    "output_name": "FASTA with contigs related to ARGs",
+                    "uuid": "429639a7-265b-4f5f-9696-01aa763ebeca"
                 }
-            ],
-            "position": {
-                "left": 4616.548873447804,
-                "top": 1141.0036896377676
-            },
-            "post_job_actions": {
-                "ChangeDatatypeActionout_file1": {
-                    "action_arguments": {
-                        "newtype": "tabular"
-                    },
-                    "action_type": "ChangeDatatypeAction",
-                    "output_name": "out_file1"
-                }
-            },
-            "tool_id": "Remove beginning1",
-            "tool_state": "{\"input\": {\"__class__\": \"ConnectedValue\"}, \"num_lines\": \"1\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_uuid": null,
-            "tool_version": "1.0.0",
-            "type": "tool",
-            "uuid": "2937e7d8-cfce-4715-9a8c-085862821f8e",
-            "when": null,
-            "workflow_outputs": []
+            ]
         },
-        "26": {
+        "28": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/column_remove_by_header/column_remove_by_header/1.0",
             "errors": null,
-            "id": 26,
+            "id": 28,
             "input_connections": {
                 "input_tabular": {
-                    "id": 22,
+                    "id": 26,
                     "output_name": "output_dataset"
                 }
             },
@@ -2307,7 +2885,7 @@
             ],
             "position": {
                 "left": 4942.021561668145,
-                "top": 952.1773906338818
+                "top": 748.2773906338819
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/column_remove_by_header/column_remove_by_header/1.0",
@@ -2321,19 +2899,19 @@
             "tool_uuid": null,
             "tool_version": "1.0",
             "type": "tool",
-            "uuid": "125e69c1-ff93-4c17-afaa-c6f7db889ff2",
+            "uuid": "fee40b4f-2835-43c9-be31-8d935e06b216",
             "when": null,
             "workflow_outputs": []
         },
-        "27": {
+        "29": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
             "errors": null,
-            "id": 27,
+            "id": 29,
             "input_connections": {
                 "style_cond|type_cond|pick_from_0|value": {
-                    "id": 24,
-                    "output_name": "FASTA with CDS corresponding to ARGs"
+                    "id": 27,
+                    "output_name": "FASTA with CDS corresponding to ARGs (ARGs)"
                 }
             },
             "inputs": [],
@@ -2347,7 +2925,7 @@
             ],
             "position": {
                 "left": 3481.8987600699293,
-                "top": 1059.9327443080056
+                "top": 856.0327443080056
             },
             "post_job_actions": {
                 "HideDatasetActiondata_param": {
@@ -2367,23 +2945,23 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "8bf694e0-4656-4936-8b61-3b4fdb0a4a60",
+            "uuid": "f02e6229-5618-4328-bb67-bcc75e74b1ff",
             "when": null,
             "workflow_outputs": []
         },
-        "28": {
+        "30": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
             "errors": null,
-            "id": 28,
+            "id": 30,
             "input_connections": {
                 "style_cond|type_cond|pick_from_0|value": {
                     "id": 16,
                     "output_name": "output_rep_seq"
                 },
                 "style_cond|type_cond|pick_from_1|value": {
-                    "id": 24,
-                    "output_name": "CDSs from contigs linked to an ARG"
+                    "id": 27,
+                    "output_name": "FASTA with CDS related to ARGs (linked to)"
                 }
             },
             "inputs": [],
@@ -2396,8 +2974,8 @@
                 }
             ],
             "position": {
-                "left": 3378.80880447208,
-                "top": 1819.902507914293
+                "left": 3436.833251953125,
+                "top": 1608
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
@@ -2411,58 +2989,62 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "407cbbed-c682-4482-a449-ac0d11bac430",
+            "uuid": "f841ed32-2fff-43f5-972e-e5e44e2836c8",
             "when": null,
             "workflow_outputs": []
         },
-        "29": {
+        "31": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/column_remove_by_header/column_remove_by_header/1.0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
             "errors": null,
-            "id": 29,
+            "id": 31,
             "input_connections": {
-                "input_tabular": {
-                    "id": 25,
-                    "output_name": "out_file1"
+                "style_cond|type_cond|pick_from_0|value": {
+                    "id": 16,
+                    "output_name": "output_rep_seq"
+                },
+                "style_cond|type_cond|pick_from_1|value": {
+                    "id": 27,
+                    "output_name": "FASTA with CDS corresponding and related to ARGs (ARGs and linked to)"
                 }
             },
             "inputs": [],
             "label": null,
-            "name": "Remove columns",
+            "name": "Pick parameter value",
             "outputs": [
                 {
-                    "name": "output_tabular",
-                    "type": "tabular"
+                    "name": "data_param",
+                    "type": "input"
                 }
             ],
             "position": {
-                "left": 4911.048629307179,
-                "top": 1136.8369415908926
+                "left": 3379,
+                "top": 1802
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/column_remove_by_header/column_remove_by_header/1.0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
             "tool_shed_repository": {
-                "changeset_revision": "2040e4c2750a",
-                "name": "column_remove_by_header",
+                "changeset_revision": "b19e21af9c52",
+                "name": "pick_value",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"headers\": [{\"__index__\": 0, \"name\": \"Protein identifier\"}], \"input_tabular\": {\"__class__\": \"ConnectedValue\"}, \"keep_columns\": false, \"strip_characters\": \"#\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"style_cond\": {\"pick_style\": \"first\", \"__current_case__\": 0, \"type_cond\": {\"param_type\": \"data\", \"__current_case__\": 4, \"pick_from\": [{\"__index__\": 0, \"value\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"value\": {\"__class__\": \"ConnectedValue\"}}]}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
-            "tool_version": "1.0",
+            "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "efbbf605-af27-4bc1-b922-50a91f8bb9a6",
+            "uuid": "18da25d0-09a9-41cd-bae0-743b70f943fe",
             "when": null,
             "workflow_outputs": []
         },
-        "30": {
+        "32": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/mmseqs2_easy_linclust_clustering/mmseqs2_easy_linclust_clustering/17-b804f+galaxy1",
             "errors": null,
-            "id": 30,
+            "id": 32,
             "input_connections": {
                 "input_fasta": {
-                    "id": 27,
+                    "id": 29,
                     "output_name": "data_param"
                 },
                 "when": {
@@ -2470,7 +3052,12 @@
                     "output_name": "boolean_param"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool MMseqs2 easy-linclust",
+                    "name": "input_fasta"
+                }
+            ],
             "label": "MMseqs2 ARGs Sequence Clustering",
             "name": "MMseqs2 easy-linclust",
             "outputs": [
@@ -2488,8 +3075,8 @@
                 }
             ],
             "position": {
-                "left": 3861.1382697589174,
-                "top": 620.4276044738021
+                "left": 3877.13330078125,
+                "top": 414.5333251953125
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/mmseqs2_easy_linclust_clustering/mmseqs2_easy_linclust_clustering/17-b804f+galaxy1",
@@ -2499,80 +3086,26 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"align\": {\"convertalis\": false, \"alignment_output_mode\": \"0\", \"wrapped_scoring\": false, \"min_aln_len\": \"0\", \"seq_id_mode\": \"0\", \"alt_ali\": \"0\", \"score_bias\": \"0.0\", \"realign\": false, \"realign_score_bias\": \"-0.2\", \"realign_max_seqs\": \"2147483647\", \"corr_score_weight\": \"0.0\", \"alignment_mode\": \"0\", \"evalue\": \"0.001\", \"max_rejected\": \"2147483647\", \"max_accept\": \"2147483647\"}, \"alph_type\": {\"dbtype\": \"0\", \"__current_case__\": 0}, \"cluster\": {\"cluster_mode\": \"0\", \"max_iterations\": \"1000\", \"similarity_type\": \"2\"}, \"common\": {\"max_seq_len\": \"65535\"}, \"cov\": \"0.8\", \"cov_mode\": \"0\", \"expert\": {\"filter_hits\": false, \"sort_results\": \"0\"}, \"input_fasta\": {\"__class__\": \"ConnectedValue\"}, \"kmermatcher\": {\"cluster_weight_threshold\": \"0.9\", \"kmer_per_seq\": \"21\", \"hash_shift\": \"67\", \"include_only_extendable\": false, \"ignore_multi_kmer\": false}, \"min_seq_id\": \"0.95\", \"misc\": {\"rescore_mode\": \"0\", \"shuffle\": true, \"id_offset\": \"0\"}, \"output_files\": {\"output_selection\": [\"file_rep_seq\", \"file_all_seq\", \"file_cluster_tsv\"]}, \"prefilter\": {\"add_self_matches\": false, \"kmer_length\": \"0\", \"mask\": \"1\", \"mask_prob\": \"0.9\", \"mask_lower_case\": \"0\", \"mask_n_repeat\": \"0\", \"spaced_kmer_mode\": \"0\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"align\": {\"convertalis\": false, \"alignment_output_mode\": \"0\", \"wrapped_scoring\": false, \"min_aln_len\": \"0\", \"seq_id_mode\": \"0\", \"alt_ali\": \"0\", \"score_bias\": \"0.0\", \"realign\": false, \"realign_score_bias\": \"-0.2\", \"realign_max_seqs\": \"2147483647\", \"corr_score_weight\": \"0.0\", \"alignment_mode\": \"0\", \"evalue\": \"0.001\", \"max_rejected\": \"2147483647\", \"max_accept\": \"2147483647\"}, \"alph_type\": {\"dbtype\": \"0\", \"__current_case__\": 0}, \"cluster\": {\"cluster_mode\": \"0\", \"max_iterations\": \"1000\", \"similarity_type\": \"2\"}, \"common\": {\"max_seq_len\": \"65535\"}, \"cov\": \"0.8\", \"cov_mode\": \"0\", \"expert\": {\"filter_hits\": false, \"sort_results\": \"0\"}, \"input_fasta\": {\"__class__\": \"RuntimeValue\"}, \"kmermatcher\": {\"cluster_weight_threshold\": \"0.9\", \"kmer_per_seq\": \"21\", \"hash_shift\": \"67\", \"include_only_extendable\": false, \"ignore_multi_kmer\": false}, \"min_seq_id\": \"0.95\", \"misc\": {\"rescore_mode\": \"0\", \"shuffle\": true, \"id_offset\": \"0\"}, \"output_files\": {\"output_selection\": [\"file_rep_seq\", \"file_all_seq\", \"file_cluster_tsv\"]}, \"prefilter\": {\"add_self_matches\": false, \"kmer_length\": \"0\", \"mask\": \"1\", \"mask_prob\": \"0.9\", \"mask_lower_case\": \"0\", \"mask_n_repeat\": \"0\", \"spaced_kmer_mode\": \"0\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "17-b804f+galaxy1",
             "type": "tool",
-            "uuid": "b678f707-45da-4e56-986a-f2521bb74edf",
+            "uuid": "b2674d2c-d7f6-448c-8cfd-9738257b3437",
             "when": "$(inputs.when)",
             "workflow_outputs": []
         },
-        "31": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/seqkit_translate/seqkit_translate/2.13.0+galaxy0",
-            "errors": null,
-            "id": 31,
-            "input_connections": {
-                "input": {
-                    "id": 28,
-                    "output_name": "data_param"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "SeqKit translate",
-            "outputs": [
-                {
-                    "name": "output",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 3398.6028633919486,
-                "top": 2207.1628915397478
-            },
-            "post_job_actions": {
-                "RenameDatasetActionoutput": {
-                    "action_arguments": {
-                        "newname": "Seqkit Protein Translation"
-                    },
-                    "action_type": "RenameDatasetAction",
-                    "output_name": "output"
-                }
-            },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/seqkit_translate/seqkit_translate/2.13.0+galaxy0",
-            "tool_shed_repository": {
-                "changeset_revision": "0d9d8de82304",
-                "name": "seqkit_translate",
-                "owner": "iuc",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"__input_ext\": \"input\", \"append_frame\": false, \"chromInfo\": \"/shared/ifbstor1/galaxy/mutable-config/tool-data/shared/ucsc/chrom/?.len\", \"clean\": false, \"frame\": \"1\", \"init_codon_as_M\": false, \"input\": {\"__class__\": \"ConnectedValue\"}, \"transl_table\": \"1\", \"translate_or_remove_unknown\": {\"selector\": \"trimming\", \"__current_case__\": 0, \"trim\": false}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_uuid": null,
-            "tool_version": "2.13.0+galaxy0",
-            "type": "tool",
-            "uuid": "ac801ee8-9492-4390-b24c-bb3b9e6f0d53",
-            "when": null,
-            "workflow_outputs": [
-                {
-                    "label": "Seqkit Protein Translation",
-                    "output_name": "output",
-                    "uuid": "f025619b-f6b7-40c6-9289-9ca533a395d8"
-                }
-            ]
-        },
-        "32": {
+        "33": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/eggnog_mapper/eggnog_mapper/2.1.13+galaxy0",
             "errors": null,
-            "id": 32,
+            "id": 33,
             "input_connections": {
                 "eggnog_data": {
                     "id": 6,
                     "output_name": "output"
                 },
                 "ortho_method|input": {
-                    "id": 28,
+                    "id": 30,
                     "output_name": "data_param"
                 }
             },
@@ -2600,7 +3133,7 @@
             ],
             "position": {
                 "left": 3813.3584574315432,
-                "top": 1799.1854657143258
+                "top": 1595.2854657143257
             },
             "post_job_actions": {
                 "RenameDatasetActionannotations": {
@@ -2639,42 +3172,85 @@
                 "owner": "galaxyp",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"annotation_options\": {\"no_annot\": \"\", \"__current_case__\": 0, \"seed_ortholog_evalue\": \"1e-30\", \"seed_ortholog_score\": \"70.0\", \"tax_scope\": null, \"target_orthologs\": \"all\", \"go_evidence\": \"non-electronic\"}, \"eggnog_data\": {\"__class__\": \"ConnectedValue\"}, \"ortho_method\": {\"m\": \"diamond\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}, \"input_trans\": {\"itype\": \"CDS\", \"__current_case__\": 1, \"translate\": true}, \"matrix_gapcosts\": {\"matrix\": \"BLOSUM62\", \"__current_case__\": 2, \"gap_costs\": \"--gapopen 11 --gapextend 1\"}, \"sensmode\": \"fast\", \"dmnd_iterate\": false, \"dmnd_ignore_warnings\": false, \"query_cover\": \"70\", \"subject_cover\": \"70\", \"pident\": \"80\", \"evalue\": \"1e-30\", \"score\": \"70.0\"}, \"output_options\": {\"no_file_comments\": true, \"report_orthologs\": true, \"md5\": false}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"annotation_options\": {\"no_annot\": \"\", \"__current_case__\": 0, \"seed_ortholog_evalue\": \"1e-30\", \"seed_ortholog_score\": \"70.0\", \"tax_scope\": null, \"target_orthologs\": \"all\", \"go_evidence\": \"non-electronic\"}, \"eggnog_data\": {\"__class__\": \"ConnectedValue\"}, \"ortho_method\": {\"m\": \"diamond\", \"__current_case__\": 0, \"input\": {\"__class__\": \"RuntimeValue\"}, \"input_trans\": {\"itype\": \"CDS\", \"__current_case__\": 1, \"translate\": true}, \"matrix_gapcosts\": {\"matrix\": \"BLOSUM62\", \"__current_case__\": 2, \"gap_costs\": \"--gapopen 11 --gapextend 1\"}, \"sensmode\": \"fast\", \"dmnd_iterate\": false, \"dmnd_ignore_warnings\": false, \"query_cover\": \"70\", \"subject_cover\": \"70\", \"pident\": \"80\", \"evalue\": \"1e-30\", \"score\": \"70.0\"}, \"output_options\": {\"no_file_comments\": true, \"report_orthologs\": true, \"md5\": false}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "2.1.13+galaxy0",
             "type": "tool",
-            "uuid": "6996a0ca-5bc2-4ac3-81f0-c6343a128545",
+            "uuid": "acba5543-8029-4145-b0ab-30df591430d7",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Eggnog Report Orthologs",
-                    "output_name": "annotations_orthologs",
-                    "uuid": "46722213-1719-42b1-a7cb-9a2a5a9ba348"
-                },
-                {
-                    "label": "Eggnog Seed Orthologs",
-                    "output_name": "seed_orthologs",
-                    "uuid": "ffe26461-c856-4e91-be56-6bdb8a1a60a6"
-                },
-                {
                     "label": "Eggnog Annotations",
                     "output_name": "annotations",
-                    "uuid": "36592927-9796-4d5b-9a72-361eb09f4bba"
+                    "uuid": "43943c26-0dd8-458f-a13e-d4fc25bc8f87"
                 }
             ]
         },
-        "33": {
+        "34": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/seqkit_translate/seqkit_translate/2.13.0+galaxy0",
+            "errors": null,
+            "id": 34,
+            "input_connections": {
+                "input": {
+                    "id": 31,
+                    "output_name": "data_param"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool SeqKit translate",
+                    "name": "input"
+                }
+            ],
+            "label": null,
+            "name": "SeqKit translate",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 3470.60009765625,
+                "top": 2045.2666015625
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutput": {
+                    "action_arguments": {
+                        "newname": "Seqkit Protein Translation"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/seqkit_translate/seqkit_translate/2.13.0+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "0d9d8de82304",
+                "name": "seqkit_translate",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"append_frame\": false, \"clean\": false, \"frame\": \"1\", \"init_codon_as_M\": false, \"input\": {\"__class__\": \"RuntimeValue\"}, \"transl_table\": \"1\", \"translate_or_remove_unknown\": {\"selector\": \"trimming\", \"__current_case__\": 0, \"trim\": false}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "2.13.0+galaxy0",
+            "type": "tool",
+            "uuid": "bb0a3028-49c5-46b2-b0e9-bf25b5e83aef",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "35": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/pick_value/pick_value/0.2.0",
             "errors": null,
-            "id": 33,
+            "id": 35,
             "input_connections": {
                 "style_cond|type_cond|pick_from_0|value": {
                     "id": 16,
                     "output_name": "output_rep_seq"
                 },
                 "style_cond|type_cond|pick_from_1|value": {
-                    "id": 30,
+                    "id": 32,
                     "output_name": "output_rep_seq"
                 }
             },
@@ -2689,7 +3265,7 @@
             ],
             "position": {
                 "left": 3586.909853819165,
-                "top": 264.9646449438012
+                "top": 61.0646449438012
             },
             "post_job_actions": {
                 "RenameDatasetActiondata_param": {
@@ -2711,24 +3287,69 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "e565723d-706c-4cb6-aa06-a2ddee60307f",
+            "uuid": "b13f643d-9317-438b-bb16-8a74fe18c96a",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "MMseqs2 representative sequences",
                     "output_name": "data_param",
-                    "uuid": "4b8270a1-ea51-4f08-9b15-1fdb643fecdc"
+                    "uuid": "e21c23ca-423c-4de7-a21d-af633d6db96a"
                 }
             ]
         },
-        "34": {
+        "36": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/recetox/table_pandas_rename_column/table_pandas_rename_column/3.0.2+galaxy0",
+            "errors": null,
+            "id": 36,
+            "input_connections": {
+                "input_dataset": {
+                    "id": 33,
+                    "output_name": "annotations"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool table rename column",
+                    "name": "input_dataset"
+                }
+            ],
+            "label": null,
+            "name": "table rename column",
+            "outputs": [
+                {
+                    "name": "output_dataset",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 4784.382125400929,
+                "top": 1267.7703156143302
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/recetox/table_pandas_rename_column/table_pandas_rename_column/3.0.2+galaxy0",
+            "tool_shed_repository": {
+                "changeset_revision": "761f8ab8fdb6",
+                "name": "table_pandas_rename_column",
+                "owner": "recetox",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"columns_selection\": [{\"__index__\": 0, \"column\": \"1\", \"new_name\": \"query\"}], \"input_dataset\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_uuid": null,
+            "tool_version": "3.0.2+galaxy0",
+            "type": "tool",
+            "uuid": "0fc43c7b-b863-4891-b475-8578dba70e8c",
+            "when": null,
+            "workflow_outputs": []
+        },
+        "37": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/mmseqs2_taxonomy_assignment/mmseqs2_taxonomy_assignment/17-b804f+galaxy1",
             "errors": null,
-            "id": 34,
+            "id": 37,
             "input_connections": {
                 "createdb|input_fasta": {
-                    "id": 31,
+                    "id": 34,
                     "output_name": "output"
                 },
                 "database|database_type|mmseqs2_db_select": {
@@ -2756,7 +3377,7 @@
             ],
             "position": {
                 "left": 3749.1829444009327,
-                "top": 2209.8533095972643
+                "top": 2005.9533095972643
             },
             "post_job_actions": {
                 "ChangeDatatypeActionoutput_taxonomy_kraken": {
@@ -2795,77 +3416,37 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"createdb\": {\"input_fasta\": {\"__class__\": \"ConnectedValue\"}, \"alph_type\": {\"dbtype\": \"0\", \"__current_case__\": 0}, \"shuffle\": true}, \"createtsv\": {\"first_seq_as_repr\": false, \"target_column\": \"1\", \"full_header\": false, \"idx_seq_src\": \"0\"}, \"database\": {\"database_type\": {\"type\": \"amino_acid_tax\", \"__current_case__\": 0, \"mmseqs2_db_select\": {\"__class__\": \"ConnectedValue\"}, \"search_type\": \"0\"}}, \"download_tax_db\": \"\", \"filtertaxseqdb\": {\"taxon_list\": \"\"}, \"kraken_report\": {\"keep_report\": \"Yes\", \"__current_case__\": 0}, \"krona_report\": {\"keep_report\": \"No\", \"__current_case__\": 1}, \"taxonomy\": {\"prefilter\": {\"add_self_matches\": false, \"kmer_length\": \"0\", \"mask\": \"1\", \"mask_prob\": \"0.9\", \"mask_lower_case\": \"0\", \"mask_n_repeat\": \"0\", \"spaced_kmer_mode\": \"1\", \"min_ungapped_score\": \"15\", \"sensitivity\": \"2.0\", \"target_search_mode\": \"0\", \"max_seqs\": \"300\", \"split\": \"0\", \"split_mode\": \"2\", \"diag_score\": true, \"exact_kmer_matching\": \"0\"}, \"align\": {\"convertalis\": false, \"alignment_output_mode\": \"0\", \"wrapped_scoring\": false, \"min_aln_len\": \"0\", \"seq_id_mode\": \"0\", \"alt_ali\": \"0\", \"score_bias\": \"0.0\", \"realign\": false, \"realign_score_bias\": \"-0.2\", \"realign_max_seqs\": \"2147483647\", \"corr_score_weight\": \"0.0\", \"alignment_mode\": \"1\", \"evalue\": \"1.0\", \"min_seq_id\": \"0.0\", \"cov_mode\": \"0\", \"cov\": \"0.0\", \"max_rejected\": \"5\", \"max_accept\": \"30\", \"exhaustive_search_filter\": false}, \"profile\": {\"mask_profile\": true, \"e_profile\": \"0.001\", \"wg\": false, \"filter_msa\": true, \"filter_min_enable\": \"0\", \"max_seq_id\": \"0.9\", \"qid\": \"0\", \"qsc\": \"-20.0\", \"cov\": \"0.0\", \"diff\": \"1000\", \"pseudo_cnt_mode\": \"0\", \"exhaustive_search\": false, \"lca_search\": false}, \"misc\": {\"orf_filter_e\": \"100.0\", \"orf_filter_s\": \"2.0\", \"lca_mode\": \"3\", \"majority\": \"0.5\", \"vote_mode\": \"1\", \"tax_lineage\": \"0\", \"blacklist\": \"\", \"taxon_list\": \"\", \"rescore_mode\": \"0\", \"allow_deletion\": false, \"min_length\": \"30\", \"max_length\": \"32734\", \"max_gaps\": \"2147483647\", \"contig_start_mode\": \"2\", \"contig_end_mode\": \"2\", \"orf_start_mode\": \"1\", \"forward_frames\": \"1,2,3\", \"reverse_frames\": \"1,2,3\", \"translation_table\": \"1\", \"translate\": false, \"use_all_table_starts\": false, \"id_offset\": \"0\", \"sequence_overlap\": \"0\", \"sequence_split_mode\": \"1\", \"headers_split_mode\": \"0\", \"prefilter_mode\": \"0\"}, \"common\": {\"max_seq_len\": \"65535\"}, \"expert\": {\"filter_hits\": false, \"sort_results\": \"0\", \"chain_alignments\": \"0\", \"merge_query\": \"1\"}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"createdb\": {\"input_fasta\": {\"__class__\": \"RuntimeValue\"}, \"alph_type\": {\"dbtype\": \"0\", \"__current_case__\": 0}, \"shuffle\": true}, \"createtsv\": {\"first_seq_as_repr\": false, \"target_column\": \"1\", \"full_header\": false, \"idx_seq_src\": \"0\"}, \"database\": {\"database_type\": {\"type\": \"amino_acid_tax\", \"__current_case__\": 0, \"mmseqs2_db_select\": {\"__class__\": \"ConnectedValue\"}, \"search_type\": \"0\"}}, \"download_tax_db\": \"\", \"filtertaxseqdb\": {\"taxon_list\": \"\"}, \"kraken_report\": {\"keep_report\": \"Yes\", \"__current_case__\": 0}, \"krona_report\": {\"keep_report\": \"No\", \"__current_case__\": 1}, \"taxonomy\": {\"prefilter\": {\"add_self_matches\": false, \"kmer_length\": \"0\", \"mask\": \"1\", \"mask_prob\": \"0.9\", \"mask_lower_case\": \"0\", \"mask_n_repeat\": \"0\", \"spaced_kmer_mode\": \"1\", \"min_ungapped_score\": \"15\", \"sensitivity\": \"2.0\", \"target_search_mode\": \"0\", \"max_seqs\": \"300\", \"split\": \"0\", \"split_mode\": \"2\", \"diag_score\": true, \"exact_kmer_matching\": \"0\"}, \"align\": {\"convertalis\": false, \"alignment_output_mode\": \"0\", \"wrapped_scoring\": false, \"min_aln_len\": \"0\", \"seq_id_mode\": \"0\", \"alt_ali\": \"0\", \"score_bias\": \"0.0\", \"realign\": false, \"realign_score_bias\": \"-0.2\", \"realign_max_seqs\": \"2147483647\", \"corr_score_weight\": \"0.0\", \"alignment_mode\": \"1\", \"evalue\": \"1.0\", \"min_seq_id\": \"0.0\", \"cov_mode\": \"0\", \"cov\": \"0.0\", \"max_rejected\": \"5\", \"max_accept\": \"30\", \"exhaustive_search_filter\": false}, \"profile\": {\"mask_profile\": true, \"e_profile\": \"0.001\", \"wg\": false, \"filter_msa\": true, \"filter_min_enable\": \"0\", \"max_seq_id\": \"0.9\", \"qid\": \"0\", \"qsc\": \"-20.0\", \"cov\": \"0.0\", \"diff\": \"1000\", \"pseudo_cnt_mode\": \"0\", \"exhaustive_search\": false, \"lca_search\": false}, \"misc\": {\"orf_filter_e\": \"100.0\", \"orf_filter_s\": \"2.0\", \"lca_mode\": \"3\", \"majority\": \"0.5\", \"vote_mode\": \"1\", \"tax_lineage\": \"0\", \"blacklist\": \"\", \"taxon_list\": \"\", \"rescore_mode\": \"0\", \"allow_deletion\": false, \"min_length\": \"30\", \"max_length\": \"32734\", \"max_gaps\": \"2147483647\", \"contig_start_mode\": \"2\", \"contig_end_mode\": \"2\", \"orf_start_mode\": \"1\", \"forward_frames\": \"1,2,3\", \"reverse_frames\": \"1,2,3\", \"translation_table\": \"1\", \"translate\": false, \"use_all_table_starts\": false, \"id_offset\": \"0\", \"sequence_overlap\": \"0\", \"sequence_split_mode\": \"1\", \"headers_split_mode\": \"0\", \"prefilter_mode\": \"0\"}, \"common\": {\"max_seq_len\": \"65535\"}, \"expert\": {\"filter_hits\": false, \"sort_results\": \"0\", \"chain_alignments\": \"0\", \"merge_query\": \"1\"}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "17-b804f+galaxy1",
             "type": "tool",
-            "uuid": "c7c13a9d-b11e-4b11-805f-bfd64b6af089",
+            "uuid": "5512f5ba-33ac-415d-beed-42c79bd15a72",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "MMseqs2 Taxonomy Tabular",
-                    "output_name": "output_taxonomy_tsv",
-                    "uuid": "58888461-0827-48cc-9c87-d6b2279f58e0"
-                },
-                {
                     "label": "MMseqs2 Taxonomy Kraken",
                     "output_name": "output_taxonomy_kraken",
-                    "uuid": "a3be40a7-b668-468a-a359-2a5ee0626853"
+                    "uuid": "8b1bb767-a759-45cd-8375-a052a447dbe3"
+                },
+                {
+                    "label": "MMseqs2 Taxonomy Tabular",
+                    "output_name": "output_taxonomy_tsv",
+                    "uuid": "653d2224-2a8a-4324-8bbe-eda23adc16b0"
                 }
             ]
         },
-        "35": {
+        "38": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/recetox/table_pandas_rename_column/table_pandas_rename_column/3.0.2+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/coverm_contig/coverm_contig/0.7.0+galaxy0",
             "errors": null,
-            "id": 35,
-            "input_connections": {
-                "input_dataset": {
-                    "id": 32,
-                    "output_name": "annotations"
-                }
-            },
-            "inputs": [],
-            "label": null,
-            "name": "table rename column",
-            "outputs": [
-                {
-                    "name": "output_dataset",
-                    "type": "input"
-                }
-            ],
-            "position": {
-                "left": 4784.382125400929,
-                "top": 1471.6703156143303
-            },
-            "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/recetox/table_pandas_rename_column/table_pandas_rename_column/3.0.2+galaxy0",
-            "tool_shed_repository": {
-                "changeset_revision": "761f8ab8fdb6",
-                "name": "table_pandas_rename_column",
-                "owner": "recetox",
-                "tool_shed": "toolshed.g2.bx.psu.edu"
-            },
-            "tool_state": "{\"columns_selection\": [{\"__index__\": 0, \"column\": \"1\", \"new_name\": \"query\"}], \"input_dataset\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
-            "tool_uuid": null,
-            "tool_version": "3.0.2+galaxy0",
-            "type": "tool",
-            "uuid": "99c8378b-803f-4a89-bf60-b037128d2dab",
-            "when": null,
-            "workflow_outputs": []
-        },
-        "36": {
-            "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/coverm_contig/coverm_contig/0.8.0+galaxy0",
-            "errors": null,
-            "id": 36,
+            "id": 38,
             "input_connections": {
                 "mapped|mode|read_type|paired_reads": {
                     "id": 0,
                     "output_name": "output"
                 },
                 "mapped|mode|reference": {
-                    "id": 33,
+                    "id": 35,
                     "output_name": "data_param"
                 }
             },
@@ -2880,7 +3461,7 @@
             ],
             "position": {
                 "left": 3960.569981282178,
-                "top": 313.5323498358273
+                "top": 109.63234983582728
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -2891,29 +3472,29 @@
                     "output_name": "output"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/coverm_contig/coverm_contig/0.8.0+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/coverm_contig/coverm_contig/0.7.0+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "d9b724b4a136",
+                "changeset_revision": "28d740f2c0b0",
                 "name": "coverm_contig",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
             "tool_state": "{\"alignment\": {\"min_read_aligned_length\": \"0\", \"min_read_percent_identity\": \"0.0\", \"min_read_aligned_percent\": \"0.0\", \"proper_pairs_only\": {\"proper_pairs_only\": \"\", \"__current_case__\": 1}, \"exclude_supplementary\": false}, \"cov\": {\"methods\": \"mean\", \"trim_min\": \"5\", \"trim_max\": \"95\", \"min_covered_fraction\": \"10\", \"contig_end_exclusion\": \"75\"}, \"mapped\": {\"mapped\": \"not-mapped\", \"__current_case__\": 1, \"mode\": {\"mode\": \"individual\", \"__current_case__\": 0, \"read_type\": {\"type\": \"paired_collection\", \"__current_case__\": 2, \"paired_reads\": {\"__class__\": \"ConnectedValue\"}}, \"reference\": {\"__class__\": \"ConnectedValue\"}}, \"mapper\": \"minimap2-sr\"}, \"output_format\": \"dense\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
-            "tool_version": "0.8.0+galaxy0",
+            "tool_version": "0.7.0+galaxy0",
             "type": "tool",
-            "uuid": "f06704f1-e36e-436f-8123-41a61f09891d",
+            "uuid": "11da3d7e-d7b5-4fd3-9850-42fd884efed8",
             "when": null,
             "workflow_outputs": []
         },
-        "37": {
+        "39": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/krakentools_kreport2krona/krakentools_kreport2krona/1.2.1+galaxy0",
             "errors": null,
-            "id": 37,
+            "id": 39,
             "input_connections": {
                 "report": {
-                    "id": 34,
+                    "id": 37,
                     "output_name": "output_taxonomy_kraken"
                 }
             },
@@ -2928,7 +3509,7 @@
             ],
             "position": {
                 "left": 4056.7209398601613,
-                "top": 2360.3895054430086
+                "top": 2156.4895054430085
             },
             "post_job_actions": {
                 "HideDatasetActionoutput": {
@@ -2948,18 +3529,18 @@
             "tool_uuid": null,
             "tool_version": "1.2.1+galaxy0",
             "type": "tool",
-            "uuid": "73b8d0bd-9b49-4a01-8790-45969b6f767e",
+            "uuid": "db4a4e7e-6cfa-4ae7-aaa9-d0a6ddbaa0e6",
             "when": null,
             "workflow_outputs": []
         },
-        "38": {
+        "40": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/collection_column_join/collection_column_join/0.0.3",
             "errors": null,
-            "id": 38,
+            "id": 40,
             "input_connections": {
                 "input_tabular": {
-                    "id": 36,
+                    "id": 38,
                     "output_name": "output"
                 }
             },
@@ -2974,7 +3555,7 @@
             ],
             "position": {
                 "left": 4243.005658846532,
-                "top": 342.82192426498705
+                "top": 138.92192426498704
             },
             "post_job_actions": {
                 "RenameDatasetActiontabular_output": {
@@ -2996,24 +3577,24 @@
             "tool_uuid": null,
             "tool_version": "0.0.3",
             "type": "tool",
-            "uuid": "058ead50-0aab-4024-b3d2-a8ba4f83dada",
+            "uuid": "30d314d7-911d-46a0-9471-1382a60955c4",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "CoverM contig",
                     "output_name": "tabular_output",
-                    "uuid": "7d9c6094-db31-43e9-9e8d-d51eede37aa2"
+                    "uuid": "c50bf7b1-0a6d-467d-9b6d-8e1752bff98f"
                 }
             ]
         },
-        "39": {
+        "41": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/crs4/taxonomy_krona_chart/taxonomy_krona_chart/2.7.1+galaxy0",
             "errors": null,
-            "id": 39,
+            "id": 41,
             "input_connections": {
                 "type_of_data|input": {
-                    "id": 37,
+                    "id": 39,
                     "output_name": "output"
                 }
             },
@@ -3033,7 +3614,7 @@
             ],
             "position": {
                 "left": 4348.787590250786,
-                "top": 2418.722879466446
+                "top": 2214.822879466446
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput": {
@@ -3055,32 +3636,32 @@
             "tool_uuid": null,
             "tool_version": "2.7.1+galaxy0",
             "type": "tool",
-            "uuid": "be3dcd16-94e9-4e9f-9984-80a720858ca2",
+            "uuid": "0ab957e0-fc37-4e2d-9b57-8de5d47bb432",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "MMseqs2 Taxonomy Krona",
                     "output_name": "output",
-                    "uuid": "2bfdbda4-e445-4d44-b6a5-72910c3ef7a5"
+                    "uuid": "7b98e48c-f2aa-4cbf-a56a-97195afc719c"
                 }
             ]
         },
-        "40": {
+        "42": {
             "annotation": "",
             "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.35+galaxy1",
             "errors": null,
-            "id": 40,
+            "id": 42,
             "input_connections": {
                 "results_0|software_cond|input": {
                     "id": 10,
                     "output_name": "report_tabular_meta"
                 },
                 "results_1|software_cond|input": {
-                    "id": 26,
+                    "id": 28,
                     "output_name": "output_tabular"
                 },
                 "results_2|software_cond|input": {
-                    "id": 29,
+                    "id": 25,
                     "output_name": "output_tabular"
                 },
                 "results_3|software_cond|input": {
@@ -3088,15 +3669,15 @@
                     "output_name": "output_tabular"
                 },
                 "results_4|software_cond|input": {
-                    "id": 38,
+                    "id": 40,
                     "output_name": "tabular_output"
                 },
                 "results_5|software_cond|input": {
-                    "id": 35,
+                    "id": 36,
                     "output_name": "output_dataset"
                 },
                 "results_6|software_cond|input": {
-                    "id": 34,
+                    "id": 37,
                     "output_name": "output_taxonomy_tsv"
                 }
             },
@@ -3120,7 +3701,7 @@
             ],
             "position": {
                 "left": 5230.486589986652,
-                "top": 1071.7902658111568
+                "top": 867.8902658111568
             },
             "post_job_actions": {
                 "RenameDatasetActionhtml_report": {
@@ -3138,17 +3719,17 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"image_content_input\": {\"__class__\": \"RuntimeValue\"}, \"png_plots\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"quast\", \"__current_case__\": 22, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"ABRicate report\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"AMRFinderPlus report with argNorm\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 3, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"starAMR detailed report\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 4, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"CoverM\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 5, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"EggnogMapper annotations\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 6, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"MMseqs2 taxonomy\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"ConnectedValue\"}}}], \"title\": \"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"image_content_input\": {\"__class__\": \"RuntimeValue\"}, \"png_plots\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"quast\", \"__current_case__\": 22, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"ABRicate report\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"AMRFinderPlus report with argNorm\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 3, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"starAMR detailed report\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 4, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"CoverM\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 5, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"EggnogMapper annotations\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 6, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"MMseqs2 taxonomy\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}], \"title\": \"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "1.35+galaxy1",
             "type": "tool",
-            "uuid": "527dd585-4062-4413-8537-240115c1539e",
+            "uuid": "5e63ede6-b269-4691-8234-462ab23ab210",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "MultiQC Report",
                     "output_name": "html_report",
-                    "uuid": "d22a49c7-1215-47b4-af54-9b65c9cf6ad4"
+                    "uuid": "87db7fca-6e08-4844-95d5-3b365aa71bd5"
                 }
             ]
         }
@@ -3160,7 +3741,6 @@
         "genes-collection",
         "paired-collection(s)"
     ],
-    "uuid": "8c7039c9-333f-47dc-ae7d-2985935a8c8d",
-    "version": 1,
-    "release": "1.2.2"
+    "uuid": "1b280a47-34fe-4599-9069-4d08145ac1ae",
+    "version": 5
 }

--- a/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.ga
+++ b/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.ga
@@ -671,7 +671,7 @@
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.2.0",
             "tool_shed_repository": {
-                "changeset_revision": "8a19efbd2178",
+                "changeset_revision": "8061668d0868",
                 "name": "add_input_name_as_column",
                 "owner": "mvdbeek",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -879,7 +879,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/9.5+galaxy3",
             "tool_shed_repository": {
-                "changeset_revision": "c41d78ae5fee",
+                "changeset_revision": "ab83aa685821",
                 "name": "text_processing",
                 "owner": "bgruening",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2039,7 +2039,7 @@
                         "post_job_actions": {},
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy3",
                         "tool_shed_repository": {
-                            "changeset_revision": "c41d78ae5fee",
+                            "changeset_revision": "ab83aa685821",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2299,7 +2299,7 @@
                         "post_job_actions": {},
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_column/9.5+galaxy3",
                         "tool_shed_repository": {
-                            "changeset_revision": "c41d78ae5fee",
+                            "changeset_revision": "ab83aa685821",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2431,7 +2431,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.5+galaxy3",
                         "tool_shed_repository": {
-                            "changeset_revision": "c41d78ae5fee",
+                            "changeset_revision": "ab83aa685821",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2483,7 +2483,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.5+galaxy2",
                         "tool_shed_repository": {
-                            "changeset_revision": "c41d78ae5fee",
+                            "changeset_revision": "ab83aa685821",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2684,7 +2684,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy2",
                         "tool_shed_repository": {
-                            "changeset_revision": "c41d78ae5fee",
+                            "changeset_revision": "ab83aa685821",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"

--- a/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.ga
+++ b/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.ga
@@ -4,85 +4,12 @@
     "comments": [
         {
             "child_steps": [
-                12,
-                9,
-                15,
-                14,
-                13,
-                10,
-                7
-            ],
-            "color": "turquoise",
-            "data": {
-                "title": "Assembly and genes detection"
-            },
-            "id": 0,
-            "position": [
-                670.6814223676528,
-                1463.8724631998139
-            ],
-            "size": [
-                1385,
-                857
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                32,
-                16,
-                40,
-                38,
-                35
-            ],
-            "color": "yellow",
-            "data": {
-                "title": "Catalogue clustering and coverage"
-            },
-            "id": 2,
-            "position": [
-                3488.9,
-                0
-            ],
-            "size": [
-                992.4,
-                703.9
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                27,
-                24,
-                22,
-                21,
-                20,
-                19,
-                18
-            ],
-            "color": "red",
-            "data": {
-                "title": "ARG annotation"
-            },
-            "id": 1,
-            "position": [
-                2245.5,
-                452.6
-            ],
-            "size": [
-                1110,
-                1070
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                36,
-                28,
-                26,
-                25,
+                42,
                 23,
-                42
+                25,
+                26,
+                28,
+                36
             ],
             "color": "black",
             "data": {
@@ -101,13 +28,86 @@
         },
         {
             "child_steps": [
-                31,
-                30,
-                41,
-                39,
-                37,
+                7,
+                10,
+                13,
+                14,
+                15,
+                9,
+                12
+            ],
+            "color": "turquoise",
+            "data": {
+                "title": "Assembly and genes detection"
+            },
+            "id": 0,
+            "position": [
+                670.6814223676528,
+                1463.8724631998139
+            ],
+            "size": [
+                1385,
+                857
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                24,
+                27,
+                18,
+                19,
+                20,
+                21,
+                22
+            ],
+            "color": "red",
+            "data": {
+                "title": "ARG annotation"
+            },
+            "id": 1,
+            "position": [
+                2245.5,
+                452.6
+            ],
+            "size": [
+                1110,
+                1070
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                35,
+                38,
+                40,
+                16,
+                32
+            ],
+            "color": "yellow",
+            "data": {
+                "title": "Catalogue clustering and coverage"
+            },
+            "id": 2,
+            "position": [
+                3488.9,
+                0
+            ],
+            "size": [
+                992.4,
+                703.9
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                33,
                 34,
-                33
+                37,
+                39,
+                41,
+                30,
+                31
             ],
             "color": "green",
             "data": {
@@ -173,7 +173,7 @@
             "tool_state": "{\"optional\": false, \"format\": [\"fastq\", \"fastq.gz\", \"fastqsanger\", \"fastqsanger.gz\"], \"tag\": null, \"collection_type\": \"list:paired\", \"fields\": null, \"column_definitions\": null}",
             "tool_version": null,
             "type": "data_collection_input",
-            "uuid": "2e93b54f-1f59-4248-951d-a61b295b6566",
+            "uuid": "f3f9d50e-8b2f-48e1-bc1e-5e02f8f70017",
             "when": null,
             "workflow_outputs": []
         },
@@ -200,7 +200,7 @@
             "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "129b9a62-2c6a-4b98-a011-827404c6f7f4",
+            "uuid": "60659c02-5d7a-46a4-8a49-0e1865c40a1e",
             "when": null,
             "workflow_outputs": []
         },
@@ -227,7 +227,7 @@
             "tool_state": "{\"default\": false, \"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "d113adc2-aff0-452c-adc1-8414b083b207",
+            "uuid": "17e74321-6296-48fb-9d65-a64f5bf1526a",
             "when": null,
             "workflow_outputs": []
         },
@@ -254,7 +254,7 @@
             "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "3abf087d-71a8-40f7-b83c-19645564a65f",
+            "uuid": "e4d2102f-2d60-4b8e-a11d-b8b86bb6a712",
             "when": null,
             "workflow_outputs": []
         },
@@ -281,7 +281,7 @@
             "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "1a6b9d68-55bb-4ab9-9ab5-277c08e16b95",
+            "uuid": "e1ce47f0-47a2-4372-b22b-642bc2315a26",
             "when": null,
             "workflow_outputs": []
         },
@@ -308,7 +308,7 @@
             "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "0ce51ebc-2e9c-4790-8e57-5a7bfd176bc2",
+            "uuid": "dce8f5d5-2f41-4095-a59d-9f1b40695b34",
             "when": null,
             "workflow_outputs": []
         },
@@ -335,7 +335,7 @@
             "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "6e82db4e-ed10-4c07-875f-15dc1de4247e",
+            "uuid": "8a383bad-550f-4fcb-8859-546a955e1936",
             "when": null,
             "workflow_outputs": []
         },
@@ -413,13 +413,13 @@
             "tool_uuid": null,
             "tool_version": "1.2.9+galaxy2",
             "type": "tool",
-            "uuid": "25f93957-6015-4e8c-bd13-0cceaed2fa94",
+            "uuid": "40b5c6a8-e88c-4f36-af3d-82d8dfe1ad4b",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Megahit Contigs Output",
                     "output_name": "output",
-                    "uuid": "dc917ccb-5087-4747-ae20-295c9e664b85"
+                    "uuid": "5402d63a-1c46-44c8-822c-1aa65780550f"
                 }
             ]
         },
@@ -459,7 +459,7 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "f8f88eea-0202-4dc7-b746-dd4b6b6a7ad8",
+            "uuid": "c62af8d3-817f-49a4-bcf9-6724d6bd3627",
             "when": "$(inputs.when)",
             "workflow_outputs": []
         },
@@ -499,7 +499,7 @@
             "tool_uuid": null,
             "tool_version": "1.1.1",
             "type": "tool",
-            "uuid": "fa135585-8d48-4b50-92fe-6965b6190fec",
+            "uuid": "ae42b22a-e7d8-4a0d-8d8f-0979f801050c",
             "when": null,
             "workflow_outputs": []
         },
@@ -584,18 +584,18 @@
             "tool_uuid": null,
             "tool_version": "5.3.0+galaxy1",
             "type": "tool",
-            "uuid": "fe7cf1a6-77ad-4f34-adb4-dbbe8c700eef",
+            "uuid": "f26bc91e-1767-49da-8339-351443dfa5d4",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Report Tabular Meta",
-                    "output_name": "report_tabular_meta",
-                    "uuid": "b483b9c8-8eb5-4409-8bf0-a82f66501565"
-                },
-                {
                     "label": "Report HTML Meta",
                     "output_name": "report_html_meta",
-                    "uuid": "74772fcc-963c-4eb8-b7a4-950d798fb7fe"
+                    "uuid": "c2f9f547-f0f7-4d92-87da-cf92235b7a37"
+                },
+                {
+                    "label": "Report Tabular Meta",
+                    "output_name": "report_tabular_meta",
+                    "uuid": "bd6b020f-009c-4576-933b-3eceaa0091d2"
                 }
             ]
         },
@@ -635,7 +635,7 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "bb1d12f6-9b5d-4896-a581-4f9fed3394ae",
+            "uuid": "4a1533c7-d36c-476b-8a1a-2fa2a210c5fb",
             "when": null,
             "workflow_outputs": []
         },
@@ -650,12 +650,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Add input name as column",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Add input name as column",
             "outputs": [
@@ -671,16 +666,16 @@
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.2.0",
             "tool_shed_repository": {
-                "changeset_revision": "8061668d0868",
+                "changeset_revision": "3284b72eef56",
                 "name": "add_input_name_as_column",
                 "owner": "mvdbeek",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"header\": {\"contains_header\": \"no\", \"__current_case__\": 1}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"prepend\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"header\": {\"contains_header\": \"no\", \"__current_case__\": 1}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"prepend\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "079e46d4-46ac-419e-86cf-6afae9dbeb44",
+            "uuid": "33974bb8-c39d-4084-ac3f-663ea617e688",
             "when": null,
             "workflow_outputs": []
         },
@@ -728,13 +723,13 @@
             "tool_uuid": null,
             "tool_version": "1.1.1",
             "type": "tool",
-            "uuid": "14cea5ab-cdfe-4e24-9a20-88c334a8b30c",
+            "uuid": "0e377f2f-073d-484e-a137-acde8504bcd2",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Megahit output with sample name in ID",
                     "output_name": "output",
-                    "uuid": "1bfca289-deea-40a1-8100-c008713248a4"
+                    "uuid": "6bb1bcff-4a9d-4d4d-b1ff-e64846388710"
                 }
             ]
         },
@@ -820,13 +815,13 @@
             "tool_uuid": null,
             "tool_version": "2.6.3+galaxy0",
             "type": "tool",
-            "uuid": "bfd85a6d-9fc3-46ee-b4c9-f0744fee1dbd",
+            "uuid": "50d17430-650a-442a-b7ed-759f4cd3c347",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Prodigal Genes Sequences",
                     "output_name": "output_fnn",
-                    "uuid": "173fd024-6aff-496a-be61-bec910ba3ce5"
+                    "uuid": "9f7d0ef2-2d53-40d9-8e2a-c549b592c240"
                 }
             ]
         },
@@ -888,13 +883,13 @@
             "tool_uuid": null,
             "tool_version": "9.5+galaxy3",
             "type": "tool",
-            "uuid": "dac7aa53-0c0a-4908-94b9-52d516a05577",
+            "uuid": "396866cb-0579-4562-88f2-f193be4d8119",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Concatenate Datasets",
                     "output_name": "out_file1",
-                    "uuid": "f4646839-ef35-4b77-8a77-373b48bd22e4"
+                    "uuid": "db32e98a-029a-43ae-9903-1fdf76b49676"
                 }
             ]
         },
@@ -913,12 +908,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool MMseqs2 easy-linclust",
-                    "name": "input_fasta"
-                }
-            ],
+            "inputs": [],
             "label": "MMseqs2 full catalogue Sequence Clustering",
             "name": "MMseqs2 easy-linclust",
             "outputs": [
@@ -947,11 +937,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"align\": {\"convertalis\": false, \"alignment_output_mode\": \"0\", \"wrapped_scoring\": false, \"min_aln_len\": \"0\", \"seq_id_mode\": \"0\", \"alt_ali\": \"0\", \"score_bias\": \"0.0\", \"realign\": false, \"realign_score_bias\": \"-0.2\", \"realign_max_seqs\": \"2147483647\", \"corr_score_weight\": \"0.0\", \"alignment_mode\": \"0\", \"evalue\": \"0.001\", \"max_rejected\": \"2147483647\", \"max_accept\": \"2147483647\"}, \"alph_type\": {\"dbtype\": \"0\", \"__current_case__\": 0}, \"cluster\": {\"cluster_mode\": \"0\", \"max_iterations\": \"1000\", \"similarity_type\": \"2\"}, \"common\": {\"max_seq_len\": \"65535\"}, \"cov\": \"0.8\", \"cov_mode\": \"0\", \"expert\": {\"filter_hits\": false, \"sort_results\": \"0\"}, \"input_fasta\": {\"__class__\": \"RuntimeValue\"}, \"kmermatcher\": {\"cluster_weight_threshold\": \"0.9\", \"kmer_per_seq\": \"21\", \"hash_shift\": \"67\", \"include_only_extendable\": false, \"ignore_multi_kmer\": false}, \"min_seq_id\": \"0.95\", \"misc\": {\"rescore_mode\": \"0\", \"shuffle\": true, \"id_offset\": \"0\"}, \"output_files\": {\"output_selection\": [\"file_rep_seq\", \"file_all_seq\", \"file_cluster_tsv\"]}, \"prefilter\": {\"add_self_matches\": false, \"kmer_length\": \"0\", \"mask\": \"1\", \"mask_prob\": \"0.9\", \"mask_lower_case\": \"0\", \"mask_n_repeat\": \"0\", \"spaced_kmer_mode\": \"0\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"align\": {\"convertalis\": false, \"alignment_output_mode\": \"0\", \"wrapped_scoring\": false, \"min_aln_len\": \"0\", \"seq_id_mode\": \"0\", \"alt_ali\": \"0\", \"score_bias\": \"0.0\", \"realign\": false, \"realign_score_bias\": \"-0.2\", \"realign_max_seqs\": \"2147483647\", \"corr_score_weight\": \"0.0\", \"alignment_mode\": \"0\", \"evalue\": \"0.001\", \"max_rejected\": \"2147483647\", \"max_accept\": \"2147483647\"}, \"alph_type\": {\"dbtype\": \"0\", \"__current_case__\": 0}, \"cluster\": {\"cluster_mode\": \"0\", \"max_iterations\": \"1000\", \"similarity_type\": \"2\"}, \"common\": {\"max_seq_len\": \"65535\"}, \"cov\": \"0.8\", \"cov_mode\": \"0\", \"expert\": {\"filter_hits\": false, \"sort_results\": \"0\"}, \"input_fasta\": {\"__class__\": \"ConnectedValue\"}, \"kmermatcher\": {\"cluster_weight_threshold\": \"0.9\", \"kmer_per_seq\": \"21\", \"hash_shift\": \"67\", \"include_only_extendable\": false, \"ignore_multi_kmer\": false}, \"min_seq_id\": \"0.95\", \"misc\": {\"rescore_mode\": \"0\", \"shuffle\": true, \"id_offset\": \"0\"}, \"output_files\": {\"output_selection\": [\"file_rep_seq\", \"file_all_seq\", \"file_cluster_tsv\"]}, \"prefilter\": {\"add_self_matches\": false, \"kmer_length\": \"0\", \"mask\": \"1\", \"mask_prob\": \"0.9\", \"mask_lower_case\": \"0\", \"mask_n_repeat\": \"0\", \"spaced_kmer_mode\": \"0\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "17-b804f+galaxy1",
             "type": "tool",
-            "uuid": "a36905e6-cb48-460f-9ece-0805a16733e5",
+            "uuid": "d1385193-5788-495b-b06c-449cec79b200",
             "when": "$(inputs.when)",
             "workflow_outputs": []
         },
@@ -1001,7 +991,7 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "823dfaf1-5fac-4153-889f-ae4265a5face",
+            "uuid": "e2accce7-6a5a-45df-861d-8762909deb7c",
             "when": null,
             "workflow_outputs": []
         },
@@ -1069,13 +1059,13 @@
             "tool_uuid": null,
             "tool_version": "3.12.8+galaxy0",
             "type": "tool",
-            "uuid": "a64e36b2-8d96-487b-bf90-cf5136b188a9",
+            "uuid": "6cd4094b-0cc9-46c4-b48e-026bf25fe041",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "AMRFinderplus Report",
                     "output_name": "amrfinderplus_report",
-                    "uuid": "ebe6806e-6a38-4a26-87af-8792fa58e78a"
+                    "uuid": "962f937c-3585-4ea5-bd50-5b25cfd3de57"
                 }
             ]
         },
@@ -1098,10 +1088,6 @@
                 {
                     "description": "runtime parameter for tool ABRicate",
                     "name": "adv"
-                },
-                {
-                    "description": "runtime parameter for tool ABRicate",
-                    "name": "file_input"
                 }
             ],
             "label": null,
@@ -1132,17 +1118,17 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"adv\": {\"db\": {\"__class__\": \"ConnectedValue\"}, \"no_header\": false, \"min_dna_id\": \"80.0\", \"min_cov\": \"80.0\"}, \"file_input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"adv\": {\"db\": {\"__class__\": \"ConnectedValue\"}, \"no_header\": false, \"min_dna_id\": \"80.0\", \"min_cov\": \"80.0\"}, \"file_input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "1.4.0",
             "type": "tool",
-            "uuid": "ad065f5c-aa8a-4910-bec4-ddda0af1dca6",
+            "uuid": "9c4e4a54-a4c9-434d-95e0-38447e2b0b31",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Abricate Virulence Report",
                     "output_name": "report",
-                    "uuid": "19618920-0780-45cf-8e61-22a9d23050f9"
+                    "uuid": "23a96ccb-168f-42f9-8c0a-c3eda544485e"
                 }
             ]
         },
@@ -1165,10 +1151,6 @@
                 {
                     "description": "runtime parameter for tool staramr",
                     "name": "advanced"
-                },
-                {
-                    "description": "runtime parameter for tool staramr",
-                    "name": "genomes"
                 }
             ],
             "label": null,
@@ -1271,27 +1253,27 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"advanced\": {\"pid_threshold\": \"98.0\", \"percent_length_overlap_resfinder\": \"60.0\", \"percent_length_overlap_pointfinder\": \"95.0\", \"percent_length_overlap_plasmidfinder\": \"60.0\", \"genome_size_lower_bound\": \"4000000\", \"genome_size_upper_bound\": \"6000000\", \"minimum_N50_value\": \"10000\", \"minimum_contig_length\": \"300\", \"unacceptable_number_contigs\": \"1000\", \"report_all_blast\": false, \"exclude_negatives\": false, \"exclude_resistance_phenotypes\": false, \"mlst_scheme\": \"auto\", \"exclude_genes\": {\"exclude_genes_condition\": \"default\", \"__current_case__\": 0}, \"complex_mutations_file\": {\"__class__\": \"RuntimeValue\"}, \"plasmidfinder_type\": \"include_all\"}, \"genomes\": {\"__class__\": \"RuntimeValue\"}, \"hide_db_build\": \"\", \"output_files\": {\"output_selection\": [\"mlst_table\", \"summary_table\", \"detailed_summary_table\", \"resfinder_table\", \"plasmidfinder_table\", \"pointfinder_table\"]}, \"pointfinder_organism\": \"disabled\", \"staramr_db_select\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"advanced\": {\"pid_threshold\": \"98.0\", \"percent_length_overlap_resfinder\": \"60.0\", \"percent_length_overlap_pointfinder\": \"95.0\", \"percent_length_overlap_plasmidfinder\": \"60.0\", \"genome_size_lower_bound\": \"4000000\", \"genome_size_upper_bound\": \"6000000\", \"minimum_N50_value\": \"10000\", \"minimum_contig_length\": \"300\", \"unacceptable_number_contigs\": \"1000\", \"report_all_blast\": false, \"exclude_negatives\": false, \"exclude_resistance_phenotypes\": false, \"mlst_scheme\": \"auto\", \"exclude_genes\": {\"exclude_genes_condition\": \"default\", \"__current_case__\": 0}, \"complex_mutations_file\": {\"__class__\": \"RuntimeValue\"}, \"plasmidfinder_type\": \"include_all\"}, \"genomes\": {\"__class__\": \"ConnectedValue\"}, \"hide_db_build\": \"\", \"output_files\": {\"output_selection\": [\"mlst_table\", \"summary_table\", \"detailed_summary_table\", \"resfinder_table\", \"plasmidfinder_table\", \"pointfinder_table\"]}, \"pointfinder_organism\": \"disabled\", \"staramr_db_select\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "0.12.3+galaxy0",
             "type": "tool",
-            "uuid": "1f9e38db-f209-4f44-83aa-02292382c9eb",
+            "uuid": "d76f0150-abd4-400b-96e9-5d9870a21929",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Plasmidfinder",
                     "output_name": "plasmidfinder",
-                    "uuid": "fbe752a4-24ee-4cd0-b123-b7bafdf7d3e8"
+                    "uuid": "e88e58aa-49ae-4bd5-a311-ca30e15c40c1"
                 },
                 {
                     "label": "Detailed Summary",
                     "output_name": "detailed_summary",
-                    "uuid": "4d1b8aec-f819-456b-9b05-f75354f360d4"
+                    "uuid": "a20f9b73-8abe-4fa5-8b93-6f17be3770c6"
                 },
                 {
                     "label": "Resfinder",
                     "output_name": "resfinder",
-                    "uuid": "8cf293a1-7118-4926-95cd-6d6da8a6f670"
+                    "uuid": "e3f93da9-cae6-4208-acb5-fe952a187b96"
                 }
             ]
         },
@@ -1346,13 +1328,13 @@
             "tool_uuid": null,
             "tool_version": "5.1.0",
             "type": "tool",
-            "uuid": "cb656d71-0d17-4247-8134-59aef2437251",
+            "uuid": "408eae3c-b3e1-45f0-84b4-a7f1deaf14cf",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "AMRfinderplus Concatenated Reports",
                     "output_name": "output",
-                    "uuid": "92fc2547-5e31-4107-ac8f-c1b2595386a6"
+                    "uuid": "580ae299-0db6-461d-aae5-35dac38c68bb"
                 }
             ]
         },
@@ -1407,13 +1389,13 @@
             "tool_uuid": null,
             "tool_version": "5.1.0",
             "type": "tool",
-            "uuid": "deb5afbd-e3cf-4751-b5f4-131ef92ba516",
+            "uuid": "fd41c655-c9d6-4a24-bac1-3bf66e3db33d",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "ABRicate Virulence Concatenated Reports",
                     "output_name": "output",
-                    "uuid": "2239f73f-d3c9-45a1-903f-4e7c925a76c4"
+                    "uuid": "6d85c904-c868-4794-aab0-91bc56271152"
                 }
             ]
         },
@@ -1453,7 +1435,7 @@
             "tool_uuid": null,
             "tool_version": "1.0",
             "type": "tool",
-            "uuid": "365155d2-6ea4-48c5-8338-31f1f87acc3e",
+            "uuid": "87347787-613c-49e6-ae71-881d499c461a",
             "when": null,
             "workflow_outputs": []
         },
@@ -1508,13 +1490,13 @@
             "tool_uuid": null,
             "tool_version": "1.0.0+galaxy0",
             "type": "tool",
-            "uuid": "805a418b-e20a-4428-85c6-95b4166490ae",
+            "uuid": "34f80fee-6ecb-4675-b7ad-79e2c2579658",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Argnorm AMRfinderplus Concatenated Reports",
                     "output_name": "output",
-                    "uuid": "fd2c1d56-ac8b-4e83-923e-fa512efb48a9"
+                    "uuid": "dacb6993-d782-45b1-bac7-6cb16372cdbb"
                 }
             ]
         },
@@ -1554,7 +1536,7 @@
             "tool_uuid": null,
             "tool_version": "1.0",
             "type": "tool",
-            "uuid": "adaf0a0b-12c2-44b9-b606-9b57f8c52e63",
+            "uuid": "33dffa9b-ae28-4546-92e3-55131db5da26",
             "when": null,
             "workflow_outputs": []
         },
@@ -1569,12 +1551,7 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool table rename column",
-                    "name": "input_dataset"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "table rename column",
             "outputs": [
@@ -1595,11 +1572,11 @@
                 "owner": "recetox",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"columns_selection\": [{\"__index__\": 0, \"column\": \"1\", \"new_name\": \"FILE\"}], \"input_dataset\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"columns_selection\": [{\"__index__\": 0, \"column\": \"1\", \"new_name\": \"FILE\"}], \"input_dataset\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "3.0.2+galaxy0",
             "type": "tool",
-            "uuid": "b8b3ec82-5895-4f9c-a8a3-7b6c48b6dc8c",
+            "uuid": "2b897ae6-41f5-4d82-a92b-81cc3fb26d8e",
             "when": null,
             "workflow_outputs": []
         },
@@ -2483,7 +2460,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.5+galaxy3",
                         "tool_shed_repository": {
-                            "changeset_revision": "ab83aa685821",
+                            "changeset_revision": "c41d78ae5fee",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2684,7 +2661,7 @@
                         },
                         "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy3",
                         "tool_shed_repository": {
-                            "changeset_revision": "ab83aa685821",
+                            "changeset_revision": "c41d78ae5fee",
                             "name": "text_processing",
                             "owner": "bgruening",
                             "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -2848,18 +2825,18 @@
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "90573785-f551-4979-89ec-39e39d5aa401",
+            "uuid": "a80b9bea-24e0-4785-b334-f3d291a02c3d",
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
                     "label": "FASTA with CDS corresponding and related to ARGs (ARGs and linked to)",
                     "output_name": "FASTA with CDS corresponding and related to ARGs (ARGs and linked to)",
-                    "uuid": "f3209c32-1ce9-43cd-903a-f8c0d7d2cff1"
+                    "uuid": "25ee9491-96c3-42ad-8c04-3cfbbfe6a7f8"
                 },
                 {
                     "label": "FASTA with contigs related to ARGs",
                     "output_name": "FASTA with contigs related to ARGs",
-                    "uuid": "429639a7-265b-4f5f-9696-01aa763ebeca"
+                    "uuid": "281a8637-3297-40de-8ef9-718b246d6c62"
                 }
             ]
         },
@@ -2899,7 +2876,7 @@
             "tool_uuid": null,
             "tool_version": "1.0",
             "type": "tool",
-            "uuid": "fee40b4f-2835-43c9-be31-8d935e06b216",
+            "uuid": "be51f693-6ad9-49a4-a9ea-d9bf8bdef831",
             "when": null,
             "workflow_outputs": []
         },
@@ -2945,7 +2922,7 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "f02e6229-5618-4328-bb67-bcc75e74b1ff",
+            "uuid": "e51dcbfa-d0fa-40cd-9009-443174bb95ba",
             "when": null,
             "workflow_outputs": []
         },
@@ -2989,7 +2966,7 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "f841ed32-2fff-43f5-972e-e5e44e2836c8",
+            "uuid": "a6cb32f9-5c74-4867-89cb-9788290ae41f",
             "when": null,
             "workflow_outputs": []
         },
@@ -3033,7 +3010,7 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "18da25d0-09a9-41cd-bae0-743b70f943fe",
+            "uuid": "3ea407f3-0827-47fd-a475-ccfdc510fd89",
             "when": null,
             "workflow_outputs": []
         },
@@ -3052,12 +3029,7 @@
                     "output_name": "boolean_param"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool MMseqs2 easy-linclust",
-                    "name": "input_fasta"
-                }
-            ],
+            "inputs": [],
             "label": "MMseqs2 ARGs Sequence Clustering",
             "name": "MMseqs2 easy-linclust",
             "outputs": [
@@ -3086,11 +3058,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"align\": {\"convertalis\": false, \"alignment_output_mode\": \"0\", \"wrapped_scoring\": false, \"min_aln_len\": \"0\", \"seq_id_mode\": \"0\", \"alt_ali\": \"0\", \"score_bias\": \"0.0\", \"realign\": false, \"realign_score_bias\": \"-0.2\", \"realign_max_seqs\": \"2147483647\", \"corr_score_weight\": \"0.0\", \"alignment_mode\": \"0\", \"evalue\": \"0.001\", \"max_rejected\": \"2147483647\", \"max_accept\": \"2147483647\"}, \"alph_type\": {\"dbtype\": \"0\", \"__current_case__\": 0}, \"cluster\": {\"cluster_mode\": \"0\", \"max_iterations\": \"1000\", \"similarity_type\": \"2\"}, \"common\": {\"max_seq_len\": \"65535\"}, \"cov\": \"0.8\", \"cov_mode\": \"0\", \"expert\": {\"filter_hits\": false, \"sort_results\": \"0\"}, \"input_fasta\": {\"__class__\": \"RuntimeValue\"}, \"kmermatcher\": {\"cluster_weight_threshold\": \"0.9\", \"kmer_per_seq\": \"21\", \"hash_shift\": \"67\", \"include_only_extendable\": false, \"ignore_multi_kmer\": false}, \"min_seq_id\": \"0.95\", \"misc\": {\"rescore_mode\": \"0\", \"shuffle\": true, \"id_offset\": \"0\"}, \"output_files\": {\"output_selection\": [\"file_rep_seq\", \"file_all_seq\", \"file_cluster_tsv\"]}, \"prefilter\": {\"add_self_matches\": false, \"kmer_length\": \"0\", \"mask\": \"1\", \"mask_prob\": \"0.9\", \"mask_lower_case\": \"0\", \"mask_n_repeat\": \"0\", \"spaced_kmer_mode\": \"0\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"align\": {\"convertalis\": false, \"alignment_output_mode\": \"0\", \"wrapped_scoring\": false, \"min_aln_len\": \"0\", \"seq_id_mode\": \"0\", \"alt_ali\": \"0\", \"score_bias\": \"0.0\", \"realign\": false, \"realign_score_bias\": \"-0.2\", \"realign_max_seqs\": \"2147483647\", \"corr_score_weight\": \"0.0\", \"alignment_mode\": \"0\", \"evalue\": \"0.001\", \"max_rejected\": \"2147483647\", \"max_accept\": \"2147483647\"}, \"alph_type\": {\"dbtype\": \"0\", \"__current_case__\": 0}, \"cluster\": {\"cluster_mode\": \"0\", \"max_iterations\": \"1000\", \"similarity_type\": \"2\"}, \"common\": {\"max_seq_len\": \"65535\"}, \"cov\": \"0.8\", \"cov_mode\": \"0\", \"expert\": {\"filter_hits\": false, \"sort_results\": \"0\"}, \"input_fasta\": {\"__class__\": \"ConnectedValue\"}, \"kmermatcher\": {\"cluster_weight_threshold\": \"0.9\", \"kmer_per_seq\": \"21\", \"hash_shift\": \"67\", \"include_only_extendable\": false, \"ignore_multi_kmer\": false}, \"min_seq_id\": \"0.95\", \"misc\": {\"rescore_mode\": \"0\", \"shuffle\": true, \"id_offset\": \"0\"}, \"output_files\": {\"output_selection\": [\"file_rep_seq\", \"file_all_seq\", \"file_cluster_tsv\"]}, \"prefilter\": {\"add_self_matches\": false, \"kmer_length\": \"0\", \"mask\": \"1\", \"mask_prob\": \"0.9\", \"mask_lower_case\": \"0\", \"mask_n_repeat\": \"0\", \"spaced_kmer_mode\": \"0\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "17-b804f+galaxy1",
             "type": "tool",
-            "uuid": "b2674d2c-d7f6-448c-8cfd-9738257b3437",
+            "uuid": "86a9e714-28c1-4b7d-8c2b-4cc279dcf0c2",
             "when": "$(inputs.when)",
             "workflow_outputs": []
         },
@@ -3172,17 +3144,17 @@
                 "owner": "galaxyp",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"annotation_options\": {\"no_annot\": \"\", \"__current_case__\": 0, \"seed_ortholog_evalue\": \"1e-30\", \"seed_ortholog_score\": \"70.0\", \"tax_scope\": null, \"target_orthologs\": \"all\", \"go_evidence\": \"non-electronic\"}, \"eggnog_data\": {\"__class__\": \"ConnectedValue\"}, \"ortho_method\": {\"m\": \"diamond\", \"__current_case__\": 0, \"input\": {\"__class__\": \"RuntimeValue\"}, \"input_trans\": {\"itype\": \"CDS\", \"__current_case__\": 1, \"translate\": true}, \"matrix_gapcosts\": {\"matrix\": \"BLOSUM62\", \"__current_case__\": 2, \"gap_costs\": \"--gapopen 11 --gapextend 1\"}, \"sensmode\": \"fast\", \"dmnd_iterate\": false, \"dmnd_ignore_warnings\": false, \"query_cover\": \"70\", \"subject_cover\": \"70\", \"pident\": \"80\", \"evalue\": \"1e-30\", \"score\": \"70.0\"}, \"output_options\": {\"no_file_comments\": true, \"report_orthologs\": true, \"md5\": false}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"annotation_options\": {\"no_annot\": \"\", \"__current_case__\": 0, \"seed_ortholog_evalue\": \"1e-30\", \"seed_ortholog_score\": \"70.0\", \"tax_scope\": null, \"target_orthologs\": \"all\", \"go_evidence\": \"non-electronic\"}, \"eggnog_data\": {\"__class__\": \"ConnectedValue\"}, \"ortho_method\": {\"m\": \"diamond\", \"__current_case__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}, \"input_trans\": {\"itype\": \"CDS\", \"__current_case__\": 1, \"translate\": true}, \"matrix_gapcosts\": {\"matrix\": \"BLOSUM62\", \"__current_case__\": 2, \"gap_costs\": \"--gapopen 11 --gapextend 1\"}, \"sensmode\": \"fast\", \"dmnd_iterate\": false, \"dmnd_ignore_warnings\": false, \"query_cover\": \"70\", \"subject_cover\": \"70\", \"pident\": \"80\", \"evalue\": \"1e-30\", \"score\": \"70.0\"}, \"output_options\": {\"no_file_comments\": true, \"report_orthologs\": true, \"md5\": false}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "2.1.13+galaxy0",
             "type": "tool",
-            "uuid": "acba5543-8029-4145-b0ab-30df591430d7",
+            "uuid": "d7604a1a-1839-4cd4-a348-9859ccf5a01d",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Eggnog Annotations",
                     "output_name": "annotations",
-                    "uuid": "43943c26-0dd8-458f-a13e-d4fc25bc8f87"
+                    "uuid": "ba797eec-67b6-4b82-beaa-5e2cc404f560"
                 }
             ]
         },
@@ -3197,12 +3169,7 @@
                     "output_name": "data_param"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool SeqKit translate",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "SeqKit translate",
             "outputs": [
@@ -3231,11 +3198,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"append_frame\": false, \"clean\": false, \"frame\": \"1\", \"init_codon_as_M\": false, \"input\": {\"__class__\": \"RuntimeValue\"}, \"transl_table\": \"1\", \"translate_or_remove_unknown\": {\"selector\": \"trimming\", \"__current_case__\": 0, \"trim\": false}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"append_frame\": false, \"clean\": false, \"frame\": \"1\", \"init_codon_as_M\": false, \"input\": {\"__class__\": \"ConnectedValue\"}, \"transl_table\": \"1\", \"translate_or_remove_unknown\": {\"selector\": \"trimming\", \"__current_case__\": 0, \"trim\": false}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "2.13.0+galaxy0",
             "type": "tool",
-            "uuid": "bb0a3028-49c5-46b2-b0e9-bf25b5e83aef",
+            "uuid": "20e67d7d-ad6e-4a6d-8eb5-682bd69f1264",
             "when": null,
             "workflow_outputs": []
         },
@@ -3287,13 +3254,13 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "b13f643d-9317-438b-bb16-8a74fe18c96a",
+            "uuid": "fa74d81c-4bd1-42e1-9785-811400d72a6b",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "MMseqs2 representative sequences",
                     "output_name": "data_param",
-                    "uuid": "e21c23ca-423c-4de7-a21d-af633d6db96a"
+                    "uuid": "6d5d428b-ff16-4e7e-9f9a-b0fc5ff355cc"
                 }
             ]
         },
@@ -3308,12 +3275,7 @@
                     "output_name": "annotations"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool table rename column",
-                    "name": "input_dataset"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "table rename column",
             "outputs": [
@@ -3334,11 +3296,11 @@
                 "owner": "recetox",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"columns_selection\": [{\"__index__\": 0, \"column\": \"1\", \"new_name\": \"query\"}], \"input_dataset\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"columns_selection\": [{\"__index__\": 0, \"column\": \"1\", \"new_name\": \"query\"}], \"input_dataset\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "3.0.2+galaxy0",
             "type": "tool",
-            "uuid": "0fc43c7b-b863-4891-b475-8578dba70e8c",
+            "uuid": "dc661665-03fe-48de-8ac4-8e13c5cc4372",
             "when": null,
             "workflow_outputs": []
         },
@@ -3416,28 +3378,28 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"createdb\": {\"input_fasta\": {\"__class__\": \"RuntimeValue\"}, \"alph_type\": {\"dbtype\": \"0\", \"__current_case__\": 0}, \"shuffle\": true}, \"createtsv\": {\"first_seq_as_repr\": false, \"target_column\": \"1\", \"full_header\": false, \"idx_seq_src\": \"0\"}, \"database\": {\"database_type\": {\"type\": \"amino_acid_tax\", \"__current_case__\": 0, \"mmseqs2_db_select\": {\"__class__\": \"ConnectedValue\"}, \"search_type\": \"0\"}}, \"download_tax_db\": \"\", \"filtertaxseqdb\": {\"taxon_list\": \"\"}, \"kraken_report\": {\"keep_report\": \"Yes\", \"__current_case__\": 0}, \"krona_report\": {\"keep_report\": \"No\", \"__current_case__\": 1}, \"taxonomy\": {\"prefilter\": {\"add_self_matches\": false, \"kmer_length\": \"0\", \"mask\": \"1\", \"mask_prob\": \"0.9\", \"mask_lower_case\": \"0\", \"mask_n_repeat\": \"0\", \"spaced_kmer_mode\": \"1\", \"min_ungapped_score\": \"15\", \"sensitivity\": \"2.0\", \"target_search_mode\": \"0\", \"max_seqs\": \"300\", \"split\": \"0\", \"split_mode\": \"2\", \"diag_score\": true, \"exact_kmer_matching\": \"0\"}, \"align\": {\"convertalis\": false, \"alignment_output_mode\": \"0\", \"wrapped_scoring\": false, \"min_aln_len\": \"0\", \"seq_id_mode\": \"0\", \"alt_ali\": \"0\", \"score_bias\": \"0.0\", \"realign\": false, \"realign_score_bias\": \"-0.2\", \"realign_max_seqs\": \"2147483647\", \"corr_score_weight\": \"0.0\", \"alignment_mode\": \"1\", \"evalue\": \"1.0\", \"min_seq_id\": \"0.0\", \"cov_mode\": \"0\", \"cov\": \"0.0\", \"max_rejected\": \"5\", \"max_accept\": \"30\", \"exhaustive_search_filter\": false}, \"profile\": {\"mask_profile\": true, \"e_profile\": \"0.001\", \"wg\": false, \"filter_msa\": true, \"filter_min_enable\": \"0\", \"max_seq_id\": \"0.9\", \"qid\": \"0\", \"qsc\": \"-20.0\", \"cov\": \"0.0\", \"diff\": \"1000\", \"pseudo_cnt_mode\": \"0\", \"exhaustive_search\": false, \"lca_search\": false}, \"misc\": {\"orf_filter_e\": \"100.0\", \"orf_filter_s\": \"2.0\", \"lca_mode\": \"3\", \"majority\": \"0.5\", \"vote_mode\": \"1\", \"tax_lineage\": \"0\", \"blacklist\": \"\", \"taxon_list\": \"\", \"rescore_mode\": \"0\", \"allow_deletion\": false, \"min_length\": \"30\", \"max_length\": \"32734\", \"max_gaps\": \"2147483647\", \"contig_start_mode\": \"2\", \"contig_end_mode\": \"2\", \"orf_start_mode\": \"1\", \"forward_frames\": \"1,2,3\", \"reverse_frames\": \"1,2,3\", \"translation_table\": \"1\", \"translate\": false, \"use_all_table_starts\": false, \"id_offset\": \"0\", \"sequence_overlap\": \"0\", \"sequence_split_mode\": \"1\", \"headers_split_mode\": \"0\", \"prefilter_mode\": \"0\"}, \"common\": {\"max_seq_len\": \"65535\"}, \"expert\": {\"filter_hits\": false, \"sort_results\": \"0\", \"chain_alignments\": \"0\", \"merge_query\": \"1\"}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"createdb\": {\"input_fasta\": {\"__class__\": \"ConnectedValue\"}, \"alph_type\": {\"dbtype\": \"0\", \"__current_case__\": 0}, \"shuffle\": true}, \"createtsv\": {\"first_seq_as_repr\": false, \"target_column\": \"1\", \"full_header\": false, \"idx_seq_src\": \"0\"}, \"database\": {\"database_type\": {\"type\": \"amino_acid_tax\", \"__current_case__\": 0, \"mmseqs2_db_select\": {\"__class__\": \"ConnectedValue\"}, \"search_type\": \"0\"}}, \"download_tax_db\": \"\", \"filtertaxseqdb\": {\"taxon_list\": \"\"}, \"kraken_report\": {\"keep_report\": \"Yes\", \"__current_case__\": 0}, \"krona_report\": {\"keep_report\": \"No\", \"__current_case__\": 1}, \"taxonomy\": {\"prefilter\": {\"add_self_matches\": false, \"kmer_length\": \"0\", \"mask\": \"1\", \"mask_prob\": \"0.9\", \"mask_lower_case\": \"0\", \"mask_n_repeat\": \"0\", \"spaced_kmer_mode\": \"1\", \"min_ungapped_score\": \"15\", \"sensitivity\": \"2.0\", \"target_search_mode\": \"0\", \"max_seqs\": \"300\", \"split\": \"0\", \"split_mode\": \"2\", \"diag_score\": true, \"exact_kmer_matching\": \"0\"}, \"align\": {\"convertalis\": false, \"alignment_output_mode\": \"0\", \"wrapped_scoring\": false, \"min_aln_len\": \"0\", \"seq_id_mode\": \"0\", \"alt_ali\": \"0\", \"score_bias\": \"0.0\", \"realign\": false, \"realign_score_bias\": \"-0.2\", \"realign_max_seqs\": \"2147483647\", \"corr_score_weight\": \"0.0\", \"alignment_mode\": \"1\", \"evalue\": \"1.0\", \"min_seq_id\": \"0.0\", \"cov_mode\": \"0\", \"cov\": \"0.0\", \"max_rejected\": \"5\", \"max_accept\": \"30\", \"exhaustive_search_filter\": false}, \"profile\": {\"mask_profile\": true, \"e_profile\": \"0.001\", \"wg\": false, \"filter_msa\": true, \"filter_min_enable\": \"0\", \"max_seq_id\": \"0.9\", \"qid\": \"0\", \"qsc\": \"-20.0\", \"cov\": \"0.0\", \"diff\": \"1000\", \"pseudo_cnt_mode\": \"0\", \"exhaustive_search\": false, \"lca_search\": false}, \"misc\": {\"orf_filter_e\": \"100.0\", \"orf_filter_s\": \"2.0\", \"lca_mode\": \"3\", \"majority\": \"0.5\", \"vote_mode\": \"1\", \"tax_lineage\": \"0\", \"blacklist\": \"\", \"taxon_list\": \"\", \"rescore_mode\": \"0\", \"allow_deletion\": false, \"min_length\": \"30\", \"max_length\": \"32734\", \"max_gaps\": \"2147483647\", \"contig_start_mode\": \"2\", \"contig_end_mode\": \"2\", \"orf_start_mode\": \"1\", \"forward_frames\": \"1,2,3\", \"reverse_frames\": \"1,2,3\", \"translation_table\": \"1\", \"translate\": false, \"use_all_table_starts\": false, \"id_offset\": \"0\", \"sequence_overlap\": \"0\", \"sequence_split_mode\": \"1\", \"headers_split_mode\": \"0\", \"prefilter_mode\": \"0\"}, \"common\": {\"max_seq_len\": \"65535\"}, \"expert\": {\"filter_hits\": false, \"sort_results\": \"0\", \"chain_alignments\": \"0\", \"merge_query\": \"1\"}}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "17-b804f+galaxy1",
             "type": "tool",
-            "uuid": "5512f5ba-33ac-415d-beed-42c79bd15a72",
+            "uuid": "25b1a606-eca8-413b-949c-f2ff19212ae5",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "MMseqs2 Taxonomy Kraken",
-                    "output_name": "output_taxonomy_kraken",
-                    "uuid": "8b1bb767-a759-45cd-8375-a052a447dbe3"
-                },
-                {
                     "label": "MMseqs2 Taxonomy Tabular",
                     "output_name": "output_taxonomy_tsv",
-                    "uuid": "653d2224-2a8a-4324-8bbe-eda23adc16b0"
+                    "uuid": "737cfa82-6e46-4b7d-9906-098525e9881e"
+                },
+                {
+                    "label": "MMseqs2 Taxonomy Kraken",
+                    "output_name": "output_taxonomy_kraken",
+                    "uuid": "9f90fc56-06cc-44a1-9210-bb94fbbe7bcf"
                 }
             ]
         },
         "38": {
             "annotation": "",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/coverm_contig/coverm_contig/0.7.0+galaxy0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/coverm_contig/coverm_contig/0.8.0+galaxy0",
             "errors": null,
             "id": 38,
             "input_connections": {
@@ -3472,18 +3434,18 @@
                     "output_name": "output"
                 }
             },
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/coverm_contig/coverm_contig/0.7.0+galaxy0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/coverm_contig/coverm_contig/0.8.0+galaxy0",
             "tool_shed_repository": {
-                "changeset_revision": "28d740f2c0b0",
+                "changeset_revision": "d9b724b4a136",
                 "name": "coverm_contig",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"alignment\": {\"min_read_aligned_length\": \"0\", \"min_read_percent_identity\": \"0.0\", \"min_read_aligned_percent\": \"0.0\", \"proper_pairs_only\": {\"proper_pairs_only\": \"\", \"__current_case__\": 1}, \"exclude_supplementary\": false}, \"cov\": {\"methods\": \"mean\", \"trim_min\": \"5\", \"trim_max\": \"95\", \"min_covered_fraction\": \"10\", \"contig_end_exclusion\": \"75\"}, \"mapped\": {\"mapped\": \"not-mapped\", \"__current_case__\": 1, \"mode\": {\"mode\": \"individual\", \"__current_case__\": 0, \"read_type\": {\"type\": \"paired_collection\", \"__current_case__\": 2, \"paired_reads\": {\"__class__\": \"ConnectedValue\"}}, \"reference\": {\"__class__\": \"ConnectedValue\"}}, \"mapper\": \"minimap2-sr\"}, \"output_format\": \"dense\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"alignment\": {\"min_read_aligned_length\": \"0\", \"min_read_percent_identity\": \"0.0\", \"min_read_aligned_percent\": \"0.0\", \"proper_pairs_only\": {\"proper_pairs_only\": \"\", \"__current_case__\": 1}, \"exclude_supplementary\": false}, \"cov\": {\"methods\": \"mean\", \"trim_min\": \"5\", \"trim_max\": \"95\", \"min_covered_fraction\": \"10\", \"contig_end_exclusion\": \"75\"}, \"mapped\": {\"mapped\": \"not-mapped\", \"__current_case__\": 1, \"mode\": {\"mode\": \"individual\", \"__current_case__\": 0, \"read_type\": {\"type\": \"paired_collection\", \"__current_case__\": 2, \"paired_reads\": {\"__class__\": \"RuntimeValue\"}}, \"reference\": {\"__class__\": \"RuntimeValue\"}}, \"mapper\": \"minimap2-sr\"}, \"output_format\": \"dense\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
-            "tool_version": "0.7.0+galaxy0",
+            "tool_version": "0.8.0+galaxy0",
             "type": "tool",
-            "uuid": "11da3d7e-d7b5-4fd3-9850-42fd884efed8",
+            "uuid": "320c357d-bb06-4d3f-a7a1-9b2b165a6939",
             "when": null,
             "workflow_outputs": []
         },
@@ -3529,7 +3491,7 @@
             "tool_uuid": null,
             "tool_version": "1.2.1+galaxy0",
             "type": "tool",
-            "uuid": "db4a4e7e-6cfa-4ae7-aaa9-d0a6ddbaa0e6",
+            "uuid": "c7e3fe2b-f328-4024-b4d5-ecbebcedd418",
             "when": null,
             "workflow_outputs": []
         },
@@ -3577,13 +3539,13 @@
             "tool_uuid": null,
             "tool_version": "0.0.3",
             "type": "tool",
-            "uuid": "30d314d7-911d-46a0-9471-1382a60955c4",
+            "uuid": "f2f07fc3-e419-4d71-988f-f029366b8d57",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "CoverM contig",
                     "output_name": "tabular_output",
-                    "uuid": "c50bf7b1-0a6d-467d-9b6d-8e1752bff98f"
+                    "uuid": "3a699b3d-a61f-426c-a2fb-17917f5809eb"
                 }
             ]
         },
@@ -3636,13 +3598,13 @@
             "tool_uuid": null,
             "tool_version": "2.7.1+galaxy0",
             "type": "tool",
-            "uuid": "0ab957e0-fc37-4e2d-9b57-8de5d47bb432",
+            "uuid": "68d5b391-9339-4eff-aeb0-aa2970ad64f4",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "MMseqs2 Taxonomy Krona",
                     "output_name": "output",
-                    "uuid": "7b98e48c-f2aa-4cbf-a56a-97195afc719c"
+                    "uuid": "2f651257-f468-42a0-9ccd-7fd7f719da8d"
                 }
             ]
         },
@@ -3719,17 +3681,17 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"image_content_input\": {\"__class__\": \"RuntimeValue\"}, \"png_plots\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"quast\", \"__current_case__\": 22, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"ABRicate report\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"AMRFinderPlus report with argNorm\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 3, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"starAMR detailed report\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 4, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"CoverM\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 5, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"EggnogMapper annotations\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}, {\"__index__\": 6, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"MMseqs2 taxonomy\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"RuntimeValue\"}}}], \"title\": \"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"comment\": \"\", \"export\": false, \"flat\": false, \"image_content_input\": {\"__class__\": \"RuntimeValue\"}, \"png_plots\": false, \"results\": [{\"__index__\": 0, \"software_cond\": {\"software\": \"quast\", \"__current_case__\": 22, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 1, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"ABRicate report\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 2, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"AMRFinderPlus report with argNorm\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 3, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"starAMR detailed report\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 4, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"CoverM\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 5, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"EggnogMapper annotations\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"ConnectedValue\"}}}, {\"__index__\": 6, \"software_cond\": {\"software\": \"custom_content\", \"__current_case__\": 54, \"plot_type\": \"table\", \"section_name\": \"MMseqs2 taxonomy\", \"title\": null, \"description\": null, \"xlab\": null, \"ylab\": null, \"input\": {\"__class__\": \"ConnectedValue\"}}}], \"title\": \"\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "1.35+galaxy1",
             "type": "tool",
-            "uuid": "5e63ede6-b269-4691-8234-462ab23ab210",
+            "uuid": "def0abc8-09cd-4769-beef-7ca296e80907",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "MultiQC Report",
                     "output_name": "html_report",
-                    "uuid": "87db7fca-6e08-4844-95d5-3b365aa71bd5"
+                    "uuid": "ef2dc354-f3b6-4d8e-8d1a-e7dacededc1b"
                 }
             ]
         }

--- a/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.ga
+++ b/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.ga
@@ -145,7 +145,7 @@
     ],
     "format-version": "0.1",
     "license": "GPL-3.0-or-later",
-    "name": "Metagenomic Genes Catalogue Analysis (concatenate later)",
+    "name": "Metagenomic Genes Catalogue Analysis",
     "report": {
         "markdown": "\n# Workflow Execution Report\n\n## Workflow Inputs\n```galaxy\ninvocation_inputs()\n```\n\n## Workflow Outputs\n```galaxy\ninvocation_outputs()\n```\n\n## Workflow\n```galaxy\nworkflow_display()\n```\n"
     },

--- a/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.ga
+++ b/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.ga
@@ -3741,6 +3741,7 @@
         "genes-collection",
         "paired-collection(s)"
     ],
-    "uuid": "1b280a47-34fe-4599-9069-4d08145ac1ae",
-    "version": 5
+    "uuid": "8c7039c9-333f-47dc-ae7d-2985935a8c8d",
+    "version": 1,
+    "release": "1.3"
 }

--- a/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.ga
+++ b/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.ga
@@ -2446,7 +2446,7 @@
                     },
                     "19": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.5+galaxy2",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.5+galaxy3",
                         "errors": null,
                         "id": 19,
                         "input_connections": {
@@ -2481,7 +2481,7 @@
                                 "output_name": "output"
                             }
                         },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.5+galaxy2",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_easyjoin_tool/9.5+galaxy3",
                         "tool_shed_repository": {
                             "changeset_revision": "ab83aa685821",
                             "name": "text_processing",
@@ -2644,7 +2644,7 @@
                     },
                     "23": {
                         "annotation": "",
-                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy2",
+                        "content_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy3",
                         "errors": null,
                         "id": 23,
                         "input_connections": {
@@ -2682,7 +2682,7 @@
                                 "output_name": "outfile"
                             }
                         },
-                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy2",
+                        "tool_id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_replace_in_line/9.5+galaxy3",
                         "tool_shed_repository": {
                             "changeset_revision": "ab83aa685821",
                             "name": "text_processing",

--- a/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.ga
+++ b/workflows/microbiome/metagenomic-genes-catalogue/metagenomic-genes-catalogue.ga
@@ -28,38 +28,38 @@
         },
         {
             "child_steps": [
-                7,
-                10,
-                13,
-                14,
-                15,
-                9,
-                12
+                33,
+                34,
+                37,
+                39,
+                41,
+                30,
+                31
             ],
-            "color": "turquoise",
+            "color": "green",
             "data": {
-                "title": "Assembly and genes detection"
+                "title": "Taxonomy and functional annotation"
             },
-            "id": 0,
+            "id": 3,
             "position": [
-                670.6814223676528,
-                1463.8724631998139
+                3317.6,
+                1543
             ],
             "size": [
-                1385,
-                857
+                1281,
+                854
             ],
             "type": "frame"
         },
         {
             "child_steps": [
-                24,
                 27,
                 18,
                 19,
                 20,
                 21,
-                22
+                22,
+                24
             ],
             "color": "red",
             "data": {
@@ -73,6 +73,31 @@
             "size": [
                 1110,
                 1070
+            ],
+            "type": "frame"
+        },
+        {
+            "child_steps": [
+                12,
+                7,
+                10,
+                13,
+                14,
+                15,
+                9
+            ],
+            "color": "turquoise",
+            "data": {
+                "title": "Assembly and genes detection"
+            },
+            "id": 0,
+            "position": [
+                670.6814223676528,
+                1463.8724631998139
+            ],
+            "size": [
+                1385,
+                857
             ],
             "type": "frame"
         },
@@ -96,31 +121,6 @@
             "size": [
                 992.4,
                 703.9
-            ],
-            "type": "frame"
-        },
-        {
-            "child_steps": [
-                33,
-                34,
-                37,
-                39,
-                41,
-                30,
-                31
-            ],
-            "color": "green",
-            "data": {
-                "title": "Taxonomy and functional annotation"
-            },
-            "id": 3,
-            "position": [
-                3317.6,
-                1543
-            ],
-            "size": [
-                1281,
-                854
             ],
             "type": "frame"
         }
@@ -173,7 +173,7 @@
             "tool_state": "{\"optional\": false, \"format\": [\"fastq\", \"fastq.gz\", \"fastqsanger\", \"fastqsanger.gz\"], \"tag\": null, \"collection_type\": \"list:paired\", \"fields\": null, \"column_definitions\": null}",
             "tool_version": null,
             "type": "data_collection_input",
-            "uuid": "f3f9d50e-8b2f-48e1-bc1e-5e02f8f70017",
+            "uuid": "bad2528a-3581-4523-827e-e049ae8a5389",
             "when": null,
             "workflow_outputs": []
         },
@@ -200,7 +200,7 @@
             "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "60659c02-5d7a-46a4-8a49-0e1865c40a1e",
+            "uuid": "3820be9e-8c8d-4749-8910-8f2e81fa82e5",
             "when": null,
             "workflow_outputs": []
         },
@@ -227,7 +227,7 @@
             "tool_state": "{\"default\": false, \"validators\": [], \"parameter_type\": \"boolean\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "17e74321-6296-48fb-9d65-a64f5bf1526a",
+            "uuid": "25c7b5ea-24a8-4a4a-a55e-8e6dad920a41",
             "when": null,
             "workflow_outputs": []
         },
@@ -254,7 +254,7 @@
             "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "e4d2102f-2d60-4b8e-a11d-b8b86bb6a712",
+            "uuid": "a2249b0f-7e03-464c-b5dd-4e66387f7520",
             "when": null,
             "workflow_outputs": []
         },
@@ -281,7 +281,7 @@
             "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "e1ce47f0-47a2-4372-b22b-642bc2315a26",
+            "uuid": "273bcef3-b8ad-402f-9a37-471cb61a5c37",
             "when": null,
             "workflow_outputs": []
         },
@@ -308,7 +308,7 @@
             "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "dce8f5d5-2f41-4095-a59d-9f1b40695b34",
+            "uuid": "506fde59-6f49-435f-83aa-2474cc0bfe63",
             "when": null,
             "workflow_outputs": []
         },
@@ -335,7 +335,7 @@
             "tool_state": "{\"multiple\": false, \"validators\": [], \"restrictOnConnections\": true, \"parameter_type\": \"text\", \"optional\": false}",
             "tool_version": null,
             "type": "parameter_input",
-            "uuid": "8a383bad-550f-4fcb-8859-546a955e1936",
+            "uuid": "9a39d51a-78fe-4e13-ba3e-01ac7e60433b",
             "when": null,
             "workflow_outputs": []
         },
@@ -413,13 +413,13 @@
             "tool_uuid": null,
             "tool_version": "1.2.9+galaxy2",
             "type": "tool",
-            "uuid": "40b5c6a8-e88c-4f36-af3d-82d8dfe1ad4b",
+            "uuid": "9bde7736-159e-4976-9872-9385783ef349",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Megahit Contigs Output",
                     "output_name": "output",
-                    "uuid": "5402d63a-1c46-44c8-822c-1aa65780550f"
+                    "uuid": "b7da78e7-1ed6-49ff-aeb8-c853230f3803"
                 }
             ]
         },
@@ -459,7 +459,7 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "c62af8d3-817f-49a4-bcf9-6724d6bd3627",
+            "uuid": "fb14670b-056e-4975-8473-444491094110",
             "when": "$(inputs.when)",
             "workflow_outputs": []
         },
@@ -499,7 +499,7 @@
             "tool_uuid": null,
             "tool_version": "1.1.1",
             "type": "tool",
-            "uuid": "ae42b22a-e7d8-4a0d-8d8f-0979f801050c",
+            "uuid": "29cb9ff4-f1cf-4786-aafa-90f66d79a3ff",
             "when": null,
             "workflow_outputs": []
         },
@@ -584,18 +584,18 @@
             "tool_uuid": null,
             "tool_version": "5.3.0+galaxy1",
             "type": "tool",
-            "uuid": "f26bc91e-1767-49da-8339-351443dfa5d4",
+            "uuid": "e21bae28-b821-4902-aa54-36f7cff89f1b",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Report HTML Meta",
                     "output_name": "report_html_meta",
-                    "uuid": "c2f9f547-f0f7-4d92-87da-cf92235b7a37"
+                    "uuid": "61bcf14b-8136-4c46-b958-4e8b4452e3b6"
                 },
                 {
                     "label": "Report Tabular Meta",
                     "output_name": "report_tabular_meta",
-                    "uuid": "bd6b020f-009c-4576-933b-3eceaa0091d2"
+                    "uuid": "f17b4718-dd55-4030-8103-8d431521a997"
                 }
             ]
         },
@@ -635,13 +635,13 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "4a1533c7-d36c-476b-8a1a-2fa2a210c5fb",
+            "uuid": "fe245aa8-e9cf-4623-bb91-41057aef5f5b",
             "when": null,
             "workflow_outputs": []
         },
         "12": {
             "annotation": "Adds the sample name to the column corresponding to the initial ID. Allows you to create a unique ID for each sample.",
-            "content_id": "toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.2.0",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.3.0",
             "errors": null,
             "id": 12,
             "input_connections": {
@@ -650,7 +650,12 @@
                     "output_name": "output"
                 }
             },
-            "inputs": [],
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Add input name as column",
+                    "name": "input"
+                }
+            ],
             "label": null,
             "name": "Add input name as column",
             "outputs": [
@@ -664,18 +669,18 @@
                 "top": 1860.6201311287323
             },
             "post_job_actions": {},
-            "tool_id": "toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.2.0",
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.3.0",
             "tool_shed_repository": {
-                "changeset_revision": "3284b72eef56",
+                "changeset_revision": "8a19efbd2178",
                 "name": "add_input_name_as_column",
                 "owner": "mvdbeek",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"header\": {\"contains_header\": \"no\", \"__current_case__\": 1}, \"input\": {\"__class__\": \"ConnectedValue\"}, \"prepend\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"header\": {\"contains_header\": \"no\", \"__current_case__\": 1}, \"input\": {\"__class__\": \"RuntimeValue\"}, \"prepend\": true, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
-            "tool_version": "0.2.0",
+            "tool_version": "0.3.0",
             "type": "tool",
-            "uuid": "33974bb8-c39d-4084-ac3f-663ea617e688",
+            "uuid": "8febe229-996f-4eca-9562-addafb51bcc1",
             "when": null,
             "workflow_outputs": []
         },
@@ -723,13 +728,13 @@
             "tool_uuid": null,
             "tool_version": "1.1.1",
             "type": "tool",
-            "uuid": "0e377f2f-073d-484e-a137-acde8504bcd2",
+            "uuid": "3e975316-6203-40ac-bd84-f7f95e49b49c",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Megahit output with sample name in ID",
                     "output_name": "output",
-                    "uuid": "6bb1bcff-4a9d-4d4d-b1ff-e64846388710"
+                    "uuid": "ee076178-f063-41ce-8c2f-f1ac44f5e77b"
                 }
             ]
         },
@@ -815,13 +820,13 @@
             "tool_uuid": null,
             "tool_version": "2.6.3+galaxy0",
             "type": "tool",
-            "uuid": "50d17430-650a-442a-b7ed-759f4cd3c347",
+            "uuid": "c58b4e41-5b6c-454b-8669-ed3ab9e61c10",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Prodigal Genes Sequences",
                     "output_name": "output_fnn",
-                    "uuid": "9f7d0ef2-2d53-40d9-8e2a-c549b592c240"
+                    "uuid": "32352a80-36c0-45e1-bc60-167a6b1da796"
                 }
             ]
         },
@@ -883,13 +888,13 @@
             "tool_uuid": null,
             "tool_version": "9.5+galaxy3",
             "type": "tool",
-            "uuid": "396866cb-0579-4562-88f2-f193be4d8119",
+            "uuid": "e3db603e-5048-4bc1-bc80-e90c21600261",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Concatenate Datasets",
                     "output_name": "out_file1",
-                    "uuid": "db32e98a-029a-43ae-9903-1fdf76b49676"
+                    "uuid": "53754997-8e07-4d19-b378-ca03709d7914"
                 }
             ]
         },
@@ -941,7 +946,7 @@
             "tool_uuid": null,
             "tool_version": "17-b804f+galaxy1",
             "type": "tool",
-            "uuid": "d1385193-5788-495b-b06c-449cec79b200",
+            "uuid": "32319560-6538-41ae-af05-ffc8bd13059b",
             "when": "$(inputs.when)",
             "workflow_outputs": []
         },
@@ -991,7 +996,7 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "e2accce7-6a5a-45df-861d-8762909deb7c",
+            "uuid": "017375cf-e4ad-43a9-9c07-cf7d48d19474",
             "when": null,
             "workflow_outputs": []
         },
@@ -1059,13 +1064,13 @@
             "tool_uuid": null,
             "tool_version": "3.12.8+galaxy0",
             "type": "tool",
-            "uuid": "6cd4094b-0cc9-46c4-b48e-026bf25fe041",
+            "uuid": "b0f0dda9-e4aa-449f-8e90-d9b577e7310e",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "AMRFinderplus Report",
                     "output_name": "amrfinderplus_report",
-                    "uuid": "962f937c-3585-4ea5-bd50-5b25cfd3de57"
+                    "uuid": "a6aef2c3-79ef-4c6b-93c8-cb4bc8fd1204"
                 }
             ]
         },
@@ -1122,13 +1127,13 @@
             "tool_uuid": null,
             "tool_version": "1.4.0",
             "type": "tool",
-            "uuid": "9c4e4a54-a4c9-434d-95e0-38447e2b0b31",
+            "uuid": "f0068a6e-6249-45bd-8afd-4f42615b3f97",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Abricate Virulence Report",
                     "output_name": "report",
-                    "uuid": "23a96ccb-168f-42f9-8c0a-c3eda544485e"
+                    "uuid": "fd22acd9-6988-46cf-b874-9fdb92edabb1"
                 }
             ]
         },
@@ -1257,23 +1262,23 @@
             "tool_uuid": null,
             "tool_version": "0.12.3+galaxy0",
             "type": "tool",
-            "uuid": "d76f0150-abd4-400b-96e9-5d9870a21929",
+            "uuid": "fd8c472a-7bb0-472f-aa97-8f8e0c18a409",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "Plasmidfinder",
-                    "output_name": "plasmidfinder",
-                    "uuid": "e88e58aa-49ae-4bd5-a311-ca30e15c40c1"
-                },
-                {
                     "label": "Detailed Summary",
                     "output_name": "detailed_summary",
-                    "uuid": "a20f9b73-8abe-4fa5-8b93-6f17be3770c6"
+                    "uuid": "997d6a08-4ffc-47fe-b7e2-a6dc40b588c2"
                 },
                 {
                     "label": "Resfinder",
                     "output_name": "resfinder",
-                    "uuid": "e3f93da9-cae6-4208-acb5-fe952a187b96"
+                    "uuid": "2a457d16-5d69-44b1-99fc-8d06bd2502e0"
+                },
+                {
+                    "label": "Plasmidfinder",
+                    "output_name": "plasmidfinder",
+                    "uuid": "aef9de9e-1ca6-40b1-93f8-5e5becd8e316"
                 }
             ]
         },
@@ -1328,13 +1333,13 @@
             "tool_uuid": null,
             "tool_version": "5.1.0",
             "type": "tool",
-            "uuid": "408eae3c-b3e1-45f0-84b4-a7f1deaf14cf",
+            "uuid": "3d196054-ae98-40d7-a723-1bd2c212ca28",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "AMRfinderplus Concatenated Reports",
                     "output_name": "output",
-                    "uuid": "580ae299-0db6-461d-aae5-35dac38c68bb"
+                    "uuid": "dcb7171a-ccde-4b15-9d99-e1c13ac961dc"
                 }
             ]
         },
@@ -1389,13 +1394,13 @@
             "tool_uuid": null,
             "tool_version": "5.1.0",
             "type": "tool",
-            "uuid": "fd41c655-c9d6-4a24-bac1-3bf66e3db33d",
+            "uuid": "806ac9f6-4a76-4da3-b69c-f7a0e3d7a871",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "ABRicate Virulence Concatenated Reports",
                     "output_name": "output",
-                    "uuid": "6d85c904-c868-4794-aab0-91bc56271152"
+                    "uuid": "96fb03c3-dec5-4bd2-8a5f-44a94f3f8094"
                 }
             ]
         },
@@ -1435,7 +1440,7 @@
             "tool_uuid": null,
             "tool_version": "1.0",
             "type": "tool",
-            "uuid": "87347787-613c-49e6-ae71-881d499c461a",
+            "uuid": "393c7a43-2d41-4253-a06f-c8066b1651bc",
             "when": null,
             "workflow_outputs": []
         },
@@ -1490,13 +1495,13 @@
             "tool_uuid": null,
             "tool_version": "1.0.0+galaxy0",
             "type": "tool",
-            "uuid": "34f80fee-6ecb-4675-b7ad-79e2c2579658",
+            "uuid": "704c5095-7253-4a1c-bb53-62e49e6a5792",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Argnorm AMRfinderplus Concatenated Reports",
                     "output_name": "output",
-                    "uuid": "dacb6993-d782-45b1-bac7-6cb16372cdbb"
+                    "uuid": "f42dc9ff-c850-4195-8909-ee7f7bde99bf"
                 }
             ]
         },
@@ -1536,7 +1541,7 @@
             "tool_uuid": null,
             "tool_version": "1.0",
             "type": "tool",
-            "uuid": "33dffa9b-ae28-4546-92e3-55131db5da26",
+            "uuid": "23429980-2aa6-42bf-a838-d6afdfab8178",
             "when": null,
             "workflow_outputs": []
         },
@@ -1576,7 +1581,7 @@
             "tool_uuid": null,
             "tool_version": "3.0.2+galaxy0",
             "type": "tool",
-            "uuid": "2b897ae6-41f5-4d82-a92b-81cc3fb26d8e",
+            "uuid": "d8a821cf-9e09-4ed6-b828-024863c07165",
             "when": null,
             "workflow_outputs": []
         },
@@ -2825,18 +2830,18 @@
             },
             "tool_id": null,
             "type": "subworkflow",
-            "uuid": "a80b9bea-24e0-4785-b334-f3d291a02c3d",
+            "uuid": "9bdaa750-fa35-4c52-b9b9-c50695e64d34",
             "when": "$(inputs.when)",
             "workflow_outputs": [
                 {
                     "label": "FASTA with CDS corresponding and related to ARGs (ARGs and linked to)",
                     "output_name": "FASTA with CDS corresponding and related to ARGs (ARGs and linked to)",
-                    "uuid": "25ee9491-96c3-42ad-8c04-3cfbbfe6a7f8"
+                    "uuid": "7edbcf97-ce1c-4248-9efd-8065f75ea74d"
                 },
                 {
                     "label": "FASTA with contigs related to ARGs",
                     "output_name": "FASTA with contigs related to ARGs",
-                    "uuid": "281a8637-3297-40de-8ef9-718b246d6c62"
+                    "uuid": "44bc2529-6ead-410f-b713-f6501916daf1"
                 }
             ]
         },
@@ -2876,7 +2881,7 @@
             "tool_uuid": null,
             "tool_version": "1.0",
             "type": "tool",
-            "uuid": "be51f693-6ad9-49a4-a9ea-d9bf8bdef831",
+            "uuid": "5eb47f55-c573-4a16-be0b-dc2d4044cff1",
             "when": null,
             "workflow_outputs": []
         },
@@ -2922,7 +2927,7 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "e51dcbfa-d0fa-40cd-9009-443174bb95ba",
+            "uuid": "aea5b9ca-0ad4-480d-a580-92ac6c0c707a",
             "when": null,
             "workflow_outputs": []
         },
@@ -2966,7 +2971,7 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "a6cb32f9-5c74-4867-89cb-9788290ae41f",
+            "uuid": "68a69009-f6f3-4335-a9e4-74f77feecec1",
             "when": null,
             "workflow_outputs": []
         },
@@ -3010,7 +3015,7 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "3ea407f3-0827-47fd-a475-ccfdc510fd89",
+            "uuid": "73da5594-23ca-4431-a2f4-f7482ea7f364",
             "when": null,
             "workflow_outputs": []
         },
@@ -3062,7 +3067,7 @@
             "tool_uuid": null,
             "tool_version": "17-b804f+galaxy1",
             "type": "tool",
-            "uuid": "86a9e714-28c1-4b7d-8c2b-4cc279dcf0c2",
+            "uuid": "96c3fd81-1d55-49c0-8360-c07b90c8646c",
             "when": "$(inputs.when)",
             "workflow_outputs": []
         },
@@ -3148,13 +3153,13 @@
             "tool_uuid": null,
             "tool_version": "2.1.13+galaxy0",
             "type": "tool",
-            "uuid": "d7604a1a-1839-4cd4-a348-9859ccf5a01d",
+            "uuid": "41497c63-fa70-4342-b7e4-456e8ff25acb",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "Eggnog Annotations",
                     "output_name": "annotations",
-                    "uuid": "ba797eec-67b6-4b82-beaa-5e2cc404f560"
+                    "uuid": "edc9f0e8-35d5-48c8-9662-b4631dc182cb"
                 }
             ]
         },
@@ -3202,7 +3207,7 @@
             "tool_uuid": null,
             "tool_version": "2.13.0+galaxy0",
             "type": "tool",
-            "uuid": "20e67d7d-ad6e-4a6d-8eb5-682bd69f1264",
+            "uuid": "f3a4e036-c12d-471c-b6f8-5db8f95616d5",
             "when": null,
             "workflow_outputs": []
         },
@@ -3254,13 +3259,13 @@
             "tool_uuid": null,
             "tool_version": "0.2.0",
             "type": "tool",
-            "uuid": "fa74d81c-4bd1-42e1-9785-811400d72a6b",
+            "uuid": "d9bbde97-c86b-4c97-a4d1-35bee7bd3ad5",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "MMseqs2 representative sequences",
                     "output_name": "data_param",
-                    "uuid": "6d5d428b-ff16-4e7e-9f9a-b0fc5ff355cc"
+                    "uuid": "ee295488-579e-4680-8cd7-29f7227cbf37"
                 }
             ]
         },
@@ -3300,7 +3305,7 @@
             "tool_uuid": null,
             "tool_version": "3.0.2+galaxy0",
             "type": "tool",
-            "uuid": "dc661665-03fe-48de-8ac4-8e13c5cc4372",
+            "uuid": "e3134c5a-8020-4a3b-bcb7-a6a501a8bd8e",
             "when": null,
             "workflow_outputs": []
         },
@@ -3382,18 +3387,18 @@
             "tool_uuid": null,
             "tool_version": "17-b804f+galaxy1",
             "type": "tool",
-            "uuid": "25b1a606-eca8-413b-949c-f2ff19212ae5",
+            "uuid": "20dec667-afc8-4a13-bb0e-6bcbf9db214d",
             "when": null,
             "workflow_outputs": [
                 {
-                    "label": "MMseqs2 Taxonomy Tabular",
-                    "output_name": "output_taxonomy_tsv",
-                    "uuid": "737cfa82-6e46-4b7d-9906-098525e9881e"
-                },
-                {
                     "label": "MMseqs2 Taxonomy Kraken",
                     "output_name": "output_taxonomy_kraken",
-                    "uuid": "9f90fc56-06cc-44a1-9210-bb94fbbe7bcf"
+                    "uuid": "e92f11cc-151d-4de0-a708-5c56fb45eb35"
+                },
+                {
+                    "label": "MMseqs2 Taxonomy Tabular",
+                    "output_name": "output_taxonomy_tsv",
+                    "uuid": "6881fc6d-3a19-4bbe-a807-660d30bf0189"
                 }
             ]
         },
@@ -3441,11 +3446,11 @@
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"alignment\": {\"min_read_aligned_length\": \"0\", \"min_read_percent_identity\": \"0.0\", \"min_read_aligned_percent\": \"0.0\", \"proper_pairs_only\": {\"proper_pairs_only\": \"\", \"__current_case__\": 1}, \"exclude_supplementary\": false}, \"cov\": {\"methods\": \"mean\", \"trim_min\": \"5\", \"trim_max\": \"95\", \"min_covered_fraction\": \"10\", \"contig_end_exclusion\": \"75\"}, \"mapped\": {\"mapped\": \"not-mapped\", \"__current_case__\": 1, \"mode\": {\"mode\": \"individual\", \"__current_case__\": 0, \"read_type\": {\"type\": \"paired_collection\", \"__current_case__\": 2, \"paired_reads\": {\"__class__\": \"RuntimeValue\"}}, \"reference\": {\"__class__\": \"RuntimeValue\"}}, \"mapper\": \"minimap2-sr\"}, \"output_format\": \"dense\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"alignment\": {\"min_read_aligned_length\": \"0\", \"min_read_percent_identity\": \"0.0\", \"min_read_aligned_percent\": \"0.0\", \"proper_pairs_only\": {\"proper_pairs_only\": \"\", \"__current_case__\": 1}, \"exclude_supplementary\": false}, \"cov\": {\"methods\": \"mean\", \"trim_min\": \"5\", \"trim_max\": \"95\", \"min_covered_fraction\": \"10\", \"contig_end_exclusion\": \"75\"}, \"mapped\": {\"mapped\": \"not-mapped\", \"__current_case__\": 1, \"mode\": {\"mode\": \"individual\", \"__current_case__\": 0, \"read_type\": {\"type\": \"paired_collection\", \"__current_case__\": 2, \"paired_reads\": {\"__class__\": \"ConnectedValue\"}}, \"reference\": {\"__class__\": \"ConnectedValue\"}}, \"mapper\": \"minimap2-sr\"}, \"output_format\": \"dense\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
             "tool_uuid": null,
             "tool_version": "0.8.0+galaxy0",
             "type": "tool",
-            "uuid": "320c357d-bb06-4d3f-a7a1-9b2b165a6939",
+            "uuid": "d42bbc13-69c8-4eb6-b060-cb81ebb44924",
             "when": null,
             "workflow_outputs": []
         },
@@ -3491,7 +3496,7 @@
             "tool_uuid": null,
             "tool_version": "1.2.1+galaxy0",
             "type": "tool",
-            "uuid": "c7e3fe2b-f328-4024-b4d5-ecbebcedd418",
+            "uuid": "3925262f-c3c5-451a-bacd-a3d0475b363a",
             "when": null,
             "workflow_outputs": []
         },
@@ -3539,13 +3544,13 @@
             "tool_uuid": null,
             "tool_version": "0.0.3",
             "type": "tool",
-            "uuid": "f2f07fc3-e419-4d71-988f-f029366b8d57",
+            "uuid": "2557877e-18ab-42ea-a543-0ba656e94645",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "CoverM contig",
                     "output_name": "tabular_output",
-                    "uuid": "3a699b3d-a61f-426c-a2fb-17917f5809eb"
+                    "uuid": "63f0bbd3-885d-43c9-8503-27f5b22f9d50"
                 }
             ]
         },
@@ -3598,13 +3603,13 @@
             "tool_uuid": null,
             "tool_version": "2.7.1+galaxy0",
             "type": "tool",
-            "uuid": "68d5b391-9339-4eff-aeb0-aa2970ad64f4",
+            "uuid": "e60b9f9d-4f99-4182-884b-1c4e2e4ce565",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "MMseqs2 Taxonomy Krona",
                     "output_name": "output",
-                    "uuid": "2f651257-f468-42a0-9ccd-7fd7f719da8d"
+                    "uuid": "ff0593d8-9809-4feb-a4c4-60d66aaf9be4"
                 }
             ]
         },
@@ -3685,13 +3690,13 @@
             "tool_uuid": null,
             "tool_version": "1.35+galaxy1",
             "type": "tool",
-            "uuid": "def0abc8-09cd-4769-beef-7ca296e80907",
+            "uuid": "003f4529-b21a-47fa-b0dd-dec70c091e28",
             "when": null,
             "workflow_outputs": [
                 {
                     "label": "MultiQC Report",
                     "output_name": "html_report",
-                    "uuid": "ef2dc354-f3b6-4d8e-8d1a-e7dacededc1b"
+                    "uuid": "03f0cb2f-940b-43dd-a428-f269caae0247"
                 }
             ]
         }


### PR DESCRIPTION
### Changed

- Concatenation used to be performed directly after assembly, but following steps (Prodigal and AMRFinderPlus) could take too long depending on the number of samples and their size. Concatenation is now performed later in the workflow, which speeds up the process when dealing with multiple samples, without affecting the results.

### Deprecated
- The updated versions of these two tools are available only on galaxy.org
- `toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.3.0` was deprecated to `toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/addName/0.2.0`
- `toolshed.g2.bx.psu.edu/repos/iuc/coverm_contig/coverm_contig/0.8.0+galaxy0` was deprecated to `toolshed.g2.bx.psu.edu/repos/iuc/coverm_contig/coverm_contig/0.7.0+galaxy0`

FOR CONTRIBUTOR:
* [x] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [x] I have added myself to the [CODEOWNERS File for the workflow](https://github.com/galaxyproject/iwc/blob/main/.github/CODEOWNERS)
* [x] License permits unrestricted use (educational + commercial)
* [x] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
