### PR TITLE
Fix check_deployments never deploying missing workflows

### DIFF
--- a/.github/workflows/check_deployments.yml
+++ b/.github/workflows/check_deployments.yml
@@ -32,7 +32,9 @@ jobs:
   deploy:
     name: Deploy missing workflows
     needs: check
-    if: github.ref == 'refs/heads/main' && needs.check.outputs.has-missing == 'true'
+    # always() is required: without it this job is skipped whenever the check
+    # job fails, which is precisely when there is something to deploy.
+    if: always() && github.ref == 'refs/heads/main' && needs.check.outputs.has-missing == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -58,10 +60,25 @@ jobs:
         credentials: 'https://${{ env.GITHUB_USER }}:${{ secrets.IWC_WORKFLOWS_BOT_TOKEN }}@github.com/'
     - name: Deploy missing workflows
       run: |
+        failed=()
         while IFS= read -r repo_dir; do
           [ -z "$repo_dir" ] && continue
-          echo "Deploying $repo_dir ..."
-          planemo workflow_upload --namespace iwc-workflows "$repo_dir"
-        done <<< "${{ needs.check.outputs.missing-repos }}"
+          echo "::group::Deploying $repo_dir"
+          if planemo workflow_upload --namespace iwc-workflows "$repo_dir"; then
+            echo "Deployed $repo_dir"
+          else
+            echo "::error::Failed to deploy $repo_dir"
+            failed+=("$repo_dir")
+          fi
+          echo "::endgroup::"
+        done <<< "$MISSING_REPOS"
+        if [ ${#failed[@]} -ne 0 ]; then
+          echo "Failed to deploy ${#failed[@]} workflow(s):"
+          printf '  %s\n' "${failed[@]}"
+          exit 1
+        fi
       env:
+        # Passed via the environment rather than interpolated into the script,
+        # so that repository paths cannot be expanded as shell syntax.
+        MISSING_REPOS: ${{ needs.check.outputs.missing-repos }}
         GITHUB_TOKEN: ${{ secrets.IWC_WORKFLOWS_BOT_TOKEN }}

--- a/scripts/check_missing_deployments.py
+++ b/scripts/check_missing_deployments.py
@@ -3,16 +3,22 @@
 iwc-workflows GitHub organization, and optionally write the list of
 repository directories that need redeployment."""
 
+import argparse
 import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import yaml
 
 WORKFLOWS_DIR = Path(__file__).resolve().parent.parent / "workflows"
 ORG = "iwc-workflows"
+# Transient GitHub API errors (secondary rate limits in particular) are common
+# when querying ~100 repositories in a row, so retry before giving up.
+API_RETRIES = 3
+API_RETRY_DELAY = 10
 
 
 def get_expected_release(repo_dir):
@@ -30,12 +36,27 @@ def get_expected_release(repo_dir):
 
 
 def release_exists(repo_name, tag):
-    """Check if a release tag exists in the iwc-workflows org via gh CLI."""
-    result = subprocess.run(
-        ["gh", "api", f"repos/{ORG}/{repo_name}/releases/tags/{tag}"],
-        capture_output=True,
-    )
-    return result.returncode == 0
+    """Check if a release tag exists in the iwc-workflows org via gh CLI.
+
+    Only a genuine 404 means the release is missing. Any other failure (rate
+    limiting, network trouble, an expired token) is retried and then raised,
+    so that an API problem is never mistaken for a missing deployment.
+    """
+    for attempt in range(1, API_RETRIES + 1):
+        result = subprocess.run(
+            ["gh", "api", "--silent", f"repos/{ORG}/{repo_name}/releases/tags/{tag}"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return True
+        stderr = result.stderr or ""
+        if "HTTP 404" in stderr or "Not Found" in stderr:
+            return False
+        if attempt < API_RETRIES:
+            print(f"      API error for {repo_name} (attempt {attempt}), retrying: {stderr.strip()}")
+            time.sleep(API_RETRY_DELAY)
+    raise RuntimeError(f"Could not determine release status of {ORG}/{repo_name} {tag}: {stderr.strip()}")
 
 
 def find_all_repos():
@@ -47,6 +68,14 @@ def find_all_repos():
 
 
 def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fail-on-missing",
+        action="store_true",
+        help="Exit non-zero when deployments are missing (the default outside GitHub Actions)",
+    )
+    args = parser.parse_args()
+
     repos = find_all_repos()
     missing = []
 
@@ -80,7 +109,12 @@ def main():
             f.write(f"missing-repos<<EOF\n{repo_list}\nEOF\n")
             f.write(f"has-missing={'true' if missing else 'false'}\n")
 
-    return 1 if missing else 0
+    # Inside Actions, missing deployments are reported through the has-missing
+    # output so that the deploy job can act on them. Failing here instead would
+    # mark the run red for the very condition the workflow exists to fix.
+    if missing and (args.fail_on_missing or not github_output):
+        return 1
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The `Check and fix missing deployments` workflow can never fix anything.

The `deploy` job depends on `check`, but its `if` lacked `always()`, so GitHub Actions skips it whenever `check` fails. Since `scripts/check_missing_deployments.py` exited 1 precisely when it found missing deployments, `deploy` could only ever run when there was nothing to deploy. The weekly scheduled run has been going red without redeploying anything.

Most recent failing run: https://github.com/galaxyproject/iwc/actions/runs/29723072857 — 5 missing deployments out of 106 repos.

## Changes

- Add `always()` to the deploy job's `if`, so it survives a failing check job.
- The check script reports through the `has-missing` output and exits 0 under Actions. `--fail-on-missing`, and running outside Actions, keep the old non-zero exit.
- `release_exists` treated any non-zero `gh` exit as a missing release, so a rate limit or network error looked like ~100 missing deployments. Only a genuine 404 counts as missing now; other errors are retried 3x and then raised, failing the job loudly instead of triggering a mass redeploy.
- The deploy loop records per-repo failures and continues instead of aborting on the first one, then exits 1 with a summary, so one bad repository no longer strands the rest. (Note: `planemo-ci-action`'s `mode: deploy` does `|| exit 1` per repo, so switching to it would reintroduce this.)
- `missing-repos` is passed via the environment rather than interpolated into the shell script.

## CI status semantics after this change

| Situation | Run status |
|---|---|
| Nothing missing | green |
| Missing, all deploys succeed | green (found and fixed) |
| Missing, a deploy fails | **red** |
| API error / crash in check | **red** |

## Verification

- Extracted the real `run:` block and executed it against a stub `planemo` failing for one of three repos: it deployed the other two and still exited 1.
- Unit-tested `release_exists` for present / 404 / persistent 403 / transient-then-success.
- Checked `release_exists` against the live API: `amr_gene_detection v1.1.7` -> True, `v1.1.8` -> False, `repeatmasking v0.1` -> False.
- Exit-code matrix verified for all three modes; `flake8` clean.

## Follow-up, not in this PR

The 5 workflows currently missing deployment need a decision before the deploy is dispatched, because this workflow deploys directly without a test gate:

| Workflow | Test evidence |
|---|---|
| `gromacs-dctmd` v0.1.7 | green on current main |
| `functional-annotation-of-sequences` v0.3 | green on current main |
| `amr_gene_detection` v1.1.8 | last test job failed after 6h5m (Actions 6-hour ceiling) |
| `clinicalmp-verification` v0.2 | merged Jan 2025, checks aged out |
| `repeatmasking` v0.1 | nightly `wftest.yml` failing 8 of last 8 runs |

Separately: `workflows/enable_ci_workflows.py` calls `/orgs/iwc-workflows/repos` without pagination, so it only ever sees the first 30 of the org's 112 repos. Repos outside that first page are never re-enabled after `disabled_inactivity` — `amr_gene_detection` and `clinicalmp-verification` are both stuck disabled for this reason.