### PR TITLE
Test against release_26.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
     types: [run-all-workflow-tests-command]
 env:
   GALAXY_FORK: galaxyproject
-  GALAXY_BRANCH: release_26.0
+  GALAXY_BRANCH: release_26.1
   MAX_CHUNKS: 40
 jobs:
   setup:

--- a/.github/workflows/workflow_test.yml
+++ b/.github/workflows/workflow_test.yml
@@ -22,7 +22,7 @@ jobs:
       python-version-list: "[\"3.11\"]"
       max-chunks: 4
       galaxy-fork: galaxyproject
-      galaxy-branch: release_26.0
+      galaxy-branch: release_26.1
 
   # Planemo lint the changed repositories
   lint:
@@ -94,7 +94,7 @@ jobs:
       python-version-list: "[\"3.11\"]"
       repository-list: ${{ needs.setup.outputs.repository-list }}
       galaxy-fork: galaxyproject
-      galaxy-branch: release_26.0
+      galaxy-branch: release_26.1
       check-outputs: false
       galaxy-user-key-environment: ${{ needs.determine_env.outputs.environment }}
     secrets: inherit


### PR DESCRIPTION
FOR CONTRIBUTOR:
* [ ] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [ ] I have added myself to the [CODEOWNERS File for the workflow](https://github.com/galaxyproject/iwc/blob/main/.github/CODEOWNERS)
* [ ] License permits unrestricted use (educational + commercial)
* [ ] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
