### PR TITLE
Skip combine_outputs when there is nothing to combine

### DIFF
--- a/.github/workflows/workflow_test.yml
+++ b/.github/workflows/workflow_test.yml
@@ -103,7 +103,7 @@ jobs:
     # same as tool step
     name: Combine chunked test results
     needs: [setup, test]
-    if: always()
+    if: ${{ always() && needs.setup.outputs.repository-list != '' }}
     strategy:
       matrix:
         python-version: ['3.11']


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on behalf of jmchilton — they did not author this text personally.**

`combine_outputs` is gated on a bare `always()`. That covers the intended case — the combined report should still be produced when some test chunks fail — but it also fires when the `test` job was *skipped* because `repository-list` came back empty. `combine` then dies on the artifacts directory that was never uploaded:

```
find: 'artifacts/': No such file or directory
```

`determine-success` fails downstream of it, so the whole run goes red.

This is hard to notice in this repo: a push here almost always touches a workflow directory, so `repository-list` is non-empty and the job has real artifacts to combine. A change confined to `.github/workflows/` reproduces it — `paths-ignore` does not cover that path, so the run triggers, `setup` returns an empty `repository-list`, `lint` and `test` skip, and `combine_outputs` runs anyway and fails.

The fix keeps `always()` and excludes the empty case:

```yaml
if: ${{ always() && needs.setup.outputs.repository-list != '' }}
```

`determine-success` already special-cases a skipped `combine_outputs` (`needs.combine_outputs.result != 'skipped'`), so it goes green without any change there.

Found while syncing `galaxyproject/iwc-lab`'s pipeline back up with this one. iwc-lab has a single workflow, so nearly every CI change produces an empty `repository-list` and it hits this on essentially every push. Verified there: red before, green after (`galaxyproject/iwc-lab` run 34363702309).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9D5uVxz3qnVRpWmuYj26M
