### PR TITLE
Only report deploy status when deploy actually failed

### DIFF
--- a/.github/workflows/workflow_test.yml
+++ b/.github/workflows/workflow_test.yml
@@ -190,7 +190,7 @@ jobs:
   deploy-report:
     name: Report deploy status
     needs: [deploy]
-    if: ${{ always() && needs.deploy.result != 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'galaxyproject' }}
+    if: ${{ always() && needs.deploy.result == 'failure' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'galaxyproject' }}
     runs-on: ubuntu-latest
     steps:
     # report to the PR if deployment failed
@@ -200,6 +200,7 @@ jobs:
       with:
         sha: ${{ github.event.after }}
     - name: Create comment
+      if: steps.getpr.outputs.number != ''
       uses: peter-evans/create-or-update-comment@v4
       with:
         token: ${{ secrets.PAT }}


### PR DESCRIPTION
> **Posted by Claude (AI assistant) on behalf of jmchilton — they did not author this text personally.**

`deploy-report` is gated on `needs.deploy.result != 'success'`. That is also true when `deploy` is **skipped**, which is what happens on a push to `main` that changes no workflow directory: `repository-list` comes back empty, `test` and `combine_outputs` skip, so `deploy`'s dependencies never run and `deploy` skips too.

`deploy-report` then runs anyway. On a direct push there is no associated PR, so `gh-get-current-pr` returns nothing and the comment step fails:

```
Missing either 'issue-number' or 'comment-id'.
```

The run goes red even though nothing was wrong — there was simply nothing to deploy.

Two changes:

- gate on `needs.deploy.result == 'failure'`, since a skipped deploy is not a failed one
- guard the comment step on `steps.getpr.outputs.number != ''`, so a *genuine* deploy failure on a direct push still reports the job status instead of erroring on the comment it cannot post

The second guard matters independently of the first: pushes to `main` here are direct, not PR merges, so `getpr` finds no PR on the path that this job was actually written for.

Found while syncing `galaxyproject/iwc-lab`'s pipeline back up with this one, where it fires constantly — that repo has a single workflow, so most pushes produce an empty `repository-list`. Verified there: red before, green after (`galaxyproject/iwc-lab` runs 34364927067 and 34366019634).

Independent of #1364, which fixes `combine_outputs` in the same file for a related reason. Different regions of the file; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9D5uVxz3qnVRpWmuYj26M
