### PR TITLE
Expanded Agent Review Command

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -19,6 +19,7 @@ The checklist below intentionally includes every workflow-review requirement fro
    - Base and head revisions
    - List of changed files
    - The actual file changes (diff)
+   - Relevant CI check names, conclusions, and failure details using `gh pr checks` and, when needed, `gh run view`
 
 2. Read the changed workflow files and enough existing repository examples to understand the applicable IWC conventions. Do not infer compliance from the diff alone when a requirement depends on the complete contents of a file.
 
@@ -93,9 +94,11 @@ The checklist below intentionally includes every workflow-review requirement fro
 
    - [ ] The changelog has a new entry, and it describes what actually changed rather than restating the version.
    - [ ] The entry heading carries a version number and a date, in the form `## [1.5] - 2026-07-06`.
-   - [ ] The size of the version bump matches the scope of the change. A renamed input or output label is not a patch-level change.
+   - [ ] The release bump is appropriate for the scope of the change under the repository's current workflow-versioning practice.
 
-   `planemo workflow_lint --iwc` already checks that the `.ga` `release` field matches the changelog version, and IWC CI runs it on every pull request. Read that result rather than re-deriving it: report a lint failure, do not repeat the check by hand.
+   The Copilot instructions ask reviewers to apply semantic versioning, while `bump_version.py` notes that IWC changelogs do not necessarily follow semantic versioning. Treat an apparently breaking change, including a renamed input or output label, as requiring human versioning review rather than asserting a particular bump category while that policy remains ambiguous.
+
+   `planemo workflow_lint --iwc` checks that the `.ga` `release` field matches the changelog version. When the IWC workflow-lint check ran and its result is accessible, rely on that result: report a lint failure rather than repeating the check by hand. The workflow CI excludes Markdown-only changes, so if the lint check is absent or inaccessible, verify the versions directly or mark the item as unverified; never infer that it passed.
 
    ### Test files and data
 

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -90,8 +90,11 @@ The checklist below intentionally includes every workflow-review requirement fro
 
    ### Changelog
 
-   - [ ] The changelog has an appropriate entry describing the changes.
-   - [ ] The entry follows semantic versioning and includes a version number and date.
+   - [ ] The changelog has a new entry, and it describes what actually changed rather than restating the version.
+   - [ ] The entry heading carries a version number and a date, in the form `## [1.5] - 2026-07-06`.
+   - [ ] The size of the version bump matches the scope of the change. A renamed input or output label is not a patch-level change.
+
+   `planemo workflow_lint --iwc` already checks that the `.ga` `release` field matches the changelog version, and IWC CI runs it on every pull request. Read that result rather than re-deriving it: report a lint failure, do not repeat the check by hand.
 
    ### Test files and data
 

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -28,8 +28,9 @@ The checklist below intentionally includes every workflow-review requirement fro
 
    - [ ] A `.dockstore.yml` file is present in the workflow folder. It is required to run tests.
    - [ ] Its authors match the creator metadata in the `.ga` workflow file.
-   - [ ] ORCID identifiers are provided for authors; they are strongly encouraged rather than required.
    - [ ] Its workflow and test file paths resolve to the correct files.
+
+   ORCID identifiers for authors are strongly encouraged but not required. Note missing ones as an optional improvement; never as a blocking finding.
 
    ### License and ownership
 

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -10,7 +10,7 @@ This review applies to changes under `workflows/`. If the pull request does not 
 
 Read both `.github/PULL_REQUEST_TEMPLATE.md` and `.github/copilot-instructions.md` from the pull request's base branch before reviewing. Apply the union of their workflow-review requirements. If either file has changed in the pull request, distinguish the existing base-branch policy from the proposed policy change and flag any conflict for human discussion.
 
-The checklist below intentionally includes every workflow-review requirement from the Copilot instructions and adds the execution and reporting procedure for this command.
+The checklist below intentionally includes every workflow-review requirement from the Copilot instructions, adds the contributor-checklist items a reviewer can confirm, and adds the execution and reporting procedure for this command.
 
 ## Your Task
 
@@ -30,6 +30,11 @@ The checklist below intentionally includes every workflow-review requirement fro
    - [ ] Its authors match the creator metadata in the `.ga` workflow file.
    - [ ] ORCID identifiers are provided for authors; they are strongly encouraged rather than required.
    - [ ] Its workflow and test file paths resolve to the correct files.
+
+   ### License and ownership
+
+   - [ ] The `.ga` workflow file has a `license` field, and the license permits unrestricted use, both educational and commercial.
+   - [ ] The workflow folder has an entry in `.github/CODEOWNERS`.
 
    ### Workflow genericity
 

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -4,57 +4,119 @@ description: Review a PR against the IWC reviewer checklist
 
 You are reviewing a pull request to the IWC (Intergalactic Workflow Commission) repository.
 
+## Scope and Policy Sources
+
+This review applies to changes under `workflows/`. If the pull request does not change that directory, report that the workflow review is not applicable.
+
+Read both `.github/PULL_REQUEST_TEMPLATE.md` and `.github/copilot-instructions.md` from the pull request's base branch before reviewing. Apply the union of their workflow-review requirements. If either file has changed in the pull request, distinguish the existing base-branch policy from the proposed policy change and flag any conflict for human discussion.
+
+The checklist below intentionally includes every workflow-review requirement from the Copilot instructions and adds the execution and reporting procedure for this command.
+
 ## Your Task
 
-1. Fetch the PR using the `gh` command to get:
-   - PR title and description
+1. Fetch the pull request using the `gh` command to get:
+   - Pull request title and description
+   - Base and head revisions
    - List of changed files
    - The actual file changes (diff)
 
-2. Review the PR changes against the FOR REVIEWERS checklist from `.github/PULL_REQUEST_TEMPLATE.md`:
-   - [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
-   - [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
-   - [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
-   - [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
-   - [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
-   - [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
-   - [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
-   - [ ] Changelog contains appropriate entries
-   - [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
+2. Read the changed workflow files and enough existing repository examples to understand the applicable IWC conventions. Do not infer compliance from the diff alone when a requirement depends on the complete contents of a file.
 
-3. For each checklist item:
-   - Determine if it's applicable to this PR (some items may not apply to all PRs)
-   - Check if the requirement is met
-   - Provide specific feedback with file paths and line numbers where relevant
-   - If checking requires reading file contents, use the Read tool to examine the files
+3. Review the changes against every applicable item in this checklist:
 
-4. **IMPORTANT - Check workflow_outputs labels:**
-   - In the .ga workflow file, look for ALL `workflow_outputs` sections in each step
-   - Each workflow_outputs entry has a `label` field that should be human-readable
-   - Check that these labels follow the same naming rules: spaces are fine, no underscores, dashes only where spelling dictates
-   - Example of INCORRECT: `"label": "multiqc_html_report"` (has underscores)
-   - Example of CORRECT: `"label": "MultiQC HTML report"` (human-readable, spaces)
-   - Also verify these labels match what's used in the test file (*-tests.yml)
-   - Report ALL instances where workflow_outputs labels use underscores or abbreviations
+   ### .dockstore.yml
 
-5. **Check grammar and consistency in naming:**
-   - When technical terms are used as compound adjectives (modifying another noun), they should be singular
-   - Examples:
-     - CORRECT: "short-read quality control" (short-read is an adjective modifying "quality control")
-     - INCORRECT: "short-reads quality control" (plural form as adjective)
-     - CORRECT: "single-cell RNA-seq" (single-cell is an adjective)
-     - INCORRECT: "single-cells RNA-seq"
-   - Check this consistency across: folder name, workflow name, README title, and file names
-   - When the term itself is the noun (not modifying another word), plural can be appropriate:
-     - "quality control of short reads" (reads is the noun here) - this is fine
+   - [ ] A `.dockstore.yml` file is present in the workflow folder. It is required to run tests.
+   - [ ] Its authors match the creator metadata in the `.ga` workflow file.
+   - [ ] ORCID identifiers are provided for authors; they are strongly encouraged rather than required.
+   - [ ] Its workflow and test file paths resolve to the correct files.
 
-6. Provide a summary with:
+   ### Workflow genericity
+
+   - [ ] The workflow is sufficiently generic for use with lab data.
+   - [ ] Sample names, reference data, and dataset-specific values are not hardcoded.
+   - [ ] The workflow can be run without reading an accompanying tutorial.
+   - [ ] All parameters are configurable through workflow inputs rather than fixed for a particular sample or experiment.
+
+   ### Annotation
+
+   - [ ] The workflow annotation contains a short description of what the workflow does and the result it generates or analyzes.
+   - [ ] It starts with wording such as `This workflow does/runs/performs ... to generate/analyze ...`.
+   - Example: `This workflow performs quality control and trimming on paired-end Illumina fastq files using fastp and aggregates reports with MultiQC`.
+
+   ### Human-readable naming
+
+   - [ ] Workflow input and output names are human-readable: use spaces instead of underscores, use dashes only where spelling dictates, and avoid abbreviations unless generally understood.
+   - [ ] The workflow `name` field follows the same rules.
+   - [ ] Every `workflow_outputs` label in every `.ga` workflow step follows the same rules.
+   - [ ] Test output names match their corresponding `workflow_outputs` labels exactly.
+   - [ ] Changes to input or output labels are reflected in the workflow test file.
+
+   Examples:
+   - Correct: `Raw reads`, `Qualified quality score`, `MultiQC report`
+   - Incorrect: `raw_reads`, `qual_score`, `multiqc_report`
+
+   ### Folder and file naming
+
+   - [ ] Folder and file names are lowercase and prefer dashes (`-`) over underscores (`_`).
+   - [ ] The workflow folder name is suitable as the resulting repository name in the [iwc-workflows organization](https://github.com/iwc-workflows) and as part of the TRS ID.
+
+   Examples:
+   - Correct: `short-read-qc-trimming`, `rna-seq-analysis`
+   - Incorrect: `short_read_QC_trimming`, `RNA_Seq_Analysis`
+
+   ### Grammar and consistency
+
+   - [ ] Technical terms used as compound adjectives are singular and consistent across folder names, file names, workflow names, README titles, and documentation.
+
+   Examples:
+   - Correct: `short-read sequencing`, `single-cell analysis`, `long-read assembly`
+   - Incorrect: `short-reads sequencing`, `single-cells analysis`, `long-reads assembly`
+
+   When the term is the noun itself, plural can be appropriate; for example, `quality control of short reads` is correct.
+
+   ### README
+
+   - [ ] The README explains what the workflow does.
+   - [ ] It describes valid inputs, including formats and important parameters.
+   - [ ] It describes the outputs users can expect.
+   - [ ] It links tutorials or other resources when available.
+   - [ ] If similar IWC workflows exist, it explains the differences and when a user might prefer each workflow.
+
+   ### Changelog
+
+   - [ ] The changelog has an appropriate entry describing the changes.
+   - [ ] The entry follows semantic versioning and includes a version number and date.
+
+   ### Test files and data
+
+   - [ ] Files larger than 100 KB are uploaded to Zenodo, and the test file uses their Zenodo location URLs rather than local copies.
+   - [ ] Test output names match the `.ga` workflow's `workflow_outputs` labels exactly.
+
+4. Inspect all `workflow_outputs` entries; do not sample them. Report every label with underscores, unclear abbreviations, or a mismatch with the test file.
+
+5. For each checklist item:
+   - Determine whether it applies to this pull request.
+   - Mark it as passing, needing attention, or not applicable.
+   - Cite specific file paths and line numbers for findings whenever possible.
+   - Explain what evidence was checked. Do not mark an item as passing when it could not be verified.
+
+6. When suggesting changes:
+   - Check existing repository patterns first.
+   - Follow all naming conventions above.
+   - Keep workflow-output labels and test output names aligned.
+   - Preserve the required annotation format.
+   - Clearly separate required policy fixes from optional improvements.
+
+7. Provide a summary with:
    - ✅ Items that pass
-   - ⚠️  Items that need attention
-   - ℹ️  Items that are not applicable
-   - Overall recommendation (approve, request changes, or needs discussion)
+   - ⚠️ Items that need attention
+   - ℹ️ Items that are not applicable or could not be verified
+   - An overall advisory recommendation: approve, request changes, or needs discussion
+
+The recommendation is advisory. Do not approve, modify, or merge the pull request.
 
 ## Usage
 
-The PR number or URL should be provided as an argument to the command.
+The pull request number or URL should be provided as an argument to the command.
 Example: `/review 1234` or `/review https://github.com/galaxyproject/iwc/pull/1234`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,7 @@
 # GitHub Copilot Instructions for IWC
 
+> When editing this file, mirror the change into `.claude/commands/review.md`, which must remain a superset of these review requirements.
+
 ## Scope
 These instructions apply ONLY to changes in the `workflows/` folder.
 


### PR DESCRIPTION
This PR will require more thought than the more mechanical fixes of #1364 and #1365 - sorry in advanced. 

I am working on downstream Foundry functionality that should review workflows to get them inline with what is expected by the IWC (a galaxy -> iwc-lab pipeline). My own human brain sort of hooked on the co-pilot and Claude checks being disjoint. I think maybe the Claude directions should be a superset of the Copilot ones? This change does that and I think can serve as the SOURCE OF TRUTH for this check description - I hope anyway. Ideally Foundry can just link it in and use it as a step in a Foundry pipeline.

I've read it through twice and it feels like an improvement to me but I don't love every part of this - some of it is a bit too archeology or over subscribed maybe?

I've upstreamed some Planemo fixes to make sure some things that can just be caught by linting are and that should simplify and harden the effort some:

- https://github.com/galaxyproject/planemo/issues/1693 -> https://github.com/galaxyproject/planemo/pull/1695
- https://github.com/galaxyproject/planemo/issues/1692 -> https://github.com/galaxyproject/planemo/pull/1696
- https://github.com/galaxyproject/planemo/issues/1694 -> https://github.com/galaxyproject/planemo/pull/1697

-John

FOR CONTRIBUTOR:
* [x] I have read the [Adding workflows guidelines](https://github.com/galaxyproject/iwc/blob/main/workflows/README.md#adding-workflows)
* [x] I have added myself to the [CODEOWNERS File for the workflow](https://github.com/galaxyproject/iwc/blob/main/.github/CODEOWNERS)
* [x] License permits unrestricted use (educational + commercial)
* [x] Please also take note of the reviewer guidelines below to facilitate a smooth review process.

FOR REVIEWERS:
* [ ] .dockstore.yml: file is present and aligned with creator metadata in workflow. ORCID identifiers are strongly encouraged in creator metadata. The .dockstore.yml file is required to run tests
* [ ] Workflow is sufficiently generic to be used with lab data and does not hardcode sample names, reference data and can be run without reading an accompanying tutorial.
* [ ] In workflow: annotation field contains short description of what the workflow does. Should start with `This workflow does/runs/performs … xyz … to generate/analyze/etc …`
* [ ] In workflow: workflow inputs and outputs have human readable names (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless it is generally understood. Altering input or output labels requires adjusting these labels in the the workflow-tests.yml file as well
* [ ] In workflow: `name` field should be human readable (spaces are fine, no underscore, dash only where spelling dictates it), no abbreviation unless generally understood
* [ ] Workflow folder: prefer dash (`-`) over underscore (`_`), prefer all lowercase. Folder becomes repository in [iwc-workflows organization](https://github.com/iwc-workflows) and is included in TRS id
* [ ] Readme explains what workflow does, what are valid inputs and what outputs users can expect. If a tutorial or other resources exist they can be linked. If a similar workflow exists in IWC readme should explain differences with existing workflow and when one might prefer one workflow over another
* [ ] Changelog contains appropriate entries
* [ ] Large files (> 100 KB) are uploaded to zenodo and location urls are used in test file
